### PR TITLE
Away-team waypoints + medical emergency (v0.7.0)

### DIFF
--- a/docs/superpowers/plans/2026-04-17-v0.7.0-away-team-and-medical.md
+++ b/docs/superpowers/plans/2026-04-17-v0.7.0-away-team-and-medical.md
@@ -1,0 +1,369 @@
+# v0.7.0 Implementation Plan — Away-Team Waypoints + Medical Emergency
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship v0.7.0 — a rebuild of waypoint diverts as a real away-team mechanic (#17) plus the crew medical emergency event (#6), both sharing a new corpse-weight mechanic and riding on the v0.6.0 multi-stage framework. Also wires in the medic flavor line (#21).
+
+**Architecture:** New pure modules `src/systems/awayTeam.js` and `src/systems/corpse.js`. New content pools `awayTeamChains.js` and `medicalEmergency.js`. Existing `src/systems/waypoints.js` is gutted of the old "divert = pay km, resolve on arrival" flow and rewired to initiate an away-team camp. `src/systems/travel.js` gains a camp-mode branch in `advanceSol` that freezes rover movement while `state.awayTeam` is set. Corpse weight plugs into the existing `cargoPounds` path. Medical emergency is authored as a single multi-stage event consumed by the v0.6.0 engine; body-disposal at Stage 3 reuses the same corpse helper as away-team reunion.
+
+**Tech Stack:** Vanilla ES modules. `node --test` for tests. No new dependencies.
+
+**Related:** Spec at `docs/superpowers/specs/2026-04-17-v0.7.0-away-team-and-medical-design.md`. Closes #17 and #6, lands #21. Ships as `v0.7.0`.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/systems/corpse.js` — `addCorpse`, `corpseWeight`. Shared helper. ~20 lines.
+- `src/systems/awayTeam.js` — `acceptAwayTeam`, `advanceAwayTeam`, `resolveAwayTeamStage`, `returnAwayTeam`. ~120 lines.
+- `src/content/awayTeamChains.js` — dict keyed by `waypointId` → stage tree with `returnSolDelta` on choices. 12 entries.
+- `src/content/medicalEmergency.js` — single multi-stage event (3 stages). ~80 lines.
+- `sim/corpse.test.mjs` — corpse accounting tests.
+- `sim/awayTeam.test.mjs` — full lifecycle tests.
+- `sim/medicalEmergency.test.mjs` — diagnosis → treatment → disposal happy path + medic-is-patient branch.
+
+**Modify:**
+- `src/state.js` — add `awayTeam: null`, `corpses: []`. Remove `pendingWaypoint`.
+- `src/systems/travel.js` — `cargoPounds` widens to `(state)`; `advanceSol` gains camp branch; delete old `pendingWaypoint` branch in landmark-arrival logic.
+- `src/systems/waypoints.js` — delete `resolveWaypoint`. Rewire `acceptWaypoint` to open the picker (no km add). `rollWaypoints` gated on `aliveCrew ≥ 3`.
+- `src/systems/multiStage.js` — `applyStageChoice` surfaces `returnSolDelta` from the chosen choice in its return value so callers (away-team) can mutate their own timer.
+- `src/ui/modals.js` — `showAwayTeamPickerModal`, `showAwayTeamReunionModal`. Reuse `showMultiStageModal` for the medical event.
+- `src/main.js` — dispatch branches for `away_team_picker` and `away_team_reunion`. Away-team chain stages dispatch through the existing `multi_stage` branch (bridging logic applies `returnSolDelta` to `state.awayTeam.returnSol`).
+- `src/render.js` — "DUE BACK: sol N" chip in the topbar/dashboard. Minimap waypoint gets an `awayActive` visual state.
+- `sim/play.mjs` — auto-handler for `away_team_picker` (pick first N=min(3, alive-1)), `away_team_reunion` (always bring bodies back for determinism).
+- `package.json` — version 0.6.0 → 0.7.0.
+
+**Untouched:** landmark encounters, scoring, career, minimap route base rendering, existing single-choice events, `sim/multiStage.test.mjs`.
+
+---
+
+## Task 1: Corpse mechanic (foundation — both features need it)
+
+**Files:**
+- Create: `src/systems/corpse.js`
+- Create: `sim/corpse.test.mjs`
+- Modify: `src/state.js` (add `corpses: []`)
+- Modify: `src/systems/travel.js` (`cargoPounds` widens to `(state)`; sum corpses)
+
+TDD flow: write tests + helper first, then plumb into state and travel, commit.
+
+- [ ] **Step 1.1 — Define `src/systems/corpse.js`.**
+
+```js
+// Mars Trail — corpse accounting (shared by away-team reunion + #6 medical disposal).
+// Pure. State writes go through addCorpse; reads via corpseWeight.
+
+const DEFAULT_CORPSE_LBS = 180;  // suit + body, per issue #6
+
+export function addCorpse(state, crewId, weightLbs = DEFAULT_CORPSE_LBS) {
+  if (state.corpses.some(c => c.crewId === crewId)) return state;   // idempotent
+  return { ...state, corpses: [...state.corpses, { crewId, weightLbs }] };
+}
+
+export function corpseWeight(state) {
+  return state.corpses.reduce((n, c) => n + c.weightLbs, 0);
+}
+```
+
+- [ ] **Step 1.2 — Tests in `sim/corpse.test.mjs`.**
+
+Cases:
+- `addCorpse` adds an entry with default 180 LB.
+- `addCorpse` with explicit weight uses that weight.
+- `addCorpse` is idempotent for the same crewId (no double-add).
+- `corpseWeight` sums multiple entries correctly.
+- `corpseWeight` of empty state is 0.
+
+- [ ] **Step 1.3 — State shape in `src/state.js`.**
+
+Inside `createInitialState()`, add `corpses: []` alongside existing crew/resources fields. Don't touch anything else this step.
+
+- [ ] **Step 1.4 — Widen `cargoPounds` in `src/systems/travel.js`.**
+
+Before:
+```js
+function cargoPounds(resources) { ... }
+```
+After:
+```js
+function cargoPounds(state) {
+  let lbs = 0;
+  for (const t of PART_TYPES) {
+    if (!t.supply) lbs += (state.resources[t.key] || 0) * t.lbs;
+  }
+  for (const c of state.corpses) lbs += c.weightLbs;
+  return lbs;
+}
+```
+Update both internal call sites (lines 114, 133 currently) from `cargoPounds(s.resources)` → `cargoPounds(s)`.
+
+- [ ] **Step 1.5 — Run tests + play.** `node --test sim/corpse.test.mjs` and `node sim/play.mjs` should both pass.
+
+- [ ] **Step 1.6 — Commit.** `Add corpse mechanic: shared body-weight helper for #17 + #6 (refs #17, #6)`
+
+---
+
+## Task 2: Away-team pure systems + tests
+
+**Files:**
+- Create: `src/systems/awayTeam.js`
+- Create: `src/content/awayTeamChains.js` (one entry only — `olivine_outcrop` — for tests)
+- Create: `sim/awayTeam.test.mjs`
+- Modify: `src/state.js` (add `awayTeam: null`; remove `pendingWaypoint`)
+- Modify: `src/systems/multiStage.js` (surface `returnSolDelta` from chosen choice)
+
+- [ ] **Step 2.1 — Update `src/state.js`.** Add `awayTeam: null`. Remove the existing `pendingWaypoint: null` field. Grep the project for `pendingWaypoint` references — expect hits in `src/render.js` (minimap state class) and `src/systems/waypoints.js`. Don't touch those yet; they'll break until Task 4. Note them.
+
+- [ ] **Step 2.2 — Create `src/content/awayTeamChains.js` with ONE entry.**
+
+```js
+// Keyed by waypointId. Each chain conforms to the v0.6.0 multiStage shape
+// (stages dict, startStage, per-choice outcome | skillCheck | nextStage)
+// with one extension: choices may carry a `returnSolDelta` number that
+// mutates state.awayTeam.returnSol when taken.
+export const AWAY_TEAM_CHAINS = {
+  olivine_outcrop: {
+    startStage: 'approach',
+    stages: {
+      approach: {
+        title: 'Olivine Outcrop — On Foot',
+        description: '...authored copy...',
+        choices: [
+          { label: 'Rappel to the fresh face',
+            nextStage: 'deep_sample',
+            returnSolDelta: +1 },
+          { label: 'Scan from the ridgeline',
+            skillCheck: { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 40 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage: null }
+        ]
+      },
+      deep_sample: {
+        title: 'Down the Face',
+        description: '...',
+        choices: [
+          { label: 'Drill the exposed vein',
+            skillCheck: { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 80 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 20 },
+            nextStage: null }
+        ]
+      }
+    }
+  }
+};
+```
+
+Notes:
+- `awayTeamDamage` is a NEW outcome field. Wire it in Step 2.4 to apply HP damage to a random away-team member (not main-rover crew).
+- Other away-team outcome fields reuse existing shapes (`sciencePoints`, resource deltas).
+
+- [ ] **Step 2.3 — Extend `applyStageChoice` in `src/systems/multiStage.js`.**
+
+Current return includes `{ state, nextStage, skillResult, damageTarget, applied }`. Add `returnSolDelta: choice.returnSolDelta ?? 0` to the return object. Don't apply it here — caller decides (main.js bridge). One line change plus one test.
+
+- [ ] **Step 2.4 — Define `src/systems/awayTeam.js`.**
+
+Exports:
+- `acceptAwayTeam(state, waypointId, crewIds)` — sets `state.awayTeam`, snapshots `departSol`, computes `returnSol = state.sol + waypoint.detourSols`. Returns state with the first stage loaded into `state.activeModal.type === 'multi_stage'` payload pointing at the chain. **No km change.**
+- `advanceAwayTeam(state)` — called from `advanceSol` each sol the team is out. If no `currentStage`, check `sol >= returnSol` → trigger `returnAwayTeam`. Else fire next stage modal via the same shape.
+- `resolveAwayTeamStage(state, choiceIdx)` — wraps `applyStageChoice` on the current stage. Applies `returnSolDelta` to `state.awayTeam.returnSol`. Applies `awayTeamDamage` to a randomly-picked alive away-team member. Sets `currentStage ← nextStage`. Accumulates rewards into `state.awayTeam.accumulated`.
+- `returnAwayTeam(state)` — computes final reward snapshot, builds `away_team_reunion` activeModal payload. Does NOT apply rewards yet (reunion modal's acknowledge is where they land — same pattern as waypoint_reward today).
+
+- [ ] **Step 2.5 — Tests in `sim/awayTeam.test.mjs` (TDD before Step 2.4 if desired).**
+
+Cases:
+- `acceptAwayTeam` sets state correctly, doesn't touch `kmToNextLandmark`.
+- Gating: `acceptAwayTeam` fails (returns state unchanged + log line) if `aliveCrew < 3`.
+- `resolveAwayTeamStage` applies `returnSolDelta` to `awayTeam.returnSol`.
+- `resolveAwayTeamStage` applies `awayTeamDamage` only to an away-team member.
+- `returnAwayTeam` assembles correct reward payload including deaths array.
+- Full lifecycle: accept → advance 3 sols → all stages resolved → return → `activeModal.type === 'away_team_reunion'`.
+- Rover `kmToNextLandmark` is unchanged across all camp sols.
+
+- [ ] **Step 2.6 — Run tests.** `node --test sim/awayTeam.test.mjs sim/multiStage.test.mjs`.
+
+- [ ] **Step 2.7 — Commit.** `Away-team pure systems: accept/advance/resolve/return (refs #17)`
+
+---
+
+## Task 3: Medical emergency content + tests
+
+**Files:**
+- Create: `src/content/medicalEmergency.js`
+- Create: `sim/medicalEmergency.test.mjs`
+- Modify: `src/content/multiStageEvents.js` (import + include the new event in the pool)
+
+- [ ] **Step 3.1 — Author `src/content/medicalEmergency.js`.**
+
+Single export: the event object, shape matches v0.6.0 `MULTI_STAGE_EVENTS` entries.
+
+Required structure:
+- `id: 'medical_emergency'`, `multiStage: true`, `oneShot: true`, `weight: 3`.
+- `startStage: 'diagnose'`.
+- **Stage `diagnose`** — choices: consult-medic (skill check), consult-Earth (resource delta + worsening flag), dose-and-hope (random outcome → death or survive).
+- **Stage `treat`** — only reached from some diagnose branches. Choices: surgery (EVA + power cost + medic skill check → death on fail), stabilize-and-push (adds `worsening` flag on state; dies on next landmark), induced-coma (power + O₂ cost, revival roll).
+- **Stage `dispose`** — only reached when patient dies. Choices: bury (`addCorpse` NOT called, but logs + SCI bonus), keep-body (`addCorpse`), jettison (no corpse, weight-relief log).
+- **Medic flavor line (#21)**: on any Stage `treat` failure that kills the patient, if `medicAlive && patient !== medic`, append `"Well, there goes paradise."` to the failure outcome's log line. Implement as a per-stage `failLogLine` computed from state.
+
+Patient selection: first alive non-medic crew member. If only medic is alive, medic is the patient and Stage `diagnose`'s medic-consult choice is replaced with a "self-treat with penalty" option (P reduced by 20pp).
+
+- [ ] **Step 3.2 — Tests in `sim/medicalEmergency.test.mjs`.**
+
+Cases:
+- Full happy path: diagnose → stabilize → survive → no dispose stage.
+- Death path: surgery fails → dispose stage → keep body → `state.corpses.length === 1`.
+- Bury path: Stage 3 bury → no corpse added, SCI bumps.
+- Jettison path: Stage 3 jettison → no corpse, specific log line present.
+- Medic-is-patient branch: self-treat penalty applied.
+- Medic flavor line present on surgery-fail when medic alive and not the patient.
+- Medic flavor line absent when medic is the patient.
+- `oneShot` prevents re-roll.
+
+- [ ] **Step 3.3 — Wire into pool.** In `src/content/multiStageEvents.js`, add `import { MEDICAL_EMERGENCY } from './medicalEmergency.js'` and push into the `MULTI_STAGE_EVENTS` array.
+
+- [ ] **Step 3.4 — Run tests.** `node --test sim/medicalEmergency.test.mjs sim/multiStage.test.mjs`.
+
+- [ ] **Step 3.5 — Commit.** `Medical emergency event: 3-stage chain with body disposal + medic flavor line (refs #6, #21)`
+
+---
+
+## Task 4: Travel integration + kill the old waypoint flow
+
+**Files:**
+- Modify: `src/systems/travel.js` (camp branch in `advanceSol`; delete old `pendingWaypoint` branch)
+- Modify: `src/systems/waypoints.js` (delete `resolveWaypoint`; rewire `acceptWaypoint`; add gate to `rollWaypoints`)
+
+- [ ] **Step 4.1 — Delete the stale code.** In `src/systems/waypoints.js`, remove `resolveWaypoint` entirely. In `src/systems/travel.js`, remove the import of `resolveWaypoint` and the Step-A branch (`if (s.pendingWaypoint) { s = resolveWaypoint(s); return s; }`).
+
+- [ ] **Step 4.2 — Rewire `acceptWaypoint`.** It should now delegate to `acceptAwayTeam`. It still takes `(state, segmentIdx)`; looks up the waypoint; calls `acceptAwayTeam(state, waypoint.id, crewIds)`. But picker UI runs BEFORE this — so actually move the `acceptWaypoint` body into main.js's picker-onConfirm handler. Delete `acceptWaypoint` from `waypoints.js`.
+
+- [ ] **Step 4.3 — Gate `rollWaypoints`.** At the top of the function, early-return `{ ...state, waypoints: [] }` if `state.crew.filter(c => c.alive).length < 3` at roll time. (In practice rollWaypoints runs at mission start with full crew, so this is a no-op — but keeps the invariant honest if we ever roll later.) Also add a gate at offer time: in `travel.js`'s landmark-arrival Step B, only fire the offer if `aliveCrew >= 3`.
+
+- [ ] **Step 4.4 — Add camp branch to `advanceSol`.** Near the top of the function, BEFORE any km / resource drain:
+
+```js
+if (state.awayTeam) {
+  // Camp mode: rover doesn't move. Drain resources normally (both parties).
+  let s = applyCampSolDrain(state);     // extracted subroutine
+  s = advanceAwayTeam(s);               // stage or return
+  return s;
+}
+```
+
+`applyCampSolDrain` is a new private function that runs the same background damage + resource drain loop that normal `advanceSol` does, minus the km/landmark logic. Extract carefully to avoid duplication.
+
+- [ ] **Step 4.5 — Run full test suite.** `node --test sim/*.test.mjs`. Expect the old `sim/waypoints.test.mjs` to fail (tests `resolveWaypoint`). Update or delete its cases that are now obsolete. Preserve the rollWaypoints tests (update the new ≥3 gate).
+
+- [ ] **Step 4.6 — Run `node sim/play.mjs`** to confirm no runtime error. It'll stall at the new modals — that's the next task. For now, exit after first away-team modal and verify state shape.
+
+- [ ] **Step 4.7 — Commit.** `Travel + waypoints: swap old resolve flow for camp-mode dispatch (refs #17)`
+
+---
+
+## Task 5: UI — modals + dispatch + render
+
+**Files:**
+- Modify: `src/ui/modals.js` (two new renderers)
+- Modify: `src/main.js` (dispatch branches)
+- Modify: `src/render.js` (DUE BACK chip, AWAY minimap state)
+- Modify: `sim/play.mjs` (auto-handlers)
+
+- [ ] **Step 5.1 — `showAwayTeamPickerModal(state, waypoint, onConfirm)`** in `src/ui/modals.js`.
+
+Renders: waypoint name + briefing + detourSols estimate. Crew checkboxes (alive only). Live validation: at least 1 crew selected, at most 3, and ≤ aliveCrew − 1 (so ≥1 stays on rover). Specialist name highlighted. CONFIRM button disabled until valid. `onConfirm(crewIds)` fires on click.
+
+- [ ] **Step 5.2 — `showAwayTeamReunionModal(payload, onAcknowledge)`** in `src/ui/modals.js`.
+
+Payload: `{ waypoint, survivors, deaths, sciencePoints, facts }`. Renders survivor HP table, death list. If deaths.length > 0, per-corpse radio: `bring back (+180 LB)` vs `leave behind`. CONFIRM applies: `addCorpse` for each brought-back, apply SCI/facts to state.
+
+- [ ] **Step 5.3 — Dispatch in `src/main.js`.**
+
+Add branches:
+```js
+if (modal.type === 'away_team_picker') {
+  const { waypoint } = modal.payload;
+  showAwayTeamPickerModal(state, waypoint, (crewIds) => {
+    state = acceptAwayTeam(state, waypoint.id, crewIds);
+    renderAll();
+  });
+  return;
+}
+
+if (modal.type === 'away_team_reunion') {
+  showAwayTeamReunionModal(modal.payload, (choices) => {
+    state = finalizeReunion(state, modal.payload, choices);   // new helper in awayTeam.js
+    renderAll();
+  });
+  return;
+}
+```
+
+Also: in the existing `multi_stage` branch, when the event originated from the away-team chain, apply `returnSolDelta` to `state.awayTeam.returnSol`. Cleanest: the stage payload carries a context flag `{ source: 'awayTeam' }` set by `advanceAwayTeam`.
+
+- [ ] **Step 5.4 — Render.**
+
+In `src/render.js`:
+- "DUE BACK: sol N" chip in topbar next to the clock, visible only when `state.awayTeam != null`.
+- Minimap: waypoint marker with `state.awayTeam?.waypointId === waypoint.id` gets a new visual class `awayActive` — pulse with larger radius. Handled alongside existing `pending/accepted/fired` states in `renderMinimap`.
+- Add CSS for `awayActive` pulse in `styles/components.css`.
+
+- [ ] **Step 5.5 — `sim/play.mjs` auto-handlers.** Add cases for the two new modal types so the sim completes a run. Pick deterministic choices (first valid for picker; bring-bodies-back for reunion).
+
+- [ ] **Step 5.6 — Playtest in browser.** `open http://localhost:8000`. Trigger a divert; verify picker UI, camp log lines each sol, stage modals, DUE BACK chip, reunion modal, corpse weight reflected in subsequent sols' cargo power drain.
+
+- [ ] **Step 5.7 — Commit.** `Away-team UI: picker + reunion modals, DUE BACK chip, minimap pulse (refs #17)`
+
+---
+
+## Task 6: Content fill — remaining 11 away-team chains
+
+**Files:**
+- Modify: `src/content/awayTeamChains.js` (add 11 more entries)
+
+- [ ] **Step 6.1 — List the 12 waypoints.** Pull waypoint IDs + names + factPools from `src/content/waypoints.js`. Cross-reference science role mapping (GEOLOGY → engineer, WATER → biologist, ATMOSPHERE → pilot, ASTROBIOLOGY → biologist) to pick the specialist role for each chain's skill checks.
+
+- [ ] **Step 6.2 — Author chains.** Baseline shape: 2-stage. 2–3 picks should be 1-stage quick grabs, 2–3 should be 3-stage deep descents to showcase the returnSolDelta mechanic.
+
+Guidelines:
+- Each chain ends with a terminal choice that has a skill check — this is where the advanced fact is awarded (on success).
+- At least one choice per chain should feel risky (big reward, real downside).
+- `returnSolDelta` lives on "go deeper" choices; typical values +1 or +2 sols.
+- `awayTeamDamage` used sparingly — reserve for fail outcomes of risky choices.
+
+- [ ] **Step 6.3 — Smoke test.** `node --test sim/awayTeam.test.mjs` — add one test that loops every chain through a scripted path to ensure no shape errors.
+
+- [ ] **Step 6.4 — Commit.** `Away-team chains: author 11 additional waypoint content trees (refs #17)`
+
+---
+
+## Task 7: Version bump + final polish
+
+**Files:**
+- Modify: `package.json` (0.6.0 → 0.7.0)
+
+- [ ] **Step 7.1 — Bump version.** Change `"version": "0.6.0"` to `"version": "0.7.0"` in `package.json`.
+
+- [ ] **Step 7.2 — Full test run.** `node --test sim/*.test.mjs`. All green.
+
+- [ ] **Step 7.3 — Sim run.** `node sim/play.mjs` completes a mission without throwing. Spot-check the log for camp sols, reunion, reward application.
+
+- [ ] **Step 7.4 — Browser playtest.** At least one divert to a 3-stage chain, one divert to a 1-stage chain, one successful medical emergency, one fatal medical emergency with body kept. Verify corpse weight affects power drain.
+
+- [ ] **Step 7.5 — Commit.** `Bump to v0.7.0 — away-team waypoints + medical emergency`
+
+- [ ] **Step 7.6 — PR to main.** `gh pr create --base main --title "Away-team waypoints + medical emergency (v0.7.0)" --body "..."` with summary referencing #17, #6, #21.
+
+- [ ] **Step 7.7 — Merge, tag, release.** Same pattern as v0.6.0: rebase-merge, `git tag -a v0.7.0`, `git push --tags`, `gh release create v0.7.0`.
+
+---
+
+## Risk register
+
+- **`cargoPounds` signature change** (Task 1.4) touches two internal call sites. If either is missed, power drain math breaks silently. Grep before commit.
+- **`pendingWaypoint` removal** (Task 2.1) breaks `src/render.js` (minimap state class) and the old waypoint-reward tests. Task 4 fixes render; tests must be updated or deleted.
+- **Stage-per-sol cadence** is a gameplay bet. If playtest says "this is tedious" in Task 5.6, consider flipping to "play whole chain on accept, camp is just idle sols." This would be a Task-5-follow-up, not a re-spec.
+- **Authored chain variety** (Task 6) is content-heavy. If time is tight, ship with 6–8 fleshed-out chains and stub the rest as single-stage quick grabs — add a follow-up issue for polish.
+- **Simulator coverage** — if the sim play.mjs can't navigate the new modals deterministically, full-run tests fail and regressions slip through. Task 5.5 is load-bearing.

--- a/docs/superpowers/specs/2026-04-17-v0.7.0-away-team-and-medical-design.md
+++ b/docs/superpowers/specs/2026-04-17-v0.7.0-away-team-and-medical-design.md
@@ -1,0 +1,237 @@
+# v0.7.0 Design — Away-Team Waypoints + Crew Medical Emergency
+
+**Date:** 2026-04-17
+**Status:** Draft — pending user review
+**Related issues:** #17 (away-team waypoints), #6 (crew medical emergency)
+**Ships as:** v0.7.0 (bundled; both features depend on v0.6.0 multi-stage framework and share the corpse-weight mechanic)
+
+## Problem
+
+Two issues converge on one release.
+
+**#17 — waypoint diverts are invisible.** The current "pay sols, earn SCI on next landmark" waypoint has no narrative texture. The rover just keeps driving. Playtest feedback: *"feels like we just keep going."*
+
+**#6 — the event system has no room for real medical drama.** Single-choice events can't carry a three-act medical emergency (diagnosis → treatment → possible disposal). The v0.6.0 multi-stage framework made it possible; this release makes it happen.
+
+Both features need the same new state primitive: **a crew member can be dead-but-still-physically-present**, carrying body weight. Once we build it for one, the other gets it for free.
+
+## Goal
+
+Replace shallow waypoint diverts with a first-class away-team mechanic, and ship the medical emergency as the first real multi-stage content event. Both build on v0.6.0's `multiStage.js` engine and share a new `corpses` state track.
+
+Two success criteria:
+1. Diverting *feels* like dispatching an away team — distinct crew, sols of camp, real stakes, reunion modal.
+2. The medical emergency event exercises the multi-stage framework with branching outcomes that affect downstream play (corpse weight).
+
+## Scope
+
+**In:**
+- Divert gating (≥3 alive crew required, min 1 kept on rover).
+- Away-team picker modal (1–3 crew, specialist highlighted).
+- Camp lifecycle (rover parked, sols advance for both parties, damage applies to both).
+- Authored 1–3 stage chain per waypoint, firing one stage per sol during camp.
+- In-chain choices that modify `returnSol` via `returnSolDelta`.
+- Reunion modal (survivors, injuries, optional body-recovery choice).
+- Shared corpse mechanic: `state.corpses: [{ crewId, weightLbs }]` feeding `cargoPounds`.
+- Medical emergency event: 3-stage chain with diagnosis → treatment → disposal.
+- Minimap visual: waypoint pulses "AWAY TEAM OUT" while active.
+- Unit tests for away-team lifecycle and medical-emergency flow.
+
+**Out (deferred):**
+- Multiple simultaneous away teams.
+- Custom away-team gear loadout beyond standard EVA kit.
+- Persistent cross-run "away-team experience" (career arc).
+- Follow-up events referencing the dead crew member by name (future issue).
+- Full medical sim (persistent symptoms across sols).
+- Animated camp/reunion transitions (log lines + modals only).
+
+## Architecture
+
+**New files:**
+- `src/systems/awayTeam.js` — pure module. Exports `acceptAwayTeam`, `advanceAwayTeam`, `resolveAwayTeamStage`, `returnAwayTeam`.
+- `src/content/awayTeamChains.js` — per-waypoint chain data. Each entry keyed by `waypointId`, value is a stage dict compatible with the v0.6.0 `multiStage` shape, plus `returnSolDelta` on choices.
+- `src/content/medicalEmergency.js` — the multi-stage event data (3 stages: diagnosis, treatment, disposal).
+- `sim/awayTeam.test.mjs` — unit tests.
+- `sim/medicalEmergency.test.mjs` — unit tests.
+
+**Modified files:**
+- `src/state.js` — new fields: `awayTeam`, `corpses`. Remove old `pendingWaypoint` (superseded).
+- `src/systems/waypoints.js` — `acceptWaypoint` rewired: no longer bumps `kmToNextLandmark`; delegates to `acceptAwayTeam`. `resolveWaypoint` deleted (superseded by away-team return flow). `rollWaypoints` gains a gating check for `aliveCrew >= 3`.
+- `src/systems/travel.js` — `advanceSol` gains a camp mode: when `state.awayTeam` is set, rover doesn't move; away-team stages fire via `advanceAwayTeam`.
+- `src/systems/loadout.js` (or wherever `cargoPounds` lives) — sums `corpses[].weightLbs` into the total.
+- `src/systems/multiStage.js` — extend `applyStageChoice` to honor `returnSolDelta` when the event runs under an away-team context. Minimal change: pass an optional `onChoice` hook that away-team can use to mutate its own state field.
+- `src/ui/modals.js` — two new renderers: `showAwayTeamPickerModal`, `showAwayTeamReunionModal`. Medical emergency reuses the existing `showMultiStageModal`.
+- `src/main.js` — dispatch branches for the two new modal types.
+- `src/render.js` — minimap waypoint shows "AWAY" pulse while `awayTeam.waypointId === waypoint.id`. Dashboard gains a "DUE BACK: sol N" chip.
+- `src/content/waypoints.js` — no schema change; existing 12 waypoints keep their fields. Away-team chain data lives in the parallel `awayTeamChains.js` keyed by `waypointId`.
+- `package.json` — version bump to 0.7.0.
+
+**Untouched:** scoring, career bonuses, existing single-choice events, minimap route rendering, landmark encounters.
+
+## State shape
+
+```js
+// src/state.js — inside createInitialState(), new/changed fields
+awayTeam: null,         // see shape below
+corpses:  [],           // [{ crewId, weightLbs }]
+pendingWaypoint: /* REMOVED */
+```
+
+```js
+// awayTeam shape while active
+awayTeam = {
+  waypointId:   'olivine_outcrop',
+  crewIds:      ['c2', 'c3'],
+  departSol:    6,
+  returnSol:    10,           // mutable via stage returnSolDelta
+  currentStage: 'approach',   // null once chain completes; camp continues until returnSol
+  accumulated: {              // reward snapshot built during chain
+    sciencePoints: 0,
+    facts:         [],
+    damageByCrew:  { c2: 0, c3: 0 },
+  },
+  deaths: []                  // crewIds who died during chain
+}
+```
+
+**Invariant:** `awayTeam === null` means no detour in progress. All away-team logic is guarded on its presence.
+
+## Away-team lifecycle
+
+```
+[segment start]
+   ↓ roll waypoint (same as v0.6.0)
+[waypoint_offer modal]
+   ↓ gate: aliveCrew.length >= 3
+   ↓ accept
+[away_team_picker modal]
+   ↓ pick 1–3, ≥1 left on rover
+   ↓ acceptAwayTeam()
+[state.awayTeam set, currentStage = chain.startStage]
+   ↓ landmark encounter for CURRENT arrival fires now
+     (same as v0.6.0; rover still "at" the turn-off)
+   ↓ player clicks NEXT SOL
+[advanceSol with awayTeam set: camp mode]
+   ↓ rover does NOT advance km
+   ↓ both groups take background damage
+   ↓ if currentStage != null:
+       fire multi_stage modal for that stage
+       player choice applies outcome + returnSolDelta
+       currentStage ← chosen.nextStage
+   ↓ else if sol >= returnSol:
+       returnAwayTeam()
+       [away_team_reunion modal]
+   ↓ else:
+       flavor log "Day N at camp. Team still out."
+[reunion complete]
+   ↓ state.awayTeam ← null
+   ↓ rover resumes next-sol travel normally
+```
+
+### Key decisions
+
+- **One stage per sol during camp**, not all-at-once on accept. Dramatizes the camp. Authored chains should be ≤ baseline `detourSols` in stage count; extensions handled via `returnSolDelta`.
+- **`returnSolDelta` lives on choice objects** in the chain data. Example: `{ label: 'Rappel down', nextStage: 'deep_sample', returnSolDelta: +1 }`.
+- **Damage during camp applies to both groups** using the existing `applyDamage` path. Away-team members take extra damage only when a stage outcome explicitly says so.
+- **If all away-team crew die mid-chain**, jump straight to reunion (as a "only the bodies came back" beat).
+- **If all rover crew die mid-camp**, standard game-over fires — away team is stranded (logged, no recovery).
+
+## Reunion modal
+
+Content it must render:
+1. Which crew returned alive (names, current HP, damage taken during the away mission).
+2. Science earned + any advanced facts learned.
+3. If anyone died:
+   - Named dead crew, cause (from stage outcome).
+   - Two-choice action: **Bring body back** (+weightLbs to corpses) or **Leave behind** (permanent loss, no body recovery).
+4. Narrative summary pulled from the `reunionText` field on the final resolved stage.
+
+## Medical emergency event (issue #6)
+
+Authored as a single 3-stage multi-stage event in `src/content/medicalEmergency.js`.
+
+**Trigger:** rolled via the existing multi-stage pool in `advanceSol`, `oneShot: true`. Weighted toward mid-mission sols (guarded by segmentIdx ≥ 2 if easy to wire; otherwise just rare).
+
+**Stage 1 — Diagnosis.** Patient pick: random alive non-medic crew; if medic is the only alive candidate, medic is the patient (self-treat branch).
+- Choices: consult medic (skill check), consult Earth (delay, patient worsens), dose + hope (random).
+
+**Stage 2 — Treatment.** Branches keyed by Stage 1 outcome.
+- Surgery (EVA + power + skill check) — success: stable. Fail: death.
+- Stabilize + push (patient worsens per sol until next landmark — sets a worsening flag).
+- Induced coma (power + O₂ burn; revival at next landmark roll).
+
+**Medic flavor line (#21):** on any Stage 2 failure path that kills the patient while `medicAlive && patient !== medic`, append the line *"Well, there goes paradise."* to the failure log entry or use it as the opening beat of Stage 3's description. Don't fire if the medic is the patient or is dead.
+
+**Stage 3 — Disposal (only if death in Stage 2).** Reuses the same body-choice mechanic as away-team reunion.
+- Bury → lighter rover, small SCI (documented burial), morale log.
+- Keep → +weightLbs to corpses (feeds Earth-return bonus hook, future issue).
+- Jettison → max weight relief, dark log entry.
+
+**Shared code path:** the body-disposal logic is a helper in `src/systems/corpse.js` (new), used by both away-team reunion and medical-emergency Stage 3. Single source of truth for weight accounting.
+
+## Corpse weight
+
+```js
+// src/systems/loadout.js — cargoPounds addition
+const corpseLbs = state.corpses.reduce((n, c) => n + c.weightLbs, 0);
+return baseCargo + corpseLbs;
+```
+
+Default weight per crew: **180 LB** (suit + body, matches issue #6's example). Authorable per crew in `src/content/crew.js` if we ever want variation.
+
+## Content strategy
+
+- Keep the existing 12-entry `WAYPOINTS` pool. No schema change.
+- `src/content/awayTeamChains.js` is a dict keyed by `waypointId`:
+  ```js
+  export const AWAY_TEAM_CHAINS = {
+    olivine_outcrop: {
+      startStage: 'approach',
+      stages: { approach: { ... }, deep_sample: { ... }, ... }
+    },
+    // ...12 total
+  };
+  ```
+- Baseline chain depth: most waypoints get a **2-stage** chain. A couple of spicy ones get 3. Simple chains (single decision = single stage) can be authored for low-effort waypoints.
+- Advanced fact pools (`ADVANCED_*_FACTS`) unchanged; award gated on success of the **final stage's skill check**, not mid-chain.
+
+## Edge cases
+
+- **Away team reduced to zero during chain** — jump to reunion; all members marked dead. Reunion offers "bring bodies" / "leave behind" per corpse.
+- **Medic is the patient** — Stage 1 "consult medic" becomes "self-treat with penalty"; skill-check P reduced by 20pp.
+- **Away team returns while a medical emergency is active on the rover** — reunion fires first (earlier in advanceSol), medical emergency continues next sol. No simultaneous modals.
+- **Game ends (win/loss) with `awayTeam` still set** — treat as unresolved, log "X crew stranded off-route" in the end-of-run modal.
+
+## Tests
+
+`sim/awayTeam.test.mjs`:
+- `acceptAwayTeam` sets state correctly, leaves rover crew untouched.
+- `advanceAwayTeam` fires one stage per call, respects `returnSolDelta`.
+- Camp sols tick damage to both parties.
+- `returnAwayTeam` produces expected reward snapshot + deaths list.
+- Gating: accept fails if `aliveCrew < 3`.
+- Invariant: rover `kmToNextLandmark` is unchanged across entire camp.
+
+`sim/medicalEmergency.test.mjs`:
+- Stage 1 → 2 → 3 happy path with death-then-bury.
+- Keep-body increases `corpses` and `cargoPounds`.
+- Medic-is-patient branch applies penalty.
+- `oneShot` flag prevents re-fire in same run.
+
+## Tradeoffs / open calls
+
+- **One stage per sol vs. all at once.** Choosing per-sol for dramatic pacing. If camps feel too slow in playtest, flip to "stages fire immediately after accept, camp is just idle sols."
+- **Stranded-crew recovery.** Not in scope. If a player strands an away team and later wants them back, the answer is no — it's a permanent-loss consequence.
+- **Reward timing.** All SCI/facts applied at reunion, not per-stage. Keeps the reward emotionally tied to the return beat.
+- **Corpse weight as a single mechanic for both features.** This is a deliberate coupling — both features bring a body back, both need the weight to mean something. One bug surface, both features benefit.
+
+## Replaces / supersedes
+
+- `resolveWaypoint` (deleted — reward is issued at reunion, not at landmark arrival).
+- The `acceptWaypoint → kmToNextLandmark += detourKm` model (deleted — rover camps, doesn't drive).
+- `state.pendingWaypoint` (deleted — replaced by `state.awayTeam`).
+
+## Rollout
+
+- Single feature branch (`feat/away-team-waypoints`), single PR to main, tagged `v0.7.0`.
+- Commit granularity: (1) state shape + corpse plumbing, (2) away-team systems + tests, (3) medical emergency systems + tests, (4) UI modals + dispatch, (5) content (away-team chains + medical emergency data), (6) version bump.

--- a/docs/superpowers/specs/2026-04-17-v0.7.0-away-team-and-medical-design.md
+++ b/docs/superpowers/specs/2026-04-17-v0.7.0-away-team-and-medical-design.md
@@ -58,7 +58,7 @@ Two success criteria:
 - `src/state.js` — new fields: `awayTeam`, `corpses`. Remove old `pendingWaypoint` (superseded).
 - `src/systems/waypoints.js` — `acceptWaypoint` rewired: no longer bumps `kmToNextLandmark`; delegates to `acceptAwayTeam`. `resolveWaypoint` deleted (superseded by away-team return flow). `rollWaypoints` gains a gating check for `aliveCrew >= 3`.
 - `src/systems/travel.js` — `advanceSol` gains a camp mode: when `state.awayTeam` is set, rover doesn't move; away-team stages fire via `advanceAwayTeam`.
-- `src/systems/loadout.js` (or wherever `cargoPounds` lives) — sums `corpses[].weightLbs` into the total.
+- `src/systems/travel.js` — `cargoPounds` (currently private to travel.js) widens from `(resources)` to `(state)` and sums `state.corpses[].weightLbs` into the total. All internal call sites updated.
 - `src/systems/multiStage.js` — extend `applyStageChoice` to honor `returnSolDelta` when the event runs under an away-team context. Minimal change: pass an optional `onChoice` hook that away-team can use to mutate its own state field.
 - `src/ui/modals.js` — two new renderers: `showAwayTeamPickerModal`, `showAwayTeamReunionModal`. Medical emergency reuses the existing `showMultiStageModal`.
 - `src/main.js` — dispatch branches for the two new modal types.
@@ -172,9 +172,15 @@ Authored as a single 3-stage multi-stage event in `src/content/medicalEmergency.
 ## Corpse weight
 
 ```js
-// src/systems/loadout.js — cargoPounds addition
-const corpseLbs = state.corpses.reduce((n, c) => n + c.weightLbs, 0);
-return baseCargo + corpseLbs;
+// src/systems/travel.js — cargoPounds widened
+function cargoPounds(state) {
+  let lbs = 0;
+  for (const t of PART_TYPES) {
+    if (!t.supply) lbs += (state.resources[t.key] || 0) * t.lbs;
+  }
+  for (const c of state.corpses) lbs += c.weightLbs;
+  return lbs;
+}
 ```
 
 Default weight per crew: **180 LB** (suit + body, matches issue #6's example). Authorable per crew in `src/content/crew.js` if we ever want variation.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "type": "module",
   "private": true,
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/sim/awayTeam.test.mjs
+++ b/sim/awayTeam.test.mjs
@@ -60,8 +60,40 @@ test('every AWAY_TEAM_CHAINS entry has valid stage graph', () => {
           assert.ok(chain.stages[choice.nextStage],
             `${waypointId}.${stageId}: nextStage "${choice.nextStage}" missing`);
         }
+        // Terminal choices must carry a cost (outcome, or skill-check pair).
+        // Non-terminal choices can be pure branches (just nextStage).
+        const isTerminal = (choice.nextStage ?? null) === null;
+        if (isTerminal) {
+          const hasPlain = 'outcome' in choice;
+          const hasSkill = 'skillCheck' in choice
+            && 'successOutcome' in choice
+            && 'failOutcome' in choice;
+          assert.ok(hasPlain || hasSkill,
+            `${waypointId}.${stageId}: terminal choice needs outcome or skill-check pair`);
+        }
       }
     }
+  }
+});
+
+test('every waypoint in WAYPOINTS has a matching chain', () => {
+  for (const wp of WAYPOINTS) {
+    assert.ok(AWAY_TEAM_CHAINS[wp.id],
+      `no away-team chain authored for waypoint "${wp.id}"`);
+  }
+});
+
+test('every chain can be driven to a terminal stage by always picking choice 0', () => {
+  const base = makeState();
+  for (const waypointId of Object.keys(AWAY_TEAM_CHAINS)) {
+    // Force all skill-check successes for smoke drive (skip awayTeamDamage).
+    let s = acceptAwayTeam(base, waypointId, ['c1', 'c2']);
+    assert.ok(s.awayTeam, `${waypointId}: acceptAwayTeam failed`);
+    let guard = 10;
+    while (s.awayTeam && s.awayTeam.currentStage && guard-- > 0) {
+      s = withRandom([0.01, 0.5, 0.3, 0.5], () => resolveAwayTeamStage(s, 0));
+    }
+    assert.ok(guard >= 0, `${waypointId}: stage loop exceeded guard (possible cycle)`);
   }
 });
 

--- a/sim/awayTeam.test.mjs
+++ b/sim/awayTeam.test.mjs
@@ -1,0 +1,261 @@
+// Tests for src/systems/awayTeam.js. Run: node --test sim/awayTeam.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WAYPOINTS } from '../src/content/waypoints.js';
+import { AWAY_TEAM_CHAINS } from '../src/content/awayTeamChains.js';
+import {
+  acceptAwayTeam,
+  advanceAwayTeam,
+  resolveAwayTeamStage,
+  returnAwayTeam,
+  finalizeReunion,
+  MIN_CREW_FOR_DIVERT
+} from '../src/systems/awayTeam.js';
+
+function makeState(overrides = {}) {
+  return {
+    status: 'active',
+    sol: 5,
+    route: ['jezero','syrtis','arabia','meridiani','gale','elysium','tharsis','olympus_base'],
+    routeKm: [330, 420, 290, 360, 460, 315, 375],
+    currentLandmarkIndex: 1,
+    kmToNextLandmark: 420,
+    resources: { oxygen: 100, water: 100, food: 100, power: 100, panels: 100, mech: 4, eva: 4, cell: 3 },
+    crew: [
+      { id: 'c1', name: 'A', role: 'engineer',  health: 100, status: 'healthy', alive: true },
+      { id: 'c2', name: 'B', role: 'biologist', health: 100, status: 'healthy', alive: true },
+      { id: 'c3', name: 'C', role: 'medic',     health: 100, status: 'healthy', alive: true },
+      { id: 'c4', name: 'D', role: 'pilot',     health: 100, status: 'healthy', alive: true },
+      { id: 'c5', name: 'E', role: 'security',  health: 100, status: 'healthy', alive: true }
+    ],
+    sciencePoints: 0,
+    factsLearned: [],
+    awayTeam: null,
+    corpses: [],
+    log: [],
+    ...overrides
+  };
+}
+
+function withRandom(values, fn) {
+  const original = Math.random;
+  let i = 0;
+  Math.random = () => values[i++ % values.length];
+  try { return fn(); }
+  finally { Math.random = original; }
+}
+
+const OLIVINE = WAYPOINTS.find(w => w.id === 'olivine_outcrop');
+
+// --- Shape ---
+
+test('every AWAY_TEAM_CHAINS entry has valid stage graph', () => {
+  for (const [waypointId, chain] of Object.entries(AWAY_TEAM_CHAINS)) {
+    assert.ok(chain.stages[chain.startStage],
+      `${waypointId}: startStage "${chain.startStage}" missing from stages`);
+    for (const [stageId, stage] of Object.entries(chain.stages)) {
+      for (const choice of stage.choices) {
+        if (choice.nextStage !== null && choice.nextStage !== undefined) {
+          assert.ok(chain.stages[choice.nextStage],
+            `${waypointId}.${stageId}: nextStage "${choice.nextStage}" missing`);
+        }
+      }
+    }
+  }
+});
+
+// --- Accept ---
+
+test('acceptAwayTeam sets state.awayTeam and does not touch kmToNextLandmark', () => {
+  const s0 = makeState();
+  const s1 = acceptAwayTeam(s0, 'olivine_outcrop', ['c1', 'c2']);
+  assert.equal(s1.awayTeam.waypointId, 'olivine_outcrop');
+  assert.deepEqual(s1.awayTeam.crewIds, ['c1', 'c2']);
+  assert.equal(s1.awayTeam.departSol, 5);
+  assert.equal(s1.awayTeam.returnSol, 5 + OLIVINE.detourSols);
+  assert.equal(s1.awayTeam.currentStage, 'approach');
+  assert.equal(s1.kmToNextLandmark, 420, 'rover distance unchanged');
+});
+
+test('acceptAwayTeam blocks when fewer than 3 alive crew', () => {
+  const s0 = makeState({
+    crew: [
+      { id: 'c1', name: 'A', role: 'engineer', health: 100, status: 'healthy', alive: true },
+      { id: 'c2', name: 'B', role: 'medic',    health: 100, status: 'healthy', alive: true },
+      { id: 'c3', name: 'C', role: 'pilot',    health: 100, status: 'healthy', alive: false },
+      { id: 'c4', name: 'D', role: 'security', health: 100, status: 'healthy', alive: false },
+      { id: 'c5', name: 'E', role: 'biologist',health: 100, status: 'healthy', alive: false }
+    ]
+  });
+  const s1 = acceptAwayTeam(s0, 'olivine_outcrop', ['c1']);
+  assert.equal(s1.awayTeam, null);
+  assert.ok(s1.log.some(l => l.text.toLowerCase().includes('too few')));
+  assert.equal(MIN_CREW_FOR_DIVERT, 3);
+});
+
+test('acceptAwayTeam rejects a crew pick that would strand the rover', () => {
+  // 3 alive, try to send all 3 — must leave ≥1 on rover
+  const s0 = makeState({
+    crew: [
+      { id: 'c1', name: 'A', role: 'engineer',  health: 100, status: 'healthy', alive: true },
+      { id: 'c2', name: 'B', role: 'biologist', health: 100, status: 'healthy', alive: true },
+      { id: 'c3', name: 'C', role: 'medic',     health: 100, status: 'healthy', alive: true },
+      { id: 'c4', name: 'D', role: 'pilot',     health: 100, status: 'healthy', alive: false },
+      { id: 'c5', name: 'E', role: 'security',  health: 100, status: 'healthy', alive: false }
+    ]
+  });
+  const s1 = acceptAwayTeam(s0, 'olivine_outcrop', ['c1', 'c2', 'c3']);
+  assert.equal(s1.awayTeam, null);
+});
+
+// --- advanceAwayTeam ---
+
+test('advanceAwayTeam opens a multi_stage modal with source=awayTeam while a stage is pending', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  const s1 = advanceAwayTeam(s0);
+  assert.equal(s1.activeModal?.type, 'multi_stage');
+  assert.equal(s1.activeModal.payload.source, 'awayTeam');
+  assert.equal(s1.activeModal.payload.stageId, 'approach');
+});
+
+test('advanceAwayTeam with currentStage=null and sol < returnSol emits idle log', () => {
+  const base = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  const s = { ...base, awayTeam: { ...base.awayTeam, currentStage: null }, sol: base.awayTeam.returnSol - 1 };
+  const s1 = advanceAwayTeam(s);
+  assert.ok(s1.log.some(l => l.text.toLowerCase().includes('camp day')));
+  assert.equal(s1.activeModal ?? null, null);
+});
+
+test('advanceAwayTeam with currentStage=null and sol >= returnSol triggers reunion', () => {
+  const base = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  const s = { ...base, awayTeam: { ...base.awayTeam, currentStage: null }, sol: base.awayTeam.returnSol };
+  const s1 = advanceAwayTeam(s);
+  assert.equal(s1.activeModal?.type, 'away_team_reunion');
+});
+
+// --- resolveAwayTeamStage ---
+
+test('resolveAwayTeamStage applies returnSolDelta to awayTeam.returnSol', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  const baseReturn = s0.awayTeam.returnSol;
+  // approach stage, choice index 0 = "Rappel to the fresh face" (returnSolDelta: +1)
+  const s1 = resolveAwayTeamStage(s0, 0);
+  assert.equal(s1.awayTeam.returnSol, baseReturn + 1);
+  assert.equal(s1.awayTeam.currentStage, 'deep_sample');
+});
+
+test('resolveAwayTeamStage defers sciencePoints and facts to accumulated', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  // approach choice 1 = ridgeline scan, skill check success → sciencePoints: 40
+  const s1 = withRandom([0.01], () => resolveAwayTeamStage(s0, 1));
+  assert.equal(s1.awayTeam.accumulated.sciencePoints, 40);
+  assert.equal(s1.sciencePoints, 0, 'rover SCI untouched until reunion');
+  // Terminal skill check success → one fact accumulated
+  assert.equal(s1.awayTeam.accumulated.facts.length, 1);
+  assert.equal(s1.factsLearned.length, 0, 'rover facts untouched until reunion');
+  assert.equal(s1.awayTeam.currentStage, null);
+});
+
+test('resolveAwayTeamStage applies awayTeamDamage only to away-team members', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  // approach(0) → deep_sample. Then deep_sample choice 0 = drill, with fail outcome awayTeamDamage: 20.
+  const afterApproach = resolveAwayTeamStage(s0, 0);
+  assert.equal(afterApproach.awayTeam.currentStage, 'deep_sample');
+  // Force skill-check fail (Math.random returns high → fail).
+  const s1 = withRandom([0.99], () => resolveAwayTeamStage(afterApproach, 0));
+  const rover = s1.crew.find(c => !afterApproach.awayTeam.crewIds.includes(c.id));
+  assert.equal(rover.health, 100, 'rover crew untouched');
+  const away = s1.crew.filter(c => afterApproach.awayTeam.crewIds.includes(c.id));
+  const anyDamaged = away.some(c => c.health < 100);
+  assert.ok(anyDamaged, 'at least one away-team member takes damage');
+});
+
+// --- returnAwayTeam ---
+
+test('returnAwayTeam packages a reunion payload with survivors + deaths + rewards', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  // Fake a completed chain with some accumulated reward and one death.
+  const s = {
+    ...s0,
+    awayTeam: {
+      ...s0.awayTeam,
+      currentStage: null,
+      accumulated: { sciencePoints: 75, facts: ['a fact'] },
+      deaths: ['c2']
+    },
+    crew: s0.crew.map(c => c.id === 'c2' ? { ...c, alive: false, status: 'dead', health: 0 } : c)
+  };
+  const s1 = returnAwayTeam(s);
+  assert.equal(s1.activeModal.type, 'away_team_reunion');
+  assert.equal(s1.activeModal.payload.sciencePoints, 75);
+  assert.deepEqual(s1.activeModal.payload.facts, ['a fact']);
+  assert.equal(s1.activeModal.payload.survivors.length, 1);
+  assert.equal(s1.activeModal.payload.survivors[0].id, 'c1');
+  assert.equal(s1.activeModal.payload.deaths.length, 1);
+  assert.equal(s1.activeModal.payload.deaths[0].id, 'c2');
+});
+
+// --- finalizeReunion ---
+
+test('finalizeReunion applies SCI + facts and clears awayTeam', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  const s = {
+    ...s0,
+    awayTeam: {
+      ...s0.awayTeam,
+      currentStage: null,
+      accumulated: { sciencePoints: 50, facts: ['rare fact'] },
+      deaths: []
+    }
+  };
+  const s1 = finalizeReunion(s, {});
+  assert.equal(s1.sciencePoints, 50);
+  assert.deepEqual(s1.factsLearned, ['rare fact']);
+  assert.equal(s1.awayTeam, null);
+  assert.equal(s1.activeModal, null);
+  assert.equal(s1.corpses.length, 0);
+});
+
+test('finalizeReunion adds corpses for bring choices and not for leave choices', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  const s = {
+    ...s0,
+    awayTeam: {
+      ...s0.awayTeam,
+      accumulated: { sciencePoints: 0, facts: [] },
+      deaths: ['c1', 'c2']
+    }
+  };
+  const s1 = finalizeReunion(s, { c1: 'bring', c2: 'leave' });
+  assert.equal(s1.corpses.length, 1);
+  assert.equal(s1.corpses[0].crewId, 'c1');
+});
+
+// --- Full lifecycle: rover stays parked across the whole camp ---
+
+test('lifecycle: kmToNextLandmark never changes across full away-team run', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1', 'c2']);
+  const startKm = s0.kmToNextLandmark;
+  // Force all skill-check successes.
+  const s1 = withRandom([0.01, 0.5], () => resolveAwayTeamStage(s0, 0));  // approach → deep_sample
+  const s2 = withRandom([0.01, 0.5], () => resolveAwayTeamStage(s1, 0));  // deep_sample drill, success
+  assert.equal(s2.kmToNextLandmark, startKm);
+  assert.equal(s2.awayTeam.currentStage, null);
+});
+
+// --- All away crew die → skip to reunion ---
+
+test('if all away-team crew die mid-chain, stage resolution jumps straight to reunion', () => {
+  const s0 = acceptAwayTeam(makeState(), 'olivine_outcrop', ['c1']);
+  // Mark c1 as nearly dead so a big awayTeamDamage finishes them.
+  const s = {
+    ...s0,
+    crew: s0.crew.map(c => c.id === 'c1' ? { ...c, health: 5 } : c),
+    awayTeam: { ...s0.awayTeam, currentStage: 'deep_sample' }
+  };
+  // deep_sample drill, force fail (awayTeamDamage: 20 → c1 dies)
+  const s1 = withRandom([0.99], () => resolveAwayTeamStage(s, 0));
+  assert.equal(s1.activeModal?.type, 'away_team_reunion');
+  assert.ok(s1.awayTeam.deaths.includes('c1'));
+});

--- a/sim/corpse.test.mjs
+++ b/sim/corpse.test.mjs
@@ -1,0 +1,53 @@
+// Tests for src/systems/corpse.js. Run: node --test sim/corpse.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { addCorpse, corpseWeight, DEFAULT_CORPSE_LBS } from '../src/systems/corpse.js';
+
+function makeState(overrides = {}) {
+  return { corpses: [], ...overrides };
+}
+
+test('addCorpse adds an entry with default 180 LB', () => {
+  const s0 = makeState();
+  const s1 = addCorpse(s0, 'c2');
+  assert.equal(s1.corpses.length, 1);
+  assert.equal(s1.corpses[0].crewId, 'c2');
+  assert.equal(s1.corpses[0].weightLbs, DEFAULT_CORPSE_LBS);
+  assert.equal(DEFAULT_CORPSE_LBS, 180);
+});
+
+test('addCorpse accepts an explicit weight', () => {
+  const s0 = makeState();
+  const s1 = addCorpse(s0, 'c2', 210);
+  assert.equal(s1.corpses[0].weightLbs, 210);
+});
+
+test('addCorpse is idempotent for the same crewId', () => {
+  const s0 = makeState();
+  const s1 = addCorpse(s0, 'c2');
+  const s2 = addCorpse(s1, 'c2', 999);
+  assert.equal(s2.corpses.length, 1);
+  assert.equal(s2.corpses[0].weightLbs, DEFAULT_CORPSE_LBS);
+});
+
+test('addCorpse is immutable (does not mutate input state)', () => {
+  const s0 = makeState();
+  const s1 = addCorpse(s0, 'c2');
+  assert.equal(s0.corpses.length, 0);
+  assert.notEqual(s1.corpses, s0.corpses);
+});
+
+test('corpseWeight sums multiple entries', () => {
+  const s = makeState({
+    corpses: [
+      { crewId: 'c1', weightLbs: 180 },
+      { crewId: 'c2', weightLbs: 200 }
+    ]
+  });
+  assert.equal(corpseWeight(s), 380);
+});
+
+test('corpseWeight is 0 for empty state', () => {
+  assert.equal(corpseWeight(makeState()), 0);
+});

--- a/sim/medicalEmergency.test.mjs
+++ b/sim/medicalEmergency.test.mjs
@@ -1,0 +1,265 @@
+// Tests for src/systems/medicalEmergency.js. Run: node --test sim/medicalEmergency.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  pickPatient,
+  beginMedicalEmergency,
+  resolveMedicalStage,
+  MEDICAL_EMERGENCY_ID
+} from '../src/systems/medicalEmergency.js';
+import { MEDICAL_EMERGENCY } from '../src/content/medicalEmergency.js';
+
+function makeState(overrides = {}) {
+  return {
+    status: 'active',
+    sol: 5,
+    resources: { oxygen: 80, water: 80, food: 80, power: 80, panels: 100, mech: 4, eva: 4, cell: 3 },
+    crew: [
+      { id: 'c1', name: 'Alex',  role: 'engineer',  health: 100, status: 'healthy', alive: true },
+      { id: 'c2', name: 'Riya',  role: 'biologist', health: 100, status: 'healthy', alive: true },
+      { id: 'c3', name: 'Tomas', role: 'medic',     health: 100, status: 'healthy', alive: true },
+      { id: 'c4', name: 'Mei',   role: 'pilot',     health: 100, status: 'healthy', alive: true },
+      { id: 'c5', name: 'Sam',   role: 'security',  health: 100, status: 'healthy', alive: true }
+    ],
+    sciencePoints: 0,
+    factsLearned: [],
+    firedEvents: [],
+    corpses: [],
+    log: [],
+    activeModal: null,
+    ...overrides
+  };
+}
+
+function withRandom(values, fn) {
+  const original = Math.random;
+  let i = 0;
+  Math.random = () => values[i++ % values.length];
+  try { return fn(); }
+  finally { Math.random = original; }
+}
+
+// A medical modal with an explicit patient (skips the random patient pick).
+function openAt(state, stageId, patientId = 'c2', selfTreat = false) {
+  return {
+    ...state,
+    activeModal: {
+      type: 'multi_stage',
+      payload: {
+        event:   MEDICAL_EMERGENCY,
+        stageId,
+        source:  'medical',
+        context: { patientId, selfTreat }
+      }
+    }
+  };
+}
+
+function choiceIdx(stageId, key) {
+  return MEDICAL_EMERGENCY.stages[stageId].choices.findIndex(c => c.key === key);
+}
+
+// --- Shape / registry ---
+
+test('event id is stable', () => {
+  assert.equal(MEDICAL_EMERGENCY_ID, 'medical_emergency');
+  assert.equal(MEDICAL_EMERGENCY.oneShot, true);
+});
+
+test('stages have choices with keys; no dangling nextStage refs', () => {
+  for (const [stageId, stage] of Object.entries(MEDICAL_EMERGENCY.stages)) {
+    assert.ok(stage.choices.length > 0, `${stageId} has no choices`);
+    for (const c of stage.choices) assert.ok(c.key, `${stageId}: choice missing key`);
+  }
+});
+
+// --- pickPatient ---
+
+test('pickPatient selects a non-medic when one is alive', () => {
+  const s = makeState();
+  const pick = withRandom([0.0], () => pickPatient(s));
+  assert.notEqual(pick.id, 'c3');  // medic
+  assert.equal(pick.selfTreat, false);
+});
+
+test('pickPatient selects the medic only when medic is the only alive crew', () => {
+  const s = makeState({
+    crew: [
+      { id: 'c1', name: 'A', role: 'engineer', health: 0, status: 'dead', alive: false },
+      { id: 'c2', name: 'B', role: 'biologist',health: 0, status: 'dead', alive: false },
+      { id: 'c3', name: 'C', role: 'medic',    health: 100, status: 'healthy', alive: true },
+      { id: 'c4', name: 'D', role: 'pilot',    health: 0, status: 'dead', alive: false },
+      { id: 'c5', name: 'E', role: 'security', health: 0, status: 'dead', alive: false }
+    ]
+  });
+  const pick = pickPatient(s);
+  assert.equal(pick.id, 'c3');
+  assert.equal(pick.selfTreat, true);
+});
+
+// --- beginMedicalEmergency ---
+
+test('beginMedicalEmergency opens the diagnose stage and marks fired', () => {
+  const s0 = makeState();
+  const s1 = beginMedicalEmergency(s0);
+  assert.equal(s1.activeModal.type, 'multi_stage');
+  assert.equal(s1.activeModal.payload.source, 'medical');
+  assert.equal(s1.activeModal.payload.stageId, 'diagnose');
+  assert.ok(s1.firedEvents.includes(MEDICAL_EMERGENCY_ID));
+});
+
+// --- diagnose stage ---
+
+test('diagnose: consult-medic success goes to treat with no damage', () => {
+  const s0 = openAt(makeState(), 'diagnose');
+  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'medic')));
+  assert.equal(s1.activeModal.payload.stageId, 'treat');
+  const patient = s1.crew.find(c => c.id === 'c2');
+  assert.equal(patient.health, 100);
+});
+
+test('diagnose: consult-medic fail damages patient', () => {
+  const s0 = openAt(makeState(), 'diagnose');
+  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'medic')));
+  assert.equal(s1.activeModal.payload.stageId, 'treat');
+  const patient = s1.crew.find(c => c.id === 'c2');
+  assert.equal(patient.health, 90);
+});
+
+test('diagnose: consult-earth drains resources and worsens patient', () => {
+  const s0 = openAt(makeState(), 'diagnose');
+  const s1 = resolveMedicalStage(s0, choiceIdx('diagnose', 'earth'));
+  assert.equal(s1.activeModal.payload.stageId, 'treat');
+  assert.ok(s1.resources.oxygen < 80);
+  assert.ok(s1.resources.water < 80);
+  const patient = s1.crew.find(c => c.id === 'c2');
+  assert.equal(patient.health, 80);
+});
+
+test('diagnose: hope stabilizes 40% (ends chain)', () => {
+  const s0 = openAt(makeState(), 'diagnose');
+  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'hope')));
+  assert.equal(s1.activeModal, null);
+});
+
+test('diagnose: hope fail worsens patient heavily, routes to treat', () => {
+  const s0 = openAt(makeState(), 'diagnose');
+  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'hope')));
+  assert.equal(s1.activeModal.payload.stageId, 'treat');
+  const patient = s1.crew.find(c => c.id === 'c2');
+  assert.equal(patient.health, 70);
+});
+
+// --- treat stage ---
+
+test('treat: surgery success ends chain with patient stable', () => {
+  const s0 = openAt(makeState(), 'treat');
+  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
+  assert.equal(s1.activeModal, null);
+  const patient = s1.crew.find(c => c.id === 'c2');
+  assert.ok(patient.alive);
+});
+
+test('treat: surgery fail kills patient and routes to dispose', () => {
+  const s0 = openAt(makeState(), 'treat');
+  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
+  assert.equal(s1.activeModal.payload.stageId, 'dispose');
+  const patient = s1.crew.find(c => c.id === 'c2');
+  assert.equal(patient.alive, false);
+});
+
+test('treat: surgery fail with medic alive & not patient appends the medic flavor line', () => {
+  const s0 = openAt(makeState(), 'treat', 'c2', /* selfTreat */ false);
+  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
+  assert.ok(s1.log.some(l => l.text === 'Well, there goes paradise.'));
+});
+
+test('treat: surgery fail when medic is the patient does NOT emit the flavor line', () => {
+  // Only medic is alive → selfTreat path. Patient is the medic.
+  const s0 = openAt(makeState({
+    crew: [
+      { id: 'c1', name: 'A', role: 'engineer', health: 0, status: 'dead', alive: false },
+      { id: 'c2', name: 'B', role: 'biologist',health: 0, status: 'dead', alive: false },
+      { id: 'c3', name: 'C', role: 'medic',    health: 100, status: 'healthy', alive: true },
+      { id: 'c4', name: 'D', role: 'pilot',    health: 0, status: 'dead', alive: false },
+      { id: 'c5', name: 'E', role: 'security', health: 0, status: 'dead', alive: false }
+    ]
+  }), 'treat', 'c3', /* selfTreat */ true);
+  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
+  assert.ok(!s1.log.some(l => l.text === 'Well, there goes paradise.'));
+});
+
+test('treat: stabilize-push damages patient; survival ends chain, death routes to dispose', () => {
+  // Survives (starts at 100, takes 15 → 85).
+  const s0 = openAt(makeState(), 'treat');
+  const s1 = resolveMedicalStage(s0, choiceIdx('treat', 'push'));
+  assert.equal(s1.activeModal, null);
+  const p1 = s1.crew.find(c => c.id === 'c2');
+  assert.equal(p1.health, 85);
+
+  // Dies (starts at 10, takes 15 → 0).
+  const s2Base = makeState({
+    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 10 } : c)
+  });
+  const s2 = openAt(s2Base, 'treat');
+  const s3 = resolveMedicalStage(s2, choiceIdx('treat', 'push'));
+  assert.equal(s3.activeModal?.payload.stageId, 'dispose');
+  const p2 = s3.crew.find(c => c.id === 'c2');
+  assert.equal(p2.alive, false);
+});
+
+test('treat: coma burns resources, keeps patient alive, ends chain', () => {
+  const s0 = openAt(makeState(), 'treat');
+  const s1 = resolveMedicalStage(s0, choiceIdx('treat', 'coma'));
+  assert.equal(s1.activeModal, null);
+  assert.ok(s1.resources.power < 80);
+  assert.ok(s1.resources.oxygen < 80);
+  const patient = s1.crew.find(c => c.id === 'c2');
+  assert.ok(patient.alive);
+});
+
+// --- dispose stage ---
+
+test('dispose: bury ends chain, no corpse, grants SCI', () => {
+  const deadBase = makeState({
+    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 0, alive: false, status: 'dead' } : c)
+  });
+  const s0 = openAt(deadBase, 'dispose');
+  const s1 = resolveMedicalStage(s0, choiceIdx('dispose', 'bury'));
+  assert.equal(s1.activeModal, null);
+  assert.equal(s1.corpses.length, 0);
+  assert.ok(s1.sciencePoints > 0);
+});
+
+test('dispose: keep adds the corpse', () => {
+  const deadBase = makeState({
+    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 0, alive: false, status: 'dead' } : c)
+  });
+  const s0 = openAt(deadBase, 'dispose');
+  const s1 = resolveMedicalStage(s0, choiceIdx('dispose', 'keep'));
+  assert.equal(s1.activeModal, null);
+  assert.equal(s1.corpses.length, 1);
+  assert.equal(s1.corpses[0].crewId, 'c2');
+  assert.equal(s1.corpses[0].weightLbs, 180);
+});
+
+test('dispose: jettison ends chain with no corpse and a specific log line', () => {
+  const deadBase = makeState({
+    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 0, alive: false, status: 'dead' } : c)
+  });
+  const s0 = openAt(deadBase, 'dispose');
+  const s1 = resolveMedicalStage(s0, choiceIdx('dispose', 'jettison'));
+  assert.equal(s1.activeModal, null);
+  assert.equal(s1.corpses.length, 0);
+  assert.ok(s1.log.some(l => l.text.toLowerCase().includes('jettisoned')));
+});
+
+// --- Self-treat penalty: skill-check success P is lower (0.65 → 0.45). ---
+
+test('treat: selfTreat surgery at rand=0.55 fails (above 0.45 cap)', () => {
+  const s0 = openAt(makeState(), 'treat', 'c3', /* selfTreat */ true);
+  const s1 = withRandom([0.55], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
+  // 0.55 > 0.45 selfTreat threshold → fail → patient dies → dispose
+  assert.equal(s1.activeModal?.payload.stageId, 'dispose');
+});

--- a/sim/multiStage.test.mjs
+++ b/sim/multiStage.test.mjs
@@ -49,6 +49,9 @@ const drill = MULTI_STAGE_EVENTS.find(e => e.id === 'drill_bit_seized');
 
 test('demo event shape: startStage exists; every nextStage resolves or is null', () => {
   for (const event of MULTI_STAGE_EVENTS) {
+    // Events with a customResolver use their own dispatcher; shape rules for
+    // applyStageChoice don't apply.
+    if (event.customResolver) continue;
     assert.ok(event.stages[event.startStage], `${event.id}: startStage "${event.startStage}" missing from stages`);
     for (const [stageId, stage] of Object.entries(event.stages)) {
       for (const choice of stage.choices) {
@@ -148,7 +151,8 @@ test('rollMultiStageEvent: returns null when random is above base rate', () => {
 });
 
 test('rollMultiStageEvent: respects firedEvents for oneShot', () => {
-  const s = makeState({ firedEvents: ['drill_bit_seized'] });
+  const firedAllOneShot = MULTI_STAGE_EVENTS.filter(e => e.oneShot).map(e => e.id);
+  const s = makeState({ firedEvents: firedAllOneShot });
   const event = withRandom([0.01, 0.5], () => rollMultiStageEvent(s));
   assert.equal(event, null);
 });

--- a/sim/play.mjs
+++ b/sim/play.mjs
@@ -6,6 +6,7 @@ import { createInitialState } from '../src/state.js';
 import { advanceSol, repairBattery, cleanPanels, canRepair, canClean } from '../src/systems/travel.js';
 import { applyEventChoice } from '../src/systems/events.js';
 import { applyStageChoice } from '../src/systems/multiStage.js';
+import { resolveMedicalStage } from '../src/systems/medicalEmergency.js';
 
 // Simplest strategy: always pick the first option.
 function strategyFirst(_state, _event) { return 0; }
@@ -108,14 +109,24 @@ function playGame({ pace, rations, pickChoice }) {
       s = { ...s, firedWaypoints: [...s.firedWaypoints, s.activeModal.payload.waypoint.id], activeModal: null };
       continue;
     }
-    if (s.activeModal && s.activeModal.type === 'waypoint_reward') {
+    // Away-team picker: sim doesn't dispatch (waypoints are declined above).
+    // Defensive close if one ever reaches here.
+    if (s.activeModal && s.activeModal.type === 'away_team_picker') {
       s = { ...s, activeModal: null };
+      continue;
+    }
+    if (s.activeModal && s.activeModal.type === 'away_team_reunion') {
+      s = { ...s, activeModal: null, awayTeam: null };
       continue;
     }
     // Multi-stage events: sim picks choice 0 on every stage. Keeps the
     // game loop from stalling on the new modal type. Not a strategy-rich
     // runner; any future multi-stage strategy would replace this.
     if (s.activeModal && s.activeModal.type === 'multi_stage') {
+      if (s.activeModal.payload.source === 'medical') {
+        s = resolveMedicalStage(s, 0);
+        continue;
+      }
       const { event, stageId } = s.activeModal.payload;
       const { state: next, nextStage } = applyStageChoice(s, event, stageId, 0);
       if (nextStage !== null) {

--- a/sim/playAwayTeam.mjs
+++ b/sim/playAwayTeam.mjs
@@ -1,0 +1,141 @@
+// Away-team acceptance simulator. Exercises the full dispatch → camp →
+// stage-chain → reunion flow across many runs to surface runtime errors
+// and report impact on mission outcome. Not part of the test suite.
+
+import { createInitialState } from '../src/state.js';
+import { advanceSol, canRepair, canClean, repairBattery, cleanPanels } from '../src/systems/travel.js';
+import { applyEventChoice } from '../src/systems/events.js';
+import { applyStageChoice } from '../src/systems/multiStage.js';
+import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from '../src/systems/awayTeam.js';
+import { resolveMedicalStage } from '../src/systems/medicalEmergency.js';
+import { makeLandmarkEncounter } from '../src/content/landmarks.js';
+import { declineWaypoint } from '../src/systems/waypoints.js';
+
+function playGame({ acceptDiverts, maxSend = 2 }) {
+  let s = createInitialState();
+  s.activeModal = null;
+  s.pace = 'steady';
+  s.rations = 'standard';
+
+  const stats = {
+    divertsOffered:  0,
+    divertsAccepted: 0,
+    reunionsSeen:    0,
+    deathsAway:      0,
+    corpsesBrought:  0,
+    medicalsSeen:    0,
+    sciFromAway:     0
+  };
+
+  const MAX = 250;
+  while (s.status === 'active' && s.sol < MAX) {
+    const m = s.activeModal;
+
+    if (m && m.type === 'event') {
+      const event = m.payload;
+      const { state: next } = applyEventChoice(s, event, 0);
+      s = next;
+      continue;
+    }
+
+    if (m && m.type === 'waypoint_offer') {
+      stats.divertsOffered++;
+      if (!acceptDiverts) {
+        s = { ...s, firedWaypoints: [...s.firedWaypoints, m.payload.waypoint.id], activeModal: null };
+      } else {
+        s = { ...s, activeModal: { type: 'away_team_picker', payload: m.payload } };
+      }
+      continue;
+    }
+
+    if (m && m.type === 'away_team_picker') {
+      const aliveIds = s.crew.filter(c => c.alive).map(c => c.id);
+      const toSend = aliveIds.slice(0, Math.min(maxSend, aliveIds.length - 1));
+      if (toSend.length < 1) {
+        s = { ...s, activeModal: null };
+        continue;
+      }
+      stats.divertsAccepted++;
+      s = acceptAwayTeam(s, m.payload.waypoint.id, toSend);
+      s = { ...s, firedWaypoints: [...s.firedWaypoints, m.payload.waypoint.id] };
+      const arrivedId = s.route[s.currentLandmarkIndex];
+      s = { ...s, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
+      continue;
+    }
+
+    if (m && m.type === 'away_team_reunion') {
+      stats.reunionsSeen++;
+      stats.deathsAway += m.payload.deaths.length;
+      stats.sciFromAway += m.payload.sciencePoints;
+      const corpseChoices = {};
+      for (const d of m.payload.deaths) {
+        corpseChoices[d.id] = 'bring';
+        stats.corpsesBrought++;
+      }
+      s = finalizeReunion(s, corpseChoices);
+      continue;
+    }
+
+    if (m && m.type === 'multi_stage') {
+      if (m.payload.source === 'medical') {
+        stats.medicalsSeen++;
+        s = resolveMedicalStage(s, 0);
+        continue;
+      }
+      if (m.payload.source === 'awayTeam') {
+        s = resolveAwayTeamStage(s, 0);
+        continue;
+      }
+      const { event, stageId } = m.payload;
+      const { state: next, nextStage } = applyStageChoice(s, event, stageId, 0);
+      if (nextStage !== null) {
+        s = { ...next, activeModal: { type: 'multi_stage', payload: { event, stageId: nextStage } } };
+      } else {
+        s = { ...next, activeModal: null };
+      }
+      continue;
+    }
+
+    if (canRepair(s) && s.resources.power < 35) { s = repairBattery(s); continue; }
+    if (canClean(s)  && s.resources.panels < 40) { s = cleanPanels(s);   continue; }
+    s = advanceSol(s, 'travel');
+  }
+  if (s.status === 'active') s.status = 'lost', s.lossReason = 'timeout';
+  return { state: s, stats };
+}
+
+function run(label, opts, N) {
+  let wins = 0, totalSols = 0, totalSci = 0, totalCrew = 0;
+  const agg = { divertsOffered: 0, divertsAccepted: 0, reunionsSeen: 0,
+                deathsAway: 0, corpsesBrought: 0, medicalsSeen: 0, sciFromAway: 0 };
+  for (let i = 0; i < N; i++) {
+    const { state, stats } = playGame(opts);
+    if (state.status === 'won') wins++;
+    totalSols += state.sol;
+    totalSci  += state.sciencePoints;
+    totalCrew += state.crew.filter(c => c.alive).length;
+    for (const k of Object.keys(agg)) agg[k] += stats[k];
+  }
+  const pct = (v) => (v / N).toFixed(2);
+  console.log(
+    `${label.padEnd(20)} ` +
+    `win=${((wins / N) * 100).toFixed(1).padStart(5)}%  ` +
+    `sols=${pct(totalSols).padStart(5)}  ` +
+    `sci=${pct(totalSci).padStart(6)}  ` +
+    `crew=${pct(totalCrew)}  |  ` +
+    `offers=${pct(agg.divertsOffered)}  accepted=${pct(agg.divertsAccepted)}  ` +
+    `reunions=${pct(agg.reunionsSeen)}  deaths=${pct(agg.deathsAway)}  ` +
+    `corpses=${pct(agg.corpsesBrought)}  medicals=${pct(agg.medicalsSeen)}  ` +
+    `sci_away=${pct(agg.sciFromAway)}`
+  );
+}
+
+const N = 200;
+console.log(`Running ${N} games per configuration\n`);
+console.log('label'.padEnd(20) +
+  '  win%     sols    sci     crew  |  offers  accepted  reunions  deaths  corpses  medicals  sci_away');
+console.log('-'.repeat(140));
+run('Decline diverts',      { acceptDiverts: false }, N);
+run('Accept (send 1)',      { acceptDiverts: true, maxSend: 1 }, N);
+run('Accept (send 2)',      { acceptDiverts: true, maxSend: 2 }, N);
+run('Accept (send 3)',      { acceptDiverts: true, maxSend: 3 }, N);

--- a/sim/waypoints.test.mjs
+++ b/sim/waypoints.test.mjs
@@ -42,21 +42,23 @@ test('rollWaypoints produces 0–6 waypoints on a standard route', () => {
     const ids = s.waypoints.map(w => w.waypointId);
     assert.equal(new Set(ids).size, ids.length, 'duplicate waypoint id');
     for (const entry of s.waypoints) {
-      assert.ok(entry.segmentIdx < s.route.length - 2,
-        `segmentIdx ${entry.segmentIdx} should be < ${s.route.length - 2}`);
+      assert.ok(entry.segmentIdx >= 1 && entry.segmentIdx < s.route.length - 1,
+        `segmentIdx ${entry.segmentIdx} out of range [1, ${s.route.length - 1})`);
     }
   }
 });
 
-test('rollWaypoints gives every segment a fair chance over many runs', () => {
-  const counts = Array(6).fill(0);
+test('rollWaypoints gives every eligible landmark a fair chance over many runs', () => {
+  // Eligible landmarks for offers: 1..(route.length - 2), inclusive.
+  const counts = {};
   for (let i = 0; i < 200; i++) {
     const s = rollWaypoints(makeState());
-    for (const w of s.waypoints) counts[w.segmentIdx]++;
+    for (const w of s.waypoints) counts[w.segmentIdx] = (counts[w.segmentIdx] || 0) + 1;
   }
-  for (let idx = 0; idx < 6; idx++) {
-    assert.ok(counts[idx] > 10, `segment ${idx} rarely rolled (count=${counts[idx]})`);
+  for (let idx = 1; idx <= 6; idx++) {
+    assert.ok((counts[idx] || 0) > 10, `segmentIdx ${idx} rarely rolled (count=${counts[idx] || 0})`);
   }
+  assert.equal(counts[0] || 0, 0, 'segmentIdx 0 should never be rolled (issue #22)');
 });
 
 test('rollWaypoints respects WAYPOINT_ROLL_PROB exported constant', () => {

--- a/sim/waypoints.test.mjs
+++ b/sim/waypoints.test.mjs
@@ -1,17 +1,18 @@
 // Tests for src/systems/waypoints.js. Run: node --test sim/waypoints.test.mjs
+//
+// Scope: rollWaypoints + declineWaypoint. The old resolveWaypoint /
+// acceptWaypoint flow was removed in v0.7.0 when waypoints became
+// away-team missions — see sim/awayTeam.test.mjs for the replacement
+// coverage.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { WAYPOINTS } from '../src/content/waypoints.js';
 import {
   rollWaypoints,
-  acceptWaypoint,
   declineWaypoint,
-  resolveWaypoint,
   WAYPOINT_ROLL_PROB
 } from '../src/systems/waypoints.js';
 
-// --- Helper: minimal state shape used by the waypoint functions ---
 function makeState(overrides = {}) {
   return {
     status: 'active',
@@ -23,7 +24,6 @@ function makeState(overrides = {}) {
     sciencePoints: 0,
     factsLearned: [],
     waypoints: [],
-    pendingWaypoint: null,
     firedWaypoints: [],
     log: [],
     ...overrides
@@ -64,126 +64,11 @@ test('rollWaypoints respects WAYPOINT_ROLL_PROB exported constant', () => {
   assert.ok(WAYPOINT_ROLL_PROB > 0 && WAYPOINT_ROLL_PROB < 1);
 });
 
-// --- acceptWaypoint ---
-
-test('acceptWaypoint sets pendingWaypoint and extends the segment', () => {
-  const s0 = makeState({
-    waypoints: [{ waypointId: 'olivine_outcrop', segmentIdx: 0 }]
-  });
-  const s1 = acceptWaypoint(s0, 0);
-  assert.equal(s1.pendingWaypoint?.id, 'olivine_outcrop');
-  assert.equal(s1.kmToNextLandmark, 330 + 80);
-  assert.ok(s1.log.some(l => l.text.includes('Diverting')));
-});
-
-test('acceptWaypoint is a no-op when no matching segment', () => {
-  const s0 = makeState({ waypoints: [] });
-  const s1 = acceptWaypoint(s0, 0);
-  assert.equal(s1, s0);
-});
-
 // --- declineWaypoint ---
 
 test('declineWaypoint pushes the waypoint id to firedWaypoints', () => {
   const s0 = makeState({ firedWaypoints: [] });
   const s1 = declineWaypoint(s0, 'olivine_outcrop');
   assert.deepEqual(s1.firedWaypoints, ['olivine_outcrop']);
-  assert.equal(s1.pendingWaypoint, null);
   assert.ok(s1.log.some(l => l.text.includes('Detour declined')));
-});
-
-// --- resolveWaypoint ---
-
-// Helper: stub Math.random with a sequence of values (auto-cycles).
-function withRandom(values, fn) {
-  const original = Math.random;
-  let i = 0;
-  Math.random = () => values[i++ % values.length];
-  try { return fn(); }
-  finally { Math.random = original; }
-}
-
-test('resolveWaypoint on SUCCESS: full SCI + advanced fact + success flag', () => {
-  const olivine = WAYPOINTS.find(w => w.id === 'olivine_outcrop');
-  const s0 = makeState({
-    pendingWaypoint: { ...olivine },
-    sciencePoints: 10,
-    factsLearned: [],
-    crew: [
-      { id: 'c1', role: 'engineer', alive: true },   // GEOLOGY waypoint → engineer
-      { id: 'c2', role: 'biologist', alive: true },
-      { id: 'c3', role: 'medic', alive: true },
-      { id: 'c4', role: 'pilot', alive: true },
-      { id: 'c5', role: 'security', alive: true }
-    ]
-  });
-  // Math.random sequence: [skill-check, jitter, fact-pick]. 0.01 < 0.75 → success.
-  const s1 = withRandom([0.01, 0.5, 0.3], () => resolveWaypoint(s0));
-  assert.equal(s1.activeModal.payload.success, true);
-  assert.equal(s1.factsLearned.length, 1, 'advanced fact added on success');
-  assert.ok(s1.sciencePoints > 10, 'SCI increased');
-  assert.ok(s1.firedWaypoints.includes('olivine_outcrop'));
-  assert.equal(s1.pendingWaypoint, null);
-  assert.equal(s1.activeModal.payload.role, 'engineer');
-  assert.equal(s1.activeModal.payload.specialistAlive, true);
-});
-
-test('resolveWaypoint on FAILURE: partial SCI + no advanced fact + success=false', () => {
-  const olivine = WAYPOINTS.find(w => w.id === 'olivine_outcrop');
-  const s0 = makeState({
-    pendingWaypoint: { ...olivine },
-    sciencePoints: 10,
-    factsLearned: [],
-    crew: [
-      { id: 'c1', role: 'engineer', alive: true },
-      { id: 'c2', role: 'biologist', alive: true },
-      { id: 'c3', role: 'medic', alive: true },
-      { id: 'c4', role: 'pilot', alive: true },
-      { id: 'c5', role: 'security', alive: true }
-    ]
-  });
-  // Math.random: [0.99 (skill fail), 0.5 (jitter)]. 0.99 > 0.75 → fail.
-  const s1 = withRandom([0.99, 0.5], () => resolveWaypoint(s0));
-  assert.equal(s1.activeModal.payload.success, false);
-  assert.equal(s1.factsLearned.length, 0, 'no advanced fact on failure');
-  assert.ok(s1.sciencePoints > 10, 'partial SCI credited');
-  assert.equal(s1.activeModal.payload.fact, '');
-});
-
-test('resolveWaypoint with dead specialist uses lower base P', () => {
-  const olivine = WAYPOINTS.find(w => w.id === 'olivine_outcrop');
-  const s0 = makeState({
-    pendingWaypoint: { ...olivine },
-    crew: [
-      { id: 'c1', role: 'engineer', alive: false },  // specialist dead
-      { id: 'c2', role: 'biologist', alive: true }
-    ]
-  });
-  // 0.40 is > 0.35 (fail threshold with dead specialist), so fail.
-  const s1 = withRandom([0.40, 0.5], () => resolveWaypoint(s0));
-  assert.equal(s1.activeModal.payload.specialistAlive, false);
-  assert.equal(s1.activeModal.payload.success, false);
-  // 0.20 is < 0.35, so success.
-  const s2 = withRandom([0.20, 0.5, 0.3], () => resolveWaypoint(s0));
-  assert.equal(s2.activeModal.payload.success, true);
-});
-
-test('resolveWaypoint applies career skillBonus to effective P', () => {
-  const olivine = WAYPOINTS.find(w => w.id === 'olivine_outcrop');
-  const s0 = makeState({
-    pendingWaypoint: { ...olivine },
-    careerBonuses: { skillBonus: 0.10 },             // tier 3 methodology
-    crew: [
-      { id: 'c1', role: 'engineer', alive: false }   // dead: baseP = 0.35
-    ]
-  });
-  // With bonus: effectiveP = 0.45. A roll of 0.40 should succeed (would fail without bonus).
-  const s1 = withRandom([0.40, 0.5, 0.3], () => resolveWaypoint(s0));
-  assert.equal(s1.activeModal.payload.success, true);
-});
-
-test('resolveWaypoint is a no-op when no pendingWaypoint', () => {
-  const s0 = makeState({ pendingWaypoint: null });
-  const s1 = resolveWaypoint(s0);
-  assert.equal(s1, s0);
 });

--- a/src/content/awayTeamChains.js
+++ b/src/content/awayTeamChains.js
@@ -12,8 +12,15 @@
 // The final stage's skill check is where the advanced fact reward is
 // gated — earlier stages may grant partial SCI, but factsLearned only
 // grows on a terminal-stage success.
+//
+// Chain-depth mix (v0.7.0): three 1-stage quick grabs, six 2-stage, three
+// 3-stage deep descents. Specialists match factPool → role:
+//   GEOLOGY → engineer, WATER/ASTROBIOLOGY → biologist, ATMOSPHERE → pilot.
 
 export const AWAY_TEAM_CHAINS = {
+
+  // ---- GEOLOGY ----
+
   olivine_outcrop: {
     startStage: 'approach',
     stages: {
@@ -47,5 +54,385 @@ export const AWAY_TEAM_CHAINS = {
         ]
       }
     }
+  },
+
+  lander_wreckage: {
+    startStage: 'approach',
+    stages: {
+      approach: {
+        title:       'Soviet Lander Crash Site',
+        description: 'The debris field stretches 200 meters. Best-preserved pieces cluster near the main body.',
+        choices: [
+          { label:     'Map the debris field first',
+            nextStage: 'debris' },
+          { label:          'Push straight to the main body',
+            nextStage:      'tape_recovery',
+            returnSolDelta: 1 }
+        ]
+      },
+      debris: {
+        title:       'Across the Wreckage',
+        description: 'RTG module is still warm. Fragments tell a thermal-failure story. The main body sits beyond, tape drive visible.',
+        choices: [
+          { label:     'Work toward the tape drive',
+            nextStage: 'tape_recovery' },
+          { label:          'Bag what you have and turn back',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 50 },
+            failOutcome:    { sciencePoints: 20 },
+            nextStage:      null }
+        ]
+      },
+      tape_recovery: {
+        title:       'The Tape Drive',
+        description: 'Corroded housing. Gentle heat might release the spool — or snap it. The RTG cells are a guaranteed haul either way.',
+        choices: [
+          { label:          'Heat the housing, spool carefully',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 80 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 20 },
+            nextStage:      null },
+          { label:          'Pull the RTG cells, skip the tape',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 40 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  lava_tube: {
+    startStage: 'pit_descent',
+    stages: {
+      pit_descent: {
+        title:       'Pit Skylight',
+        description: 'The collapse opens thirty meters down into an intact lava tube. You can rope in — or lower a probe from the lip.',
+        choices: [
+          { label:          'Descend into the tube',
+            nextStage:      'interior',
+            returnSolDelta: 1 },
+          { label:          'Drop a probe from the lip',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 40 },
+            failOutcome:    { sciencePoints: 20 },
+            nextStage:      null }
+        ]
+      },
+      interior: {
+        title:       'Inside the Tube',
+        description: 'Tube extends two hundred meters at least. Floor is clean regolith; walls show gas escape textures. Full traverse or sample-and-return?',
+        choices: [
+          { label:          'Traverse and map the full length',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 75 },
+            failOutcome:    { sciencePoints: 25, awayTeamDamage: 20 },
+            nextStage:      null },
+          { label:          'Sample the entrance zone and back out',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 35 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  meteorite_field: {
+    startStage: 'survey',
+    stages: {
+      survey: {
+        title:       'Meteorite Scatter',
+        description: 'Dozens of iron-nickel chunks across a kilometer of plain. Preserved because Mars has no plate tectonics to recycle them.',
+        choices: [
+          { label:          'Spectrometer sweep, log every specimen',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 50 },
+            failOutcome:    { sciencePoints: 20 },
+            nextStage:      null },
+          { label:          'Grab the largest three and go',
+            outcome:        { sciencePoints: 30 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  // ---- WATER ----
+
+  subsurface_ice: {
+    startStage: 'approach',
+    stages: {
+      approach: {
+        title:       'Ice-Lens Ridge',
+        description: 'GPR shows the lens four meters below the ridge crest. You can set up a drill rig or do a surface isotope scan.',
+        choices: [
+          { label:          'Deploy the core drill',
+            nextStage:      'core_sample',
+            returnSolDelta: 1 },
+          { label:          'Surface isotope scan only',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 40 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage:      null }
+        ]
+      },
+      core_sample: {
+        title:       'Drilling the Lens',
+        description: 'You have a clean three-meter ice column. Pushing to five meters gets you pre-amazonian ice — if the drill holds.',
+        choices: [
+          { label:          'Push to five meters',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 80 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 15 },
+            nextStage:      null },
+          { label:          'Three meters is plenty — pull the core',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 35 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  rsl_observation: {
+    startStage: 'observe',
+    stages: {
+      observe: {
+        title:       'Active Slope',
+        description: 'The dark streak is flowing right now. You have this window.',
+        choices: [
+          { label:          'Pull a sediment sample from the active channel',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 55 },
+            failOutcome:    { sciencePoints: 20 },
+            nextStage:      null },
+          { label:          'Spectroscopic read from stable ground',
+            outcome:        { sciencePoints: 30 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  banded_deposit: {
+    startStage: 'sample',
+    stages: {
+      sample: {
+        title:       'Layered Crater Wall',
+        description: 'Clay-sulfate banding is legible with the naked eye. A clean cross-section cut preserves the sequence; grab samples are faster.',
+        choices: [
+          { label:          'Saw a clean cross-section slab',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 55 },
+            failOutcome:    { sciencePoints: 25 },
+            nextStage:      null },
+          { label:          'Chip three samples and go',
+            outcome:        { sciencePoints: 30 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  ancient_rille: {
+    startStage: 'junction_survey',
+    stages: {
+      junction_survey: {
+        title:       'Channel Junction',
+        description: 'Two dry channels meet at thirty degrees — classic fluvial confluence. Downstream terraces are a day further.',
+        choices: [
+          { label:          'Trace downstream to the terrace exposure',
+            nextStage:      'terrace',
+            returnSolDelta: 1 },
+          { label:          'Sample the junction basalt and call it',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 40 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage:      null }
+        ]
+      },
+      terrace: {
+        title:       'Terrace Bank',
+        description: 'Stratigraphic layers exposed cleanly along the bank. Climbing gets you the full section. Falling gets you a cracked suit.',
+        choices: [
+          { label:          'Climb for a full stratigraphic read',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 75 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 20 },
+            nextStage:      null },
+          { label:          'Sample the base and retreat',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 40 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  // ---- ATMOSPHERE ----
+
+  polar_layered: {
+    startStage: 'descend',
+    stages: {
+      descend: {
+        title:       'Polar Cliff',
+        description: 'Millions of years of ice-dust layering exposed in one vertical face. Mid-column has the cleanest horizons.',
+        choices: [
+          { label:          'Rappel to mid-column for direct sampling',
+            nextStage:      'core',
+            returnSolDelta: 1 },
+          { label:          'Image-and-spectroscopy from the rim',
+            skillCheck:     { role: 'pilot', successP: 0.75 },
+            successOutcome: { sciencePoints: 40 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage:      null }
+        ]
+      },
+      core: {
+        title:       'Horizontal Core',
+        description: 'You can drill one continuous two-meter horizontal core, or take three bagged grabs. Core reads cleanly if it holds.',
+        choices: [
+          { label:          'Continuous horizontal core',
+            skillCheck:     { role: 'pilot', successP: 0.75 },
+            successOutcome: { sciencePoints: 80 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 15 },
+            nextStage:      null },
+          { label:          'Three bag samples and out',
+            outcome:        { sciencePoints: 40 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  dust_devil_corridor: {
+    startStage: 'deploy',
+    stages: {
+      deploy: {
+        title:       'Dust-Devil Corridor',
+        description: 'Fresh tracks. Devils pass this ridge several times per sol. You can set instruments and hide — or drop passive recorders.',
+        choices: [
+          { label:          'Plant sensors and wait for a contact',
+            nextStage:      'contact',
+            returnSolDelta: 1 },
+          { label:          'Drop passive recorders and leave',
+            skillCheck:     { role: 'pilot', successP: 0.75 },
+            successOutcome: { sciencePoints: 35 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage:      null }
+        ]
+      },
+      contact: {
+        title:       'Incoming Devil',
+        description: 'Funnel closing from the south-southwest. Twenty-second window. Real-time telemetry means holding position inside the tracks.',
+        choices: [
+          { label:          'Hold position through the contact',
+            skillCheck:     { role: 'pilot', successP: 0.75 },
+            successOutcome: { sciencePoints: 70 },
+            failOutcome:    { sciencePoints: 20, awayTeamDamage: 25 },
+            nextStage:      null },
+          { label:          'Retreat, rely on passive logs',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 35 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  // ---- ASTROBIOLOGY ----
+
+  methane_seep: {
+    startStage: 'sensor_setup',
+    stages: {
+      sensor_setup: {
+        title:       'Intermittent Plume',
+        description: 'The seep is fitful. A monitoring station catches a flare event if you are patient; a snapshot read gets you a decent sample now.',
+        choices: [
+          { label:          'Plant the monitoring station, wait',
+            nextStage:      'wait',
+            returnSolDelta: 1 },
+          { label:          'Snapshot read and move on',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 45 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage:      null }
+        ]
+      },
+      wait: {
+        title:       'Six Hours of Watching',
+        description: 'A flare at the four-hour mark. Plume is drifting downwind. You can chase for isotopic composition or call it here.',
+        choices: [
+          { label:          'Chase the plume downwind',
+            nextStage:      'downwind_trace',
+            returnSolDelta: 1 },
+          { label:          'Log the flare and pack up',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 60 },
+            failOutcome:    { sciencePoints: 25 },
+            nextStage:      null }
+        ]
+      },
+      downwind_trace: {
+        title:       'Downwind Trap',
+        description: 'The plume is thinning. Deploy the isotopic trap now and you get biogenic-versus-abiogenic signal. Miss and the plume is gone.',
+        choices: [
+          { label:          'Commit, deploy the trap',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 90 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 20 },
+            nextStage:      null },
+          { label:          'Partial grab sample, abort trap',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 45 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },
+
+  biosig_deposit: {
+    startStage: 'site_assay',
+    stages: {
+      site_assay: {
+        title:       'Ancient Lakebed',
+        description: 'The organics signal is right at noise. Methodical grid assay takes a full day; direct coring skips ahead but you guess at the hotspot.',
+        choices: [
+          { label:          'Run the full assay grid',
+            nextStage:      'grid',
+            returnSolDelta: 1 },
+          { label:          'Core three spots, skip the grid',
+            nextStage:      'preserve',
+            returnSolDelta: 1 }
+        ]
+      },
+      grid: {
+        title:       'Grid Complete',
+        description: 'Hotspot is in the northeast quadrant. Concentrated cores there are the high-value play; a light sampling walks away clean.',
+        choices: [
+          { label:          'Focus the northeast, deep cores',
+            nextStage: 'preserve' },
+          { label:          'Light sampling across the grid',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 60 },
+            failOutcome:    { sciencePoints: 25 },
+            nextStage:      null }
+        ]
+      },
+      preserve: {
+        title:       'Sample Preservation',
+        description: 'You have the material. Vacuum-sealing under full contamination protocol preserves volatile organics for Earth return. Standard prep is faster but loses the light molecules.',
+        choices: [
+          { label:          'Full vacuum protocol',
+            skillCheck:     { role: 'biologist', successP: 0.75 },
+            successOutcome: { sciencePoints: 95 },
+            failOutcome:    { sciencePoints: 35, awayTeamDamage: 25 },
+            nextStage:      null },
+          { label:          'Standard prep and bag it',
+            outcome:        { sciencePoints: 50 },
+            nextStage:      null }
+        ]
+      }
+    }
   }
+
 };

--- a/src/content/awayTeamChains.js
+++ b/src/content/awayTeamChains.js
@@ -1,0 +1,51 @@
+// Mars Trail — away-team chain content (issue #17).
+// Keyed by waypointId. Each chain matches the v0.6.0 multiStage shape
+// (stages dict, startStage, per-choice outcome | skillCheck | nextStage)
+// with one extension: choices may carry `returnSolDelta` (number). When a
+// choice is taken inside an away-team camp, that delta is added to
+// state.awayTeam.returnSol — "go deeper" pushes the due-back sol out;
+// "bail early" pulls it in.
+//
+// Also supported: outcome.awayTeamDamage (number). Applies HP damage to
+// a random alive away-team member rather than the full crew.
+//
+// The final stage's skill check is where the advanced fact reward is
+// gated — earlier stages may grant partial SCI, but factsLearned only
+// grows on a terminal-stage success.
+
+export const AWAY_TEAM_CHAINS = {
+  olivine_outcrop: {
+    startStage: 'approach',
+    stages: {
+      approach: {
+        title:       'Olivine Outcrop — On Foot',
+        description: 'The cliff face drops fifteen meters to a fresh volcanic scar. Rappel gear is in the kit; ridgeline scan is the safe read.',
+        choices: [
+          { label:          'Rappel to the fresh face (deeper sample)',
+            nextStage:      'deep_sample',
+            returnSolDelta: 1 },
+          { label:          'Scan the face from the ridgeline',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 40 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage:      null }
+        ]
+      },
+      deep_sample: {
+        title:       'Down the Face',
+        description: 'You are halfway down the scar, rope anchored above. Fresh olivine vein exposed at eye level — drillable if you commit.',
+        choices: [
+          { label:          'Drill the exposed vein',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 80 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 20 },
+            nextStage:      null },
+          { label:          'Bag a chip sample and climb out',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 35 },
+            nextStage:      null }
+        ]
+      }
+    }
+  }
+};

--- a/src/content/medicalEmergency.js
+++ b/src/content/medicalEmergency.js
@@ -1,0 +1,50 @@
+// Mars Trail — medical emergency event (issue #6).
+// A 3-stage multi-stage event: diagnose → treat → (only if patient dies) dispose.
+//
+// Stage logic is authored here as data, but resolution runs through
+// src/systems/medicalEmergency.js (not the generic applyStageChoice) so
+// that outcomes can target the specific patient crew member, route
+// conditionally on death, and handle addCorpse for the "keep body" path.
+//
+// Patient is picked at event-fire time by pickPatient(state):
+// first alive non-medic crew member. If only the medic is alive,
+// the medic is the patient and selfTreat=true (skill-check penalty).
+
+export const MEDICAL_EMERGENCY = {
+  id:             'medical_emergency',
+  multiStage:     true,
+  customResolver: 'medical',   // opens via beginMedicalEmergency, resolves via resolveMedicalStage
+  weight:         3,
+  severity:       'severe',
+  oneShot:        true,
+  startStage:     'diagnose',
+  stages: {
+    diagnose: {
+      title:       'Medical Emergency',
+      description: 'Vitals are dropping. Pain localized. You need a diagnosis — fast.',
+      choices: [
+        { label: 'Consult the medic',           key: 'medic'  },
+        { label: 'Query Earth (comms delay)',   key: 'earth'  },
+        { label: 'Dose from med kit and hope',  key: 'hope'   }
+      ]
+    },
+    treat: {
+      title:       'Treatment Window',
+      description: 'Diagnosis in hand, or close to it. Pick the treatment plan.',
+      choices: [
+        { label: 'Surgery in the rover',         key: 'surgery' },
+        { label: 'Stabilize and push to landmark', key: 'push'   },
+        { label: 'Induced coma — buy time',      key: 'coma'    }
+      ]
+    },
+    dispose: {
+      title:       'Body Disposal',
+      description: 'The patient did not make it. The body is 180 LB of suited mass. Call it.',
+      choices: [
+        { label: 'Bury at next landmark',  key: 'bury'     },
+        { label: 'Keep the body with us',  key: 'keep'     },
+        { label: 'Jettison the suit now',  key: 'jettison' }
+      ]
+    }
+  }
+};

--- a/src/content/multiStageEvents.js
+++ b/src/content/multiStageEvents.js
@@ -1,7 +1,13 @@
 // Mars Trail — multi-stage event pool (issue #17 prerequisite).
 // Events with branching stages. Engine in src/systems/multiStage.js.
+//
+// NOTE: Some entries (e.g. medical_emergency) use custom resolvers
+// instead of applyStageChoice — routed via activeModal.payload.source.
+
+import { MEDICAL_EMERGENCY } from './medicalEmergency.js';
 
 export const MULTI_STAGE_EVENTS = [
+  MEDICAL_EMERGENCY,
   {
     id:         'drill_bit_seized',
     multiStage: true,

--- a/src/main.js
+++ b/src/main.js
@@ -6,8 +6,10 @@ import { render } from './render.js';
 import { advanceSol, setPace, setRations, repairBattery, cleanPanels } from './systems/travel.js';
 import { applyEventChoice } from './systems/events.js';
 import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, showTitleLayer, dimTitleStart, hideTitleLayer, showEndOfRunModal, closeModal, showWaypointOfferModal, showWaypointRewardModal, showMultiStageModal } from './ui/modals.js';
-import { acceptWaypoint, declineWaypoint } from './systems/waypoints.js';
+import { declineWaypoint } from './systems/waypoints.js';
 import { applyStageChoice } from './systems/multiStage.js';
+import { resolveAwayTeamStage } from './systems/awayTeam.js';
+import { resolveMedicalStage } from './systems/medicalEmergency.js';
 import { WAYPOINTS } from './content/waypoints.js';
 import { makeLandmarkEncounter } from './content/landmarks.js';
 import './ui/codex.js';   // registers global click handler for codex terms
@@ -159,13 +161,11 @@ function renderAll() {
   }
 
   if (modal.type === 'waypoint_offer') {
-    const { waypoint, segmentIdx } = modal.payload;
+    const { waypoint } = modal.payload;
     showWaypointOfferModal(waypoint, state, {
       onAccept: () => {
-        state = acceptWaypoint(state, segmentIdx);
-        // Chain: proceed to the landmark encounter for the CURRENT arrival.
-        const arrivedId = state.route[state.currentLandmarkIndex];
-        state = { ...state, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
+        // Open the away-team picker (UI renderer lands in Task 5).
+        state = { ...state, activeModal: { type: 'away_team_picker', payload: { waypoint } } };
         renderAll();
       },
       onDecline: () => {
@@ -178,24 +178,30 @@ function renderAll() {
     return;
   }
 
-  if (modal.type === 'waypoint_reward') {
-    showWaypointRewardModal(modal.payload, () => {
-      // Chain: if the next segment also has a waypoint offer, fire it; else landmark encounter.
-      const segmentWp = state.waypoints.find(w => w.segmentIdx === state.currentLandmarkIndex);
-      if (segmentWp && !state.firedWaypoints.includes(segmentWp.waypointId)) {
-        const nextWaypoint = WAYPOINTS.find(w => w.id === segmentWp.waypointId);
-        state = { ...state, activeModal: { type: 'waypoint_offer', payload: { waypoint: nextWaypoint, segmentIdx: state.currentLandmarkIndex } } };
-      } else {
-        const arrivedId = state.route[state.currentLandmarkIndex];
-        state = { ...state, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
-      }
-      renderAll();
-    });
-    return;
-  }
-
   if (modal.type === 'multi_stage') {
-    const { event, stageId } = modal.payload;
+    const { event, stageId, source } = modal.payload;
+
+    // Medical emergency uses a custom resolver (patient-targeted damage,
+    // conditional Stage 3, addCorpse). No generic outcome modal — the
+    // resolver emits log lines directly.
+    if (source === 'medical') {
+      showMultiStageModal(event, stageId, (choiceIdx) => {
+        state = resolveMedicalStage(state, choiceIdx);
+        renderAll();
+      });
+      return;
+    }
+
+    // Away-team chain uses its own resolver so rewards accumulate on
+    // state.awayTeam.accumulated until reunion. No mid-chain outcome modal.
+    if (source === 'awayTeam') {
+      showMultiStageModal(event, stageId, (choiceIdx) => {
+        state = resolveAwayTeamStage(state, choiceIdx);
+        renderAll();
+      });
+      return;
+    }
+
     showMultiStageModal(event, stageId, (choiceIdx) => {
       const { state: next, nextStage, skillResult, damageTarget, applied } = applyStageChoice(state, event, stageId, choiceIdx);
       state = next;

--- a/src/main.js
+++ b/src/main.js
@@ -5,10 +5,10 @@ import { createInitialState, CARGO_BUDGET, PART_TYPES } from './state.js';
 import { render } from './render.js';
 import { advanceSol, setPace, setRations, repairBattery, cleanPanels } from './systems/travel.js';
 import { applyEventChoice } from './systems/events.js';
-import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, showTitleLayer, dimTitleStart, hideTitleLayer, showEndOfRunModal, closeModal, showWaypointOfferModal, showWaypointRewardModal, showMultiStageModal } from './ui/modals.js';
+import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, showTitleLayer, dimTitleStart, hideTitleLayer, showEndOfRunModal, closeModal, showWaypointOfferModal, showMultiStageModal, showAwayTeamPickerModal, showAwayTeamReunionModal } from './ui/modals.js';
 import { declineWaypoint } from './systems/waypoints.js';
 import { applyStageChoice } from './systems/multiStage.js';
-import { resolveAwayTeamStage } from './systems/awayTeam.js';
+import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from './systems/awayTeam.js';
 import { resolveMedicalStage } from './systems/medicalEmergency.js';
 import { WAYPOINTS } from './content/waypoints.js';
 import { makeLandmarkEncounter } from './content/landmarks.js';
@@ -164,7 +164,6 @@ function renderAll() {
     const { waypoint } = modal.payload;
     showWaypointOfferModal(waypoint, state, {
       onAccept: () => {
-        // Open the away-team picker (UI renderer lands in Task 5).
         state = { ...state, activeModal: { type: 'away_team_picker', payload: { waypoint } } };
         renderAll();
       },
@@ -174,6 +173,36 @@ function renderAll() {
         state = { ...state, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
         renderAll();
       }
+    });
+    return;
+  }
+
+  if (modal.type === 'away_team_picker') {
+    const { waypoint } = modal.payload;
+    showAwayTeamPickerModal(state, waypoint, {
+      onConfirm: (crewIds) => {
+        state = acceptAwayTeam(state, waypoint.id, crewIds);
+        state = { ...state, firedWaypoints: [...state.firedWaypoints, waypoint.id] };
+        // Fire the landmark encounter for the turn-off. The rover is parked
+        // at this landmark while the away team is out.
+        const arrivedId = state.route[state.currentLandmarkIndex];
+        state = { ...state, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
+        renderAll();
+      },
+      onCancel: () => {
+        state = declineWaypoint(state, waypoint.id);
+        const arrivedId = state.route[state.currentLandmarkIndex];
+        state = { ...state, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
+        renderAll();
+      }
+    });
+    return;
+  }
+
+  if (modal.type === 'away_team_reunion') {
+    showAwayTeamReunionModal(modal.payload, (corpseChoices) => {
+      state = finalizeReunion(state, corpseChoices);
+      renderAll();
     });
     return;
   }

--- a/src/render.js
+++ b/src/render.js
@@ -37,6 +37,21 @@ function renderTopbar(state) {
 
   const sci = document.getElementById('sci-counter');
   if (sci) sci.textContent = `SCI ${state.sciencePoints || 0}`;
+
+  // DUE BACK chip — visible only while an away team is out.
+  let chip = document.getElementById('away-due-chip');
+  if (state.awayTeam) {
+    if (!chip) {
+      chip = document.createElement('span');
+      chip.id = 'away-due-chip';
+      chip.className = 'away-due-chip';
+      chip.title = 'Away team return sol';
+      $.clock.parentNode.insertBefore(chip, $.clock);
+    }
+    chip.textContent = `AWAY · DUE ${state.awayTeam.returnSol}`;
+  } else if (chip) {
+    chip.remove();
+  }
 }
 
 // ---------- Route ----------

--- a/src/render.js
+++ b/src/render.js
@@ -146,7 +146,7 @@ function renderMinimap(state) {
       const ox = (-dy / len) * 6;
       const oy = (dx / len) * 6;
       const stateClass = state.firedWaypoints.includes(waypoint.id) ? 'fired'
-        : state.pendingWaypoint?.id === waypoint.id ? 'accepted'
+        : state.awayTeam?.waypointId === waypoint.id ? 'accepted'
         : 'pending';
       const r = stateClass === 'accepted' ? 3.5 : 2.8;
       const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');

--- a/src/state.js
+++ b/src/state.js
@@ -88,6 +88,7 @@ export function createInitialState() {
     waypoints:       [],    // [{ waypointId, segmentIdx }] — rolled at run start
     pendingWaypoint: null,  // full waypoint object while detour is in progress
     firedWaypoints:  [],    // ids already resolved or declined
+    corpses:         [],    // [{ crewId, weightLbs }] — bodies carried, count toward cargoPounds
     log: [
       { sol: 1, text: 'Mission begins. Crew nominal. Departing Jezero Crater.' }
     ],

--- a/src/state.js
+++ b/src/state.js
@@ -86,8 +86,8 @@ export function createInitialState() {
     factsLearned: [],
     firedEvents: [],   // IDs of one-shot events already triggered this run
     waypoints:       [],    // [{ waypointId, segmentIdx }] — rolled at run start
-    pendingWaypoint: null,  // full waypoint object while detour is in progress
     firedWaypoints:  [],    // ids already resolved or declined
+    awayTeam:        null,  // see src/systems/awayTeam.js for shape
     corpses:         [],    // [{ crewId, weightLbs }] — bodies carried, count toward cargoPounds
     log: [
       { sol: 1, text: 'Mission begins. Crew nominal. Departing Jezero Crater.' }

--- a/src/systems/awayTeam.js
+++ b/src/systems/awayTeam.js
@@ -1,0 +1,256 @@
+// Mars Trail — away-team systems (issue #17).
+// Pure. Manages the lifecycle of a detour-as-away-mission: dispatch,
+// per-sol stage advancement, stage resolution (with returnSolDelta +
+// awayTeamDamage), and reunion packaging. Rewards accumulate in
+// state.awayTeam.accumulated and only land on the rover when the
+// reunion modal is acknowledged via finalizeReunion.
+
+import { WAYPOINTS } from '../content/waypoints.js';
+import { AWAY_TEAM_CHAINS } from '../content/awayTeamChains.js';
+import {
+  ADVANCED_GEOLOGY_FACTS,
+  ADVANCED_WATER_FACTS,
+  ADVANCED_ATMOSPHERE_FACTS,
+  ADVANCED_ASTROBIOLOGY_FACTS
+} from '../content/advancedFacts.js';
+import { applyOutcome } from './events.js';
+import { applyDamage } from './crew.js';
+import { addCorpse } from './corpse.js';
+
+export const MIN_CREW_FOR_DIVERT = 3;
+
+const ADVANCED_POOLS = {
+  GEOLOGY:      ADVANCED_GEOLOGY_FACTS,
+  WATER:        ADVANCED_WATER_FACTS,
+  ATMOSPHERE:   ADVANCED_ATMOSPHERE_FACTS,
+  ASTROBIOLOGY: ADVANCED_ASTROBIOLOGY_FACTS
+};
+
+function emptyAccumulated() {
+  return { sciencePoints: 0, facts: [] };
+}
+
+// ---- Accept ----
+// Dispatch an away team. Sets state.awayTeam; does NOT touch kmToNextLandmark
+// (rover camps at the turn-off until the team returns).
+export function acceptAwayTeam(state, waypointId, crewIds) {
+  const aliveCount = state.crew.filter(c => c.alive).length;
+  if (aliveCount < MIN_CREW_FOR_DIVERT) {
+    return {
+      ...state,
+      log: [...state.log, { sol: state.sol, text: 'Too few crew to dispatch an away team. Divert cancelled.' }]
+    };
+  }
+  const waypoint = WAYPOINTS.find(w => w.id === waypointId);
+  const chain = AWAY_TEAM_CHAINS[waypointId];
+  if (!waypoint || !chain) return state;
+
+  const validIds = crewIds.filter(id => state.crew.some(c => c.id === id && c.alive));
+  if (validIds.length === 0) return state;
+  if (validIds.length > aliveCount - 1) return state;   // keep ≥1 on rover
+
+  const returnSol = state.sol + waypoint.detourSols;
+  return {
+    ...state,
+    awayTeam: {
+      waypointId,
+      crewIds:      [...validIds],
+      departSol:    state.sol,
+      returnSol,
+      currentStage: chain.startStage,
+      accumulated:  emptyAccumulated(),
+      deaths:       []
+    },
+    log: [
+      ...state.log,
+      { sol: state.sol, text: `Away team dispatched to ${waypoint.name}. Due back sol ${returnSol}.` }
+    ]
+  };
+}
+
+// ---- Advance (one camp sol) ----
+// Called from advanceSol when state.awayTeam is set. Either fires the next
+// stage modal, triggers return, or emits an idle-camp log line.
+export function advanceAwayTeam(state) {
+  if (!state.awayTeam) return state;
+  const { waypointId, currentStage, returnSol, departSol } = state.awayTeam;
+
+  if (currentStage !== null) {
+    const chain = AWAY_TEAM_CHAINS[waypointId];
+    const event = {
+      id:         `away:${waypointId}`,
+      multiStage: true,
+      stages:     chain.stages,
+      startStage: chain.startStage
+    };
+    return {
+      ...state,
+      activeModal: {
+        type:    'multi_stage',
+        payload: { event, stageId: currentStage, source: 'awayTeam' }
+      }
+    };
+  }
+
+  if (state.sol >= returnSol) {
+    return returnAwayTeam(state);
+  }
+
+  return {
+    ...state,
+    log: [
+      ...state.log,
+      { sol: state.sol, text: `Camp day ${state.sol - departSol + 1}. Away team still out.` }
+    ]
+  };
+}
+
+// ---- Resolve a stage choice ----
+// Mirrors multiStage.applyStageChoice but routes rewards into
+// state.awayTeam.accumulated (deferred) and restricts skill-check +
+// awayTeamDamage targeting to the away-team roster.
+export function resolveAwayTeamStage(state, choiceIdx) {
+  if (!state.awayTeam) return state;
+  const { waypointId, currentStage, crewIds } = state.awayTeam;
+  const chain  = AWAY_TEAM_CHAINS[waypointId];
+  const stage  = chain?.stages[currentStage];
+  const choice = stage?.choices[choiceIdx];
+  if (!choice) return state;
+
+  // ---- Skill check (specialist must be ON the away team) ----
+  let outcome = choice.outcome;
+  let skillSuccess = null;
+  if (choice.skillCheck) {
+    const { role, successP } = choice.skillCheck;
+    const awayCrew = state.crew.filter(c => crewIds.includes(c.id) && c.alive);
+    const specialistAlive = awayCrew.some(c => c.role === role);
+    const baseP  = specialistAlive ? successP : Math.max(0.2, successP - 0.4);
+    const bonus  = state.careerBonuses?.skillBonus || 0;
+    const effP   = Math.min(0.95, baseP + bonus);
+    skillSuccess = Math.random() < effP;
+    outcome = skillSuccess ? choice.successOutcome : choice.failOutcome;
+  }
+
+  // ---- Split reward-only fields from outcome fields that hit rover state ----
+  const {
+    sciencePoints = 0,
+    awayTeamDamage = 0,
+    ...restOutcome
+  } = outcome || {};
+  const hasRest = Object.keys(restOutcome).length > 0;
+
+  let s = hasRest ? applyOutcome(state, restOutcome).state : state;
+
+  // ---- Away-team damage (random alive member on the team) ----
+  let deaths = [...s.awayTeam.deaths];
+  if (awayTeamDamage > 0) {
+    const alive = s.crew.filter(c => crewIds.includes(c.id) && c.alive);
+    if (alive.length > 0) {
+      const victim = alive[Math.floor(Math.random() * alive.length)];
+      const res = applyDamage(s, victim.id, awayTeamDamage, 'away-team hazard');
+      s = res.state;
+      if (res.died) deaths.push(victim.id);
+    }
+  }
+
+  // ---- Accumulate deferred rewards ----
+  let accumulated = {
+    ...s.awayTeam.accumulated,
+    sciencePoints: s.awayTeam.accumulated.sciencePoints + sciencePoints
+  };
+
+  // Advanced fact awarded only on success of a terminal skill check.
+  const isTerminal = (choice.nextStage ?? null) === null;
+  if (isTerminal && skillSuccess === true) {
+    const waypoint = WAYPOINTS.find(w => w.id === waypointId);
+    const pool = ADVANCED_POOLS[waypoint?.factPool] || [];
+    if (pool.length) {
+      const fact = pool[Math.floor(Math.random() * pool.length)];
+      if (!s.factsLearned.includes(fact) && !accumulated.facts.includes(fact)) {
+        accumulated = { ...accumulated, facts: [...accumulated.facts, fact] };
+      }
+    }
+  }
+
+  const newReturnSol = s.awayTeam.returnSol + (choice.returnSolDelta || 0);
+  const newAwayTeam = {
+    ...s.awayTeam,
+    currentStage: choice.nextStage ?? null,
+    accumulated,
+    deaths,
+    returnSol:    newReturnSol
+  };
+
+  s = { ...s, awayTeam: newAwayTeam, activeModal: null };
+
+  // All away-team crew dead → skip the rest of the chain, jump to reunion.
+  const anyAlive = s.crew.some(c => crewIds.includes(c.id) && c.alive);
+  if (!anyAlive) return returnAwayTeam(s);
+
+  return s;
+}
+
+// ---- Return ----
+// Packages the reunion modal. Does not yet apply rewards or awayTeam=null —
+// that happens in finalizeReunion when the player acknowledges the modal.
+export function returnAwayTeam(state) {
+  if (!state.awayTeam) return state;
+  const { waypointId, crewIds, accumulated, deaths } = state.awayTeam;
+  const waypoint = WAYPOINTS.find(w => w.id === waypointId);
+
+  const survivors = state.crew
+    .filter(c => crewIds.includes(c.id) && c.alive)
+    .map(c => ({ id: c.id, name: c.name, role: c.role, health: c.health }));
+  const deadCrew = state.crew
+    .filter(c => deaths.includes(c.id))
+    .map(c => ({ id: c.id, name: c.name, role: c.role }));
+
+  const summary = deadCrew.length
+    ? `Away team reunited: ${survivors.length} back, ${deadCrew.length} lost.`
+    : `Away team reunited: ${survivors.length} back, all present.`;
+
+  return {
+    ...state,
+    log: [...state.log, { sol: state.sol, text: summary }],
+    activeModal: {
+      type: 'away_team_reunion',
+      payload: {
+        waypoint,
+        survivors,
+        deaths: deadCrew,
+        sciencePoints: accumulated.sciencePoints,
+        facts: [...accumulated.facts]
+      }
+    }
+  };
+}
+
+// ---- Finalize (reunion modal acknowledged) ----
+// corpseChoices: { [crewId]: 'bring' | 'leave' } — decides whether each
+// fallen crew member's body is carried back (addCorpse) or left at the site.
+export function finalizeReunion(state, corpseChoices = {}) {
+  if (!state.awayTeam) return state;
+  const { accumulated, deaths } = state.awayTeam;
+
+  let s = {
+    ...state,
+    sciencePoints: state.sciencePoints + accumulated.sciencePoints
+  };
+  const newFacts = accumulated.facts.filter(f => !s.factsLearned.includes(f));
+  if (newFacts.length) s = { ...s, factsLearned: [...s.factsLearned, ...newFacts] };
+
+  for (const crewId of deaths) {
+    if (corpseChoices[crewId] === 'bring') s = addCorpse(s, crewId);
+  }
+
+  const debriefText = accumulated.sciencePoints > 0
+    ? `Away-team debrief: +${accumulated.sciencePoints} SCI recovered.`
+    : 'Away-team debrief: no science recovered.';
+
+  return {
+    ...s,
+    awayTeam:    null,
+    activeModal: null,
+    log: [...s.log, { sol: s.sol, text: debriefText }]
+  };
+}

--- a/src/systems/corpse.js
+++ b/src/systems/corpse.js
@@ -1,0 +1,14 @@
+// Mars Trail — corpse accounting.
+// Shared by away-team reunion (#17) and medical-emergency disposal (#6).
+// Pure. State writes go through addCorpse; reads via corpseWeight.
+
+export const DEFAULT_CORPSE_LBS = 180;
+
+export function addCorpse(state, crewId, weightLbs = DEFAULT_CORPSE_LBS) {
+  if (state.corpses.some(c => c.crewId === crewId)) return state;
+  return { ...state, corpses: [...state.corpses, { crewId, weightLbs }] };
+}
+
+export function corpseWeight(state) {
+  return state.corpses.reduce((n, c) => n + c.weightLbs, 0);
+}

--- a/src/systems/medicalEmergency.js
+++ b/src/systems/medicalEmergency.js
@@ -1,0 +1,245 @@
+// Mars Trail — medical emergency resolver (issue #6).
+// Pure. Custom resolver for the medical_emergency event because the
+// generic applyStageChoice can't target a specific crew member by ID
+// nor conditionally route Stage 3 on the patient's death. Event data
+// lives in src/content/medicalEmergency.js.
+//
+// Flow: pickPatient at fire time → diagnose → treat → (if died) dispose.
+
+import { MEDICAL_EMERGENCY } from '../content/medicalEmergency.js';
+import { applyOutcome } from './events.js';
+import { deriveStatus } from './crew.js';
+import { addCorpse } from './corpse.js';
+
+export const MEDICAL_EMERGENCY_ID = MEDICAL_EMERGENCY.id;
+const MEDIC_FLAVOR_LINE = 'Well, there goes paradise.';
+
+// ---- Patient selection ----
+// First alive non-medic. If only the medic is alive, medic is the patient
+// (selfTreat=true → any subsequent medic skill checks take a -20pp penalty).
+export function pickPatient(state) {
+  const alive = state.crew.filter(c => c.alive);
+  if (alive.length === 0) return null;
+  const nonMedic = alive.filter(c => c.role !== 'medic');
+  if (nonMedic.length > 0) {
+    const pick = nonMedic[Math.floor(Math.random() * nonMedic.length)];
+    return { id: pick.id, selfTreat: false };
+  }
+  return { id: alive[0].id, selfTreat: true };
+}
+
+// ---- Begin the event (called when rolled) ----
+// Sets firedEvents + opens the first stage modal with the patient context.
+export function beginMedicalEmergency(state) {
+  const patient = pickPatient(state);
+  if (!patient) return state;
+  return {
+    ...state,
+    firedEvents: [...state.firedEvents, MEDICAL_EMERGENCY_ID],
+    activeModal: {
+      type: 'multi_stage',
+      payload: {
+        event:    MEDICAL_EMERGENCY,
+        stageId:  MEDICAL_EMERGENCY.startStage,
+        source:   'medical',
+        context:  { patientId: patient.id, selfTreat: patient.selfTreat }
+      }
+    }
+  };
+}
+
+// ---- Helpers ----
+
+function getCrew(state, id) {
+  return state.crew.find(c => c.id === id);
+}
+
+function damagePatient(state, patientId, amount, cause) {
+  const s = {
+    ...state,
+    crew: state.crew.map(c => {
+      if (c.id !== patientId || !c.alive) return c;
+      const newHealth = Math.max(0, c.health - amount);
+      const newStatus = deriveStatus(newHealth);
+      const alive = newStatus !== 'dead';
+      return { ...c, health: newHealth, status: newStatus, alive };
+    }),
+    log: [...state.log]
+  };
+  const after = getCrew(s, patientId);
+  if (after && !after.alive && getCrew(state, patientId)?.alive) {
+    s.log.push({
+      sol: s.sol,
+      text: `${after.name} (${after.role.toUpperCase()}) succumbed to ${cause || 'medical complications'}.`
+    });
+  }
+  return s;
+}
+
+function medicAliveExcluding(state, excludeId) {
+  return state.crew.some(c => c.role === 'medic' && c.alive && c.id !== excludeId);
+}
+
+function rollSkill(state, successP, selfTreat) {
+  const base = selfTreat ? Math.max(0.2, successP - 0.2) : successP;
+  const bonus = state.careerBonuses?.skillBonus || 0;
+  const effP = Math.min(0.95, base + bonus);
+  return Math.random() < effP;
+}
+
+function closeModal(state) {
+  return { ...state, activeModal: null };
+}
+
+function nextStage(state, stageId, context) {
+  return {
+    ...state,
+    activeModal: {
+      type: 'multi_stage',
+      payload: { event: MEDICAL_EMERGENCY, stageId, source: 'medical', context }
+    }
+  };
+}
+
+// ---- Stage: diagnose ----
+
+function resolveDiagnose(state, choiceKey, context) {
+  const { patientId, selfTreat } = context;
+  const patient = getCrew(state, patientId);
+  if (!patient) return closeModal(state);
+
+  if (choiceKey === 'medic') {
+    const success = rollSkill(state, 0.75, selfTreat);
+    let s = state;
+    if (!success) {
+      s = damagePatient(s, patientId, 10, 'misdiagnosis');
+    }
+    s = { ...s, log: [...s.log, { sol: s.sol, text: success
+      ? `Medic confident on diagnosis for ${patient.name}.`
+      : `Medic exam inconclusive. ${patient.name} worsens.` }] };
+    return nextStage(s, 'treat', context);
+  }
+
+  if (choiceKey === 'earth') {
+    let s = applyOutcome(state, { oxygen: -3, water: -3 }).state;
+    s = damagePatient(s, patientId, 20, 'delayed diagnosis');
+    s = { ...s, log: [...s.log, { sol: s.sol, text: `Earth comms lag cost 20 minutes. ${patient.name} worsens.` }] };
+    return nextStage(s, 'treat', context);
+  }
+
+  if (choiceKey === 'hope') {
+    const stabilized = Math.random() < 0.4;
+    if (stabilized) {
+      const s = { ...state, log: [...state.log, { sol: state.sol, text: `Med-kit dose held. ${patient.name} is stable — for now.` }] };
+      return closeModal(s);
+    }
+    let s = damagePatient(state, patientId, 30, 'adverse reaction');
+    s = { ...s, log: [...s.log, { sol: s.sol, text: `Dose went wrong. ${patient.name} is in worse shape.` }] };
+    return nextStage(s, 'treat', context);
+  }
+
+  return closeModal(state);
+}
+
+// ---- Stage: treat ----
+
+function resolveTreat(state, choiceKey, context) {
+  const { patientId, selfTreat } = context;
+  const patient = getCrew(state, patientId);
+  if (!patient) return closeModal(state);
+
+  if (choiceKey === 'surgery') {
+    let s = applyOutcome(state, { eva: -1, power: -15 }).state;
+    const success = rollSkill(s, 0.65, selfTreat);
+    if (success) {
+      s = {
+        ...s,
+        crew: s.crew.map(c => c.id === patientId
+          ? { ...c, health: Math.max(60, c.health), status: deriveStatus(Math.max(60, c.health)) }
+          : c),
+        log: [...s.log, { sol: s.sol, text: `Surgery successful. ${patient.name} is stable.` }]
+      };
+      return closeModal(s);
+    }
+    // Fail → patient dies.
+    const medicCanFlavor = !selfTreat && medicAliveExcluding(s, patientId);
+    s = damagePatient(s, patientId, 999, 'surgical complications');
+    if (medicCanFlavor) {
+      s = { ...s, log: [...s.log, { sol: s.sol, text: MEDIC_FLAVOR_LINE }] };
+    }
+    return nextStage(s, 'dispose', context);
+  }
+
+  if (choiceKey === 'push') {
+    let s = applyOutcome(state, { eva: -1 }).state;
+    s = damagePatient(s, patientId, 15, 'travel stress');
+    const died = !getCrew(s, patientId).alive;
+    s = { ...s, log: [...s.log, { sol: s.sol, text: died
+      ? `${patient.name} did not survive the push.`
+      : `Stabilized for travel. ${patient.name} is hanging on.` }] };
+    return died ? nextStage(s, 'dispose', context) : closeModal(s);
+  }
+
+  if (choiceKey === 'coma') {
+    let s = applyOutcome(state, { power: -15, oxygen: -10, eva: -1 }).state;
+    s = { ...s, log: [...s.log, { sol: s.sol, text: `${patient.name} placed in induced coma. Vitals held, resources burning.` }] };
+    return closeModal(s);
+  }
+
+  return closeModal(state);
+}
+
+// ---- Stage: dispose ----
+
+function resolveDispose(state, choiceKey, context) {
+  const { patientId } = context;
+  const patient = state.crew.find(c => c.id === patientId);
+  if (!patient) return closeModal(state);
+
+  if (choiceKey === 'bury') {
+    const s = applyOutcome(state, { sciencePoints: 10 }).state;
+    return {
+      ...s,
+      log: [...s.log, { sol: s.sol, text: `${patient.name} laid to rest. Burial site documented. +10 SCI.` }],
+      activeModal: null
+    };
+  }
+
+  if (choiceKey === 'keep') {
+    const s = addCorpse(state, patientId);
+    return {
+      ...s,
+      log: [...s.log, { sol: s.sol, text: `${patient.name}'s body secured. +180 LB cargo.` }],
+      activeModal: null
+    };
+  }
+
+  if (choiceKey === 'jettison') {
+    return {
+      ...state,
+      log: [...state.log, { sol: state.sol, text: `${patient.name}'s suit jettisoned. The crew will remember.` }],
+      activeModal: null
+    };
+  }
+
+  return closeModal(state);
+}
+
+// ---- Top-level resolver ----
+// state.activeModal must be { type: 'multi_stage', payload: { source: 'medical', ... } }.
+// choiceIdx is the index into the authored stage's choices.
+export function resolveMedicalStage(state, choiceIdx) {
+  const modal = state.activeModal;
+  if (modal?.type !== 'multi_stage' || modal.payload?.source !== 'medical') return state;
+
+  const { stageId, context } = modal.payload;
+  const stage = MEDICAL_EMERGENCY.stages[stageId];
+  const choice = stage?.choices[choiceIdx];
+  if (!choice) return state;
+
+  const key = choice.key;
+  if (stageId === 'diagnose') return resolveDiagnose(state, key, context);
+  if (stageId === 'treat')    return resolveTreat(state, key, context);
+  if (stageId === 'dispose')  return resolveDispose(state, key, context);
+  return state;
+}

--- a/src/systems/multiStage.js
+++ b/src/systems/multiStage.js
@@ -9,14 +9,15 @@ export const MULTI_STAGE_BASE_RATE = 0.08;
 
 // ---- Resolve a chosen option on a given stage ----
 //
-// Returns { state, nextStage, skillResult, damageTarget, applied }.
-// state:       new state after outcome application.
-// nextStage:   key of the next stage, or null to end the chain.
-// skillResult: present when the choice had a skillCheck.
+// Returns { state, nextStage, skillResult, damageTarget, applied, returnSolDelta }.
+// state:          new state after outcome application.
+// nextStage:      key of the next stage, or null to end the chain.
+// skillResult:    present when the choice had a skillCheck.
+// returnSolDelta: number to shift an away-team return sol by; 0 for non-away contexts.
 export function applyStageChoice(state, event, stageId, choiceIdx) {
   const stage  = event.stages[stageId];
   const choice = stage?.choices[choiceIdx];
-  if (!choice) return { state, nextStage: null, skillResult: null, damageTarget: null, applied: {} };
+  if (!choice) return { state, nextStage: null, skillResult: null, damageTarget: null, applied: {}, returnSolDelta: 0 };
 
   let outcome = choice.outcome;
   let skillResult = null;
@@ -38,7 +39,8 @@ export function applyStageChoice(state, event, stageId, choiceIdx) {
     nextStage: choice.nextStage ?? null,
     skillResult,
     damageTarget,
-    applied
+    applied,
+    returnSolDelta: choice.returnSolDelta ?? 0
   };
 }
 

--- a/src/systems/travel.js
+++ b/src/systems/travel.js
@@ -9,13 +9,14 @@ import { makeLandmarkEncounter } from '../content/landmarks.js';
 import { WAYPOINTS } from '../content/waypoints.js';
 import { resolveWaypoint } from './waypoints.js';
 
-// Total carried weight in pounds. Only persistent parts (MECH/EVA/CELL)
-// count — supplies are consumed at mission start.
-function cargoPounds(resources) {
+// Total carried weight in pounds. Persistent parts (MECH/EVA/CELL) plus any
+// corpses the crew is carrying back (180 LB each by default).
+function cargoPounds(state) {
   let lbs = 0;
   for (const t of PART_TYPES) {
-    if (!t.supply) lbs += (resources[t.key] || 0) * t.lbs;
+    if (!t.supply) lbs += (state.resources[t.key] || 0) * t.lbs;
   }
+  for (const c of state.corpses) lbs += c.weightLbs;
   return lbs;
 }
 
@@ -111,7 +112,7 @@ export function advanceSol(state, mode = 'travel') {
     const variance   = KM_VARIANCE[s.pace] * (pilotAlive ? 1 : NO_PILOT_VARIANCE_MULT);
     const jitter     = (Math.random() * 2 - 1) * variance;
     const pilotMult  = pilotAlive ? 1 + PILOT_KM_BONUS : 1;
-    const lbs        = cargoPounds(s.resources);
+    const lbs        = cargoPounds(s);
     const weightMult = Math.max(0.5, 1 - lbs * CARGO_WEIGHT_SPEED);
     const kmMult     = state.careerBonuses?.kmMult || 1;
     const km         = Math.max(0, baseKm * pilotMult * weightMult * kmMult * (1 + jitter));
@@ -130,7 +131,7 @@ export function advanceSol(state, mode = 'travel') {
 
   // Net power: RTG baseline + solar bonus (×panel efficiency) − travel − cargo weight.
   const panelMult   = s.resources.panels / 100;
-  const cargoWeight = cargoPounds(s.resources) * CARGO_WEIGHT_POWER;
+  const cargoWeight = cargoPounds(s) * CARGO_WEIGHT_POWER;
   let powerDelta    = RTG_RECHARGE_PER_SOL + (SOLAR_RECHARGE_PER_SOL * panelMult) - cargoWeight;
   if (mode === 'travel' && !powerDead) powerDelta -= POWER_PER_SOL[s.pace];
   if (mode === 'repair') {

--- a/src/systems/travel.js
+++ b/src/systems/travel.js
@@ -7,7 +7,8 @@ import { rollMultiStageEvent } from './multiStage.js';
 import { applyDamage, checkAllDead } from './crew.js';
 import { makeLandmarkEncounter } from '../content/landmarks.js';
 import { WAYPOINTS } from '../content/waypoints.js';
-import { resolveWaypoint } from './waypoints.js';
+import { advanceAwayTeam, MIN_CREW_FOR_DIVERT } from './awayTeam.js';
+import { beginMedicalEmergency } from './medicalEmergency.js';
 
 // Total carried weight in pounds. Persistent parts (MECH/EVA/CELL) plus any
 // corpses the crew is carrying back (180 LB each by default).
@@ -93,6 +94,12 @@ const NO_PILOT_VARIANCE_MULT = 1.5;   // wider day-to-day swings without a pilot
 export function advanceSol(state, mode = 'travel') {
   if (state.status !== 'active') return state;
 
+  // Camp mode: if an away team is out, the rover stays parked at the
+  // detour turn-off. Resources drain and crew damage accrue as usual,
+  // but km/travel/event-rolling are suppressed — the stage modal IS
+  // the event for that sol.
+  if (state.awayTeam && mode === 'travel') mode = 'camp';
+
   // Shallow clone the branches we'll mutate.
   let s = { ...state,
     resources: { ...state.resources },
@@ -104,7 +111,7 @@ export function advanceSol(state, mode = 'travel') {
   s.sol = state.sol + 1;
   const powerDead = s.resources.power === 0;
 
-  // ---- Travel (skipped on repair sols and when batteries are dead) ----
+  // ---- Travel (skipped on repair/clean/camp sols and when batteries are dead) ----
   let usableKm = 0;
   if (mode === 'travel' && !powerDead) {
     const pilotAlive = s.crew.some(c => c.role === 'pilot' && c.alive);
@@ -193,16 +200,13 @@ export function advanceSol(state, mode = 'travel') {
         // Set up the next segment's base distance.
         s.kmToNextLandmark = s.routeKm[s.currentLandmarkIndex];
 
-        // Step A — If a waypoint detour was in progress, fire the reward modal.
-        // It will chain to the offer (or the landmark encounter) when dismissed.
-        if (s.pendingWaypoint) {
-          s = resolveWaypoint(s);
-          return s;
-        }
-
-        // Step B — If this segment has a rolled waypoint not yet offered, open the offer.
+        // Step A — If this segment has a rolled waypoint not yet offered, open the
+        // offer (only when enough crew are alive to safely dispatch an away team).
+        const aliveCrewCount = s.crew.filter(c => c.alive).length;
         const segmentWp = s.waypoints.find(w => w.segmentIdx === s.currentLandmarkIndex);
-        if (segmentWp && !s.firedWaypoints.includes(segmentWp.waypointId)) {
+        if (segmentWp
+            && !s.firedWaypoints.includes(segmentWp.waypointId)
+            && aliveCrewCount >= MIN_CREW_FOR_DIVERT) {
           const waypoint = WAYPOINTS.find(w => w.id === segmentWp.waypointId);
           if (waypoint) {
             s.activeModal = {
@@ -213,7 +217,7 @@ export function advanceSol(state, mode = 'travel') {
           }
         }
 
-        // Step C — Normal landmark encounter.
+        // Step B — Normal landmark encounter.
         s.activeModal = { type: 'event', payload: makeLandmarkEncounter(arrivedId) };
       }
     } else {
@@ -244,10 +248,19 @@ export function advanceSol(state, mode = 'travel') {
     } else {
       const msEvent = rollMultiStageEvent(s);
       if (msEvent) {
-        s.activeModal = { type: 'multi_stage', payload: { event: msEvent, stageId: msEvent.startStage } };
-        if (msEvent.oneShot) s.firedEvents = [...s.firedEvents, msEvent.id];
+        if (msEvent.customResolver === 'medical') {
+          s = beginMedicalEmergency(s);
+        } else {
+          s.activeModal = { type: 'multi_stage', payload: { event: msEvent, stageId: msEvent.startStage } };
+          if (msEvent.oneShot) s.firedEvents = [...s.firedEvents, msEvent.id];
+        }
       }
     }
+  }
+
+  // ---- Camp-mode tick: advance the away-team lifecycle ----
+  if (mode === 'camp' && s.status === 'active') {
+    s = advanceAwayTeam(s);
   }
 
   return s;

--- a/src/systems/waypoints.js
+++ b/src/systems/waypoints.js
@@ -1,23 +1,14 @@
-// Mars Trail — science waypoints system (issue #7 part 1).
+// Mars Trail — science waypoints system (issue #7 part 1; rebuilt for #17 in v0.7.0).
 // Pure functions over state. No DOM, no localStorage, no side effects.
+//
+// The old "accept → detour km added → resolve at next landmark" flow was
+// removed in v0.7.0. Acceptance now dispatches to the away-team picker
+// (see src/systems/awayTeam.js). Declining and pre-roll of waypoints
+// still live here.
 
 import { WAYPOINTS } from '../content/waypoints.js';
-import {
-  ADVANCED_GEOLOGY_FACTS,
-  ADVANCED_WATER_FACTS,
-  ADVANCED_ATMOSPHERE_FACTS,
-  ADVANCED_ASTROBIOLOGY_FACTS
-} from '../content/advancedFacts.js';
 
 export const WAYPOINT_ROLL_PROB = 0.4;   // per non-final segment
-const SCIENCE_JITTER_FRAC = 0.15;
-
-const ADVANCED_POOLS = {
-  GEOLOGY:      ADVANCED_GEOLOGY_FACTS,
-  WATER:        ADVANCED_WATER_FACTS,
-  ATMOSPHERE:   ADVANCED_ATMOSPHERE_FACTS,
-  ASTROBIOLOGY: ADVANCED_ASTROBIOLOGY_FACTS
-};
 
 // ---- Run-start roll ----
 // Picks at most one waypoint per eligible segment (every segment except the
@@ -37,23 +28,6 @@ export function rollWaypoints(state) {
   return { ...state, waypoints };
 }
 
-// ---- Player accepts the offer ----
-export function acceptWaypoint(state, segmentIdx) {
-  const entry = state.waypoints.find(w => w.segmentIdx === segmentIdx);
-  if (!entry) return state;
-  const waypoint = WAYPOINTS.find(w => w.id === entry.waypointId);
-  if (!waypoint) return state;
-  return {
-    ...state,
-    pendingWaypoint: { ...waypoint },
-    kmToNextLandmark: state.kmToNextLandmark + waypoint.detourKm,
-    log: [
-      ...state.log,
-      { sol: state.sol, text: `Diverting to ${waypoint.name}. +${waypoint.detourKm} km added.` }
-    ]
-  };
-}
-
 // ---- Player declines the offer ----
 export function declineWaypoint(state, waypointId) {
   return {
@@ -63,68 +37,5 @@ export function declineWaypoint(state, waypointId) {
       ...state.log,
       { sol: state.sol, text: 'Detour declined. Pressing on.' }
     ]
-  };
-}
-
-// Specialist role by science category — who interprets the sample.
-const WAYPOINT_ROLE_BY_POOL = {
-  GEOLOGY:      'engineer',
-  WATER:        'biologist',
-  ATMOSPHERE:   'pilot',
-  ASTROBIOLOGY: 'biologist'
-};
-
-// Base skill-check probability: 75% with specialist alive, 35% without.
-// Career tier 3 (methodology) adds +skillBonus, capped at 95%.
-const WAYPOINT_BASE_P          = 0.75;
-const WAYPOINT_NO_SPECIALIST_P = 0.35;
-const WAYPOINT_MAX_P           = 0.95;
-const WAYPOINT_FAIL_SCI_FRAC   = 0.5;
-
-// ---- Detour reached: roll skill check, apply reward, queue reward modal ----
-export function resolveWaypoint(state) {
-  const w = state.pendingWaypoint;
-  if (!w) return state;
-
-  const role = WAYPOINT_ROLE_BY_POOL[w.factPool] || 'biologist';
-  const specialistAlive = state.crew.some(c => c.role === role && c.alive);
-  const baseP = specialistAlive ? WAYPOINT_BASE_P : WAYPOINT_NO_SPECIALIST_P;
-  const bonus = state.careerBonuses?.skillBonus || 0;
-  const effectiveP = Math.min(WAYPOINT_MAX_P, baseP + bonus);
-  const success = Math.random() < effectiveP;
-
-  const jitter = 1 + (Math.random() * 2 - 1) * SCIENCE_JITTER_FRAC;
-  const fullReward = Math.max(0, Math.round(w.sciencePoints * jitter));
-  const sciencePointsGained = success
-    ? fullReward
-    : Math.floor(fullReward * WAYPOINT_FAIL_SCI_FRAC);
-
-  // Advanced fact only on success.
-  const pool = ADVANCED_POOLS[w.factPool] || [];
-  const fact = (success && pool.length) ? pool[Math.floor(Math.random() * pool.length)] : '';
-
-  const alreadyLearned = fact && state.factsLearned.includes(fact);
-  const factsLearned = fact && !alreadyLearned
-    ? [...state.factsLearned, fact]
-    : state.factsLearned;
-
-  const logText = success
-    ? `${w.name}: ${role} analysis conclusive. +${sciencePointsGained} SCI.`
-    : `${w.name}: ${role} analysis inconclusive — data partial. +${sciencePointsGained} SCI.`;
-
-  return {
-    ...state,
-    sciencePoints: state.sciencePoints + sciencePointsGained,
-    factsLearned,
-    firedWaypoints: [...state.firedWaypoints, w.id],
-    pendingWaypoint: null,
-    log: [
-      ...state.log,
-      { sol: state.sol, text: logText }
-    ],
-    activeModal: {
-      type: 'waypoint_reward',
-      payload: { waypoint: w, sciencePointsGained, fact, success, role, specialistAlive }
-    }
   };
 }

--- a/src/systems/waypoints.js
+++ b/src/systems/waypoints.js
@@ -11,13 +11,14 @@ import { WAYPOINTS } from '../content/waypoints.js';
 export const WAYPOINT_ROLL_PROB = 0.4;   // per non-final segment
 
 // ---- Run-start roll ----
-// Picks at most one waypoint per eligible segment (every segment except the
-// final one, which lands at the destination and has no landmark encounter).
+// Picks at most one waypoint per eligible segment. segmentIdx matches the
+// currentLandmarkIndex at which the offer fires (arrival at landmark N →
+// offer segment N waypoint). Skip 0 (origin — never "arrived at") and the
+// final landmark (mission complete — no encounter). Issue #22.
 export function rollWaypoints(state) {
-  const eligibleSegments = state.route.length - 2;  // e.g. 8 landmarks → 6 eligible
   const used = new Set();
   const waypoints = [];
-  for (let segmentIdx = 0; segmentIdx < eligibleSegments; segmentIdx++) {
+  for (let segmentIdx = 1; segmentIdx < state.route.length - 1; segmentIdx++) {
     if (Math.random() >= WAYPOINT_ROLL_PROB) continue;
     const candidates = WAYPOINTS.filter(w => !used.has(w.id));
     if (candidates.length === 0) break;

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -482,48 +482,6 @@ export function showWaypointOfferModal(waypoint, state, { onAccept, onDecline })
   r.querySelector('#wp-decline').addEventListener('click', onDecline);
 }
 
-// ---- Waypoint reward modal (issue #7 part 1) ----
-
-export function showWaypointRewardModal(payload, onContinue) {
-  const r = root();
-  if (!r) return;
-
-  const { waypoint, sciencePointsGained, fact, success, role, specialistAlive } = payload;
-  const imgBlock = waypoint.image
-    ? `<img class="modal-image" src="${waypoint.image}" alt="" />`
-    : '';
-  const factBlock = fact
-    ? `
-      <div class="waypoint-fact">
-        <div class="waypoint-fact-label">⎋ ADVANCED DATA</div>
-        <p>${linkifyCodex(escapeHtml(fact))}</p>
-      </div>`
-    : '';
-
-  const severityLabel = success ? '⎋ DATA RECOVERED' : '⚠ PARTIAL DATA';
-  const roleLabel = role ? role.toUpperCase() : '';
-  const specialistNote = role && !specialistAlive ? ` (no ${role} aboard — improvised).` : '';
-  const description = success
-    ? `${roleLabel} analysis conclusive.${specialistNote} Sample archived.`
-    : `${roleLabel} analysis inconclusive.${specialistNote} Only partial data recovered.`;
-  const sciLabel = success ? `+${sciencePointsGained} SCI` : `+${sciencePointsGained} SCI (partial)`;
-
-  r.innerHTML = `
-    <div class="modal-backdrop">
-      <div class="modal-panel modal-waypoint-reward ${success ? 'wp-success' : 'wp-partial'}" role="dialog" aria-modal="true">
-        <div class="modal-severity severity-waypoint">${severityLabel}</div>
-        <h2 class="modal-title">${escapeHtml(waypoint.name)}</h2>
-        ${imgBlock}
-        <p class="modal-description">${escapeHtml(description)}</p>
-        <div class="waypoint-sci">${sciLabel}</div>
-        ${factBlock}
-        <button class="modal-continue primary" id="wp-continue" type="button">CONTINUE →</button>
-      </div>
-    </div>
-  `;
-  r.querySelector('#wp-continue').addEventListener('click', onContinue);
-}
-
 // ---- Multi-stage event modal (issue #17 prerequisite) ----
 
 export function showMultiStageModal(event, stageId, onChoose) {
@@ -559,6 +517,146 @@ export function showMultiStageModal(event, stageId, onChoose) {
 
   r.querySelectorAll('[data-idx]').forEach(btn => {
     btn.addEventListener('click', () => onChoose(Number(btn.dataset.idx)));
+  });
+}
+
+// ---- Away-team picker modal (issue #17) ----
+
+const POOL_SPECIALIST = {
+  GEOLOGY:      'engineer',
+  WATER:        'biologist',
+  ATMOSPHERE:   'pilot',
+  ASTROBIOLOGY: 'biologist'
+};
+
+export function showAwayTeamPickerModal(state, waypoint, { onConfirm, onCancel }) {
+  const r = root();
+  if (!r) return;
+
+  const specialistRole = POOL_SPECIALIST[waypoint.factPool] || null;
+  const aliveCrew = state.crew.filter(c => c.alive);
+  const maxSelectable = Math.min(3, aliveCrew.length - 1);   // must leave ≥1 on rover
+
+  const crewRowsHtml = aliveCrew.map(c => {
+    const roleCode = (c.role || '').toUpperCase();
+    const specialistTag = c.role === specialistRole ? ' <span class="away-specialist">SPECIALIST</span>' : '';
+    return `
+      <label class="away-crew-row" data-crew-id="${c.id}">
+        <input type="checkbox" class="away-crew-check" value="${c.id}" />
+        <span class="away-crew-name">${escapeHtml(c.name)}</span>
+        <span class="away-crew-role">${roleCode}${specialistTag}</span>
+        <span class="away-crew-hp">HP ${c.health}</span>
+      </label>
+    `;
+  }).join('');
+
+  const specialistHint = specialistRole
+    ? `Specialist for this site: <strong>${specialistRole.toUpperCase()}</strong>. No specialist → harder checks, no advanced fact.`
+    : '';
+
+  r.innerHTML = `
+    <div class="modal-backdrop">
+      <div class="modal-panel modal-away-picker" role="dialog" aria-modal="true">
+        <div class="modal-severity severity-waypoint">⎋ AWAY-TEAM DISPATCH</div>
+        <h2 class="modal-title">${escapeHtml(waypoint.name)}</h2>
+        <p class="modal-description">${escapeHtml(waypoint.briefing)}</p>
+        <div class="away-meta">
+          <div class="away-meta-row"><span>DUE BACK</span><span>~${waypoint.detourSols} sols</span></div>
+          <div class="away-meta-row"><span>SEND</span><span>1–${maxSelectable} crew</span></div>
+        </div>
+        ${specialistHint ? `<p class="away-hint">${specialistHint}</p>` : ''}
+        <div class="away-crew-list">${crewRowsHtml}</div>
+        <div class="away-picker-status" id="away-picker-status">Select 1–${maxSelectable} crew.</div>
+        <div class="modal-choices">
+          <button class="modal-choice primary" id="away-confirm" type="button" disabled>DISPATCH →</button>
+          <button class="modal-choice" id="away-cancel" type="button">CANCEL</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const confirmBtn = r.querySelector('#away-confirm');
+  const statusEl   = r.querySelector('#away-picker-status');
+  const checks     = Array.from(r.querySelectorAll('.away-crew-check'));
+
+  function update() {
+    const picked = checks.filter(c => c.checked).map(c => c.value);
+    const valid  = picked.length >= 1 && picked.length <= maxSelectable;
+    confirmBtn.disabled = !valid;
+    statusEl.textContent = valid
+      ? `${picked.length} crew dispatched — ${aliveCrew.length - picked.length} stays on rover.`
+      : `Select 1–${maxSelectable} crew.`;
+    // Soft-cap: if picked too many, block further.
+    const overCap = picked.length >= maxSelectable;
+    checks.forEach(c => { if (!c.checked) c.disabled = overCap; });
+  }
+  checks.forEach(c => c.addEventListener('change', update));
+  update();
+
+  confirmBtn.addEventListener('click', () => {
+    const crewIds = checks.filter(c => c.checked).map(c => c.value);
+    onConfirm(crewIds);
+  });
+  r.querySelector('#away-cancel').addEventListener('click', () => onCancel && onCancel());
+}
+
+// ---- Away-team reunion modal (issue #17) ----
+
+export function showAwayTeamReunionModal(payload, onConfirm) {
+  const r = root();
+  if (!r) return;
+
+  const { waypoint, survivors, deaths, sciencePoints, facts } = payload;
+
+  const survivorsHtml = survivors.length
+    ? `<ul class="away-reunion-list">${survivors.map(s => `
+        <li>${escapeHtml(s.name)} <span class="away-crew-role">${s.role.toUpperCase()}</span>
+            <span class="away-crew-hp">HP ${s.health}</span></li>`).join('')}</ul>`
+    : '<p class="away-reunion-empty">No survivors.</p>';
+
+  const deathsHtml = deaths.length
+    ? `<div class="away-deaths">
+         <div class="away-deaths-header">LOST</div>
+         <ul class="away-reunion-list">${deaths.map(d => `
+           <li class="away-deceased">
+             <span class="away-crew-name">${escapeHtml(d.name)}</span>
+             <span class="away-crew-role">${d.role.toUpperCase()}</span>
+             <span class="away-corpse-choice">
+               <label><input type="radio" name="corpse-${d.id}" value="bring" checked /> bring body (+180 LB)</label>
+               <label><input type="radio" name="corpse-${d.id}" value="leave" /> leave behind</label>
+             </span>
+           </li>`).join('')}</ul>
+       </div>`
+    : '';
+
+  const factsHtml = facts.length
+    ? `<div class="away-facts">
+         <div class="away-facts-label">⎋ ADVANCED DATA</div>
+         ${facts.map(f => `<p>${linkifyCodex(escapeHtml(f))}</p>`).join('')}
+       </div>`
+    : '';
+
+  r.innerHTML = `
+    <div class="modal-backdrop">
+      <div class="modal-panel modal-away-reunion" role="dialog" aria-modal="true">
+        <div class="modal-severity severity-waypoint">⎋ AWAY TEAM REUNITED</div>
+        <h2 class="modal-title">${escapeHtml(waypoint.name)}</h2>
+        <div class="away-reunion-sci">+${sciencePoints} SCI</div>
+        ${factsHtml}
+        ${survivorsHtml}
+        ${deathsHtml}
+        <button class="modal-continue primary" id="away-reunion-confirm" type="button">RESUME TREK →</button>
+      </div>
+    </div>
+  `;
+
+  r.querySelector('#away-reunion-confirm').addEventListener('click', () => {
+    const corpseChoices = {};
+    for (const d of deaths) {
+      const radio = r.querySelector(`input[name="corpse-${d.id}"]:checked`);
+      corpseChoices[d.id] = radio ? radio.value : 'bring';
+    }
+    onConfirm(corpseChoices);
   });
 }
 

--- a/styles/components.css
+++ b/styles/components.css
@@ -485,7 +485,13 @@ body[data-theme="lcars"] .crew-bubble::before { display: none; }
 
 .waypoint-marker.accepted {
   fill: #ee99ff;
-  filter: drop-shadow(0 0 3px #ee99ff);
+  filter: drop-shadow(0 0 4px #ee99ff);
+  animation: waypoint-away-pulse 1.3s ease-in-out infinite;
+}
+
+@keyframes waypoint-away-pulse {
+  0%, 100% { opacity: 1;   transform: scale(1);    filter: drop-shadow(0 0 4px #ee99ff); }
+  50%      { opacity: 0.7; transform: scale(1.35); filter: drop-shadow(0 0 7px #ffccff); }
 }
 
 .waypoint-marker.fired {
@@ -647,4 +653,169 @@ body[data-theme="lcars"] .crew-bubble::before { display: none; }
   font-size: 0.85rem;
   color: var(--fg-dim, #cc99cc);
   opacity: 0.85;
+}
+
+/* ---- Away-team DUE BACK chip (issue #17) ---- */
+
+.away-due-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  margin-right: 0.65rem;
+  font-family: var(--mono-font, monospace);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: #ee99ff;
+  border: 1px solid #cc88ff;
+  border-radius: 3px;
+  background: rgba(140, 80, 180, 0.12);
+  animation: waypoint-away-pulse 1.3s ease-in-out infinite;
+}
+
+/* ---- Away-team picker modal (issue #17) ---- */
+
+.modal-away-picker .away-meta {
+  display: flex;
+  gap: 1rem;
+  margin: 0.75rem 0;
+}
+.modal-away-picker .away-meta-row {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--accent-dim, #4d3a5c);
+  border-radius: 3px;
+  background: rgba(80, 60, 100, 0.15);
+}
+.modal-away-picker .away-meta-row span:first-child {
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--fg-dim, #cc99cc);
+  margin-bottom: 0.15rem;
+}
+.modal-away-picker .away-meta-row span:last-child {
+  font-size: 0.95rem;
+  color: var(--fg, #fff);
+}
+.modal-away-picker .away-hint {
+  font-size: 0.82rem;
+  color: var(--fg-dim, #cc99cc);
+  margin: 0.5rem 0;
+}
+.modal-away-picker .away-crew-list {
+  margin: 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.modal-away-picker .away-crew-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--accent-dim, #4d3a5c);
+  border-radius: 3px;
+  cursor: pointer;
+  background: rgba(60, 45, 80, 0.18);
+}
+.modal-away-picker .away-crew-row:hover {
+  background: rgba(90, 65, 120, 0.25);
+}
+.modal-away-picker .away-crew-check:disabled + .away-crew-name {
+  opacity: 0.5;
+}
+.modal-away-picker .away-crew-name { color: var(--fg, #fff); }
+.modal-away-picker .away-crew-role {
+  font-family: var(--mono-font, monospace);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--fg-dim, #cc99cc);
+}
+.modal-away-picker .away-specialist {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0.05rem 0.4rem;
+  font-size: 0.65rem;
+  color: #ffeecc;
+  background: rgba(200, 140, 60, 0.35);
+  border-radius: 2px;
+  letter-spacing: 0.08em;
+}
+.modal-away-picker .away-crew-hp {
+  font-family: var(--mono-font, monospace);
+  font-size: 0.75rem;
+  color: var(--fg-dim, #cc99cc);
+}
+.modal-away-picker .away-picker-status {
+  font-size: 0.78rem;
+  color: var(--fg-dim, #cc99cc);
+  margin-bottom: 0.6rem;
+  text-align: center;
+}
+
+/* ---- Away-team reunion modal (issue #17) ---- */
+
+.modal-away-reunion .away-reunion-sci {
+  text-align: center;
+  font-size: 1.4rem;
+  color: #ee99ff;
+  letter-spacing: 0.08em;
+  margin: 0.6rem 0;
+}
+.modal-away-reunion .away-reunion-list {
+  list-style: none;
+  margin: 0.5rem 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.modal-away-reunion .away-reunion-list li {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--accent-dim, #4d3a5c);
+  border-radius: 3px;
+}
+.modal-away-reunion .away-deaths {
+  margin: 0.8rem 0 0.5rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--accent-dim, #4d3a5c);
+}
+.modal-away-reunion .away-deaths-header {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  color: #ff9999;
+  margin-bottom: 0.35rem;
+}
+.modal-away-reunion .away-deceased {
+  border-color: #66444a;
+  background: rgba(100, 50, 60, 0.12);
+}
+.modal-away-reunion .away-corpse-choice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.78rem;
+  color: var(--fg-dim, #cc99cc);
+}
+.modal-away-reunion .away-corpse-choice label {
+  cursor: pointer;
+}
+.modal-away-reunion .away-facts {
+  margin: 0.6rem 0;
+  padding: 0.6rem;
+  border: 1px solid var(--accent-dim, #4d3a5c);
+  border-radius: 3px;
+  background: rgba(60, 45, 80, 0.2);
+}
+.modal-away-reunion .away-facts-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  color: #ee99ff;
+  margin-bottom: 0.3rem;
 }


### PR DESCRIPTION
## Summary

Rebuild of waypoint diverts as first-class away-team missions, plus the first multi-stage content event (medical emergency). Both ride on the v0.6.0 multi-stage framework.

Closes #17 · Closes #6 · Closes #21 · Closes #22.

## What changed

**Away team (#17)** — accepting a divert now opens a crew picker (1–3 alive crew, ≥1 stays on rover, min 3 alive crew to offer at all). Rover camps at the turn-off; each camp sol fires one stage of the waypoint's authored chain. Choices can push/pull the return sol via \`returnSolDelta\`. Rewards accumulate on \`state.awayTeam.accumulated\` and land at reunion. Reunion modal offers bring-back / leave-behind for each dead crew member.

**Medical emergency (#6)** — 3-stage event (diagnose → treat → dispose). Custom resolver targets the picked patient by ID, routes Stage 3 conditionally on death, and hooks body disposal into the shared corpse helper.

**Medic flavor line (#21)** — \"Well, there goes paradise.\" emitted on Stage 2 surgery-fail when the medic is alive and not the patient themselves.

**First-segment waypoint bug (#22)** — \`rollWaypoints\` was generating \`segmentIdx\` in \`[0, N-2)\`, but the offer check only fires on landmark arrival (\`currentLandmarkIndex ≥ 1\`), so segment-0 waypoints rendered on the minimap but were never offered. Shifted the range.

**Shared corpse mechanic** — \`state.corpses: [{ crewId, weightLbs }]\`, fed by both the reunion bring-back path and medical Stage 3 keep-body. \`cargoPounds\` widened to sum corpse weight into the existing power-drain / speed-penalty math.

## Files

New: \`src/systems/awayTeam.js\`, \`src/systems/corpse.js\`, \`src/systems/medicalEmergency.js\`, \`src/content/awayTeamChains.js\` (all 12 waypoints authored), \`src/content/medicalEmergency.js\`, three test files, \`sim/playAwayTeam.mjs\`.

Modified: \`src/state.js\` (new \`awayTeam\`, \`corpses\` fields; \`pendingWaypoint\` removed), \`src/systems/travel.js\` (camp-mode dispatch; medical routing; old resolveWaypoint flow deleted; \`cargoPounds(state)\`), \`src/systems/waypoints.js\` (stripped to \`rollWaypoints\` + \`declineWaypoint\`; #22 fix), \`src/systems/multiStage.js\` (surfaces \`returnSolDelta\`), \`src/ui/modals.js\` (picker + reunion renderers; old waypoint-reward modal removed), \`src/main.js\` (two new dispatch branches; medical/awayTeam source routing), \`src/render.js\` (DUE-BACK chip; minimap \`accepted\` keys off \`awayTeam.waypointId\`), \`styles/components.css\` (picker/reunion styles + pulse).

## Test plan

- [ ] \`node --test sim/*.test.mjs\` → 89/89 green (locally verified)
- [ ] \`node sim/play.mjs\` completes cleanly (locally verified)
- [ ] \`node sim/playAwayTeam.mjs\` exercises the full divert → camp → reunion loop with no runtime errors
- [ ] Browser playtest: accept a divert, watch DUE-BACK chip and minimap pulse, pick through stages, receive reunion modal, confirm corpse choices, verify weight impact on subsequent travel
- [ ] Browser playtest: trigger medical emergency (oneShot, may take a few runs), verify Stage 3 only fires on patient death and that keep-body adds to corpses
- [ ] Verify first-segment waypoint now offers when present

## Known issue (tracked separately)

Balance: accepting diverts under sim first-choice strategy drops win rate from ~47% → ~2% because camp sols burn full life support with no km progress. Loop is correct but economy needs tuning. Follow-up issue to be opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)