### PR TITLE
Camp supply fix + rank-as-checklist rescore (v0.7.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "type": "module",
   "private": true,
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/sim/awayTeam.test.mjs
+++ b/sim/awayTeam.test.mjs
@@ -12,6 +12,7 @@ import {
   finalizeReunion,
   MIN_CREW_FOR_DIVERT
 } from '../src/systems/awayTeam.js';
+import { advanceSol } from '../src/systems/travel.js';
 
 function makeState(overrides = {}) {
   return {
@@ -290,4 +291,80 @@ test('if all away-team crew die mid-chain, stage resolution jumps straight to re
   const s1 = withRandom([0.99], () => resolveAwayTeamStage(s, 0));
   assert.equal(s1.activeModal?.type, 'away_team_reunion');
   assert.ok(s1.awayTeam.deaths.includes('c1'));
+});
+
+// --- Camp-mode supply scaling (issue #25) ---
+
+// advanceSol-ready state shaped for drain comparison tests. Adds fields
+// advanceSol reads (firedEvents/firedWaypoints/pace/rations/activeModal)
+// that the core makeState omits.
+function makeDrainState(overrides = {}) {
+  const patched = {
+    pace: 'steady',
+    rations: 'standard',
+    firedEvents: [],
+    firedWaypoints: [],
+    waypoints: [],
+    totalKmTraveled: 0,
+    activeModal: null,
+    ...overrides
+  };
+  return makeState(patched);
+}
+
+test('camp mode scales life-support drain to rover-side crew share', () => {
+  const baseline = makeDrainState();
+  const afterTravel = advanceSol(baseline, 'travel');
+  const travelO2Drain   = 100 - afterTravel.resources.oxygen;
+  const travelFoodDrain = 100 - afterTravel.resources.food;
+
+  // Camp sol with 2 of 5 away — drain should be 3/5 of baseline.
+  let camp = acceptAwayTeam(baseline, 'olivine_outcrop', ['c1', 'c2']);
+  camp = { ...camp, activeModal: null };
+  const afterCamp = advanceSol(camp);
+  const campO2Drain   = 100 - afterCamp.resources.oxygen;
+  const campFoodDrain = 100 - afterCamp.resources.food;
+
+  const expectedShare = 3 / 5;
+  assert.ok(Math.abs(campO2Drain / travelO2Drain - expectedShare) < 0.01,
+    `O2 drain ratio ${(campO2Drain / travelO2Drain).toFixed(3)} ≠ ${expectedShare}`);
+  assert.ok(Math.abs(campFoodDrain / travelFoodDrain - expectedShare) < 0.01,
+    `food drain ratio ${(campFoodDrain / travelFoodDrain).toFixed(3)} ≠ ${expectedShare}`);
+});
+
+test('camp mode with 3 of 5 away drains life support to 2/5', () => {
+  const baseline = makeDrainState();
+  const afterTravel = advanceSol(baseline, 'travel');
+  const travelO2Drain = 100 - afterTravel.resources.oxygen;
+
+  let camp = acceptAwayTeam(baseline, 'olivine_outcrop', ['c1', 'c2', 'c3']);
+  camp = { ...camp, activeModal: null };
+  const afterCamp = advanceSol(camp);
+  const campO2Drain = 100 - afterCamp.resources.oxygen;
+
+  assert.ok(Math.abs(campO2Drain / travelO2Drain - 2/5) < 0.01);
+});
+
+test('camp supply scaling uses max crew count, not alive count (permanent deaths do not reduce drain)', () => {
+  // With max-crew-count denominator: (5 - 2 away) / 5 = 3/5 regardless of deaths.
+  // With alive-count denominator this would be (3 alive - 2 away) / 3 = 1/3.
+  const dead = makeDrainState({
+    crew: [
+      { id: 'c1', name: 'A', role: 'engineer',  health: 100, status: 'healthy', alive: true  },
+      { id: 'c2', name: 'B', role: 'biologist', health: 100, status: 'healthy', alive: true  },
+      { id: 'c3', name: 'C', role: 'medic',     health: 100, status: 'healthy', alive: true  },
+      { id: 'c4', name: 'D', role: 'pilot',     health: 0,   status: 'dead',    alive: false },
+      { id: 'c5', name: 'E', role: 'security',  health: 0,   status: 'dead',    alive: false }
+    ]
+  });
+  const afterTravel = advanceSol(dead, 'travel');
+  const travelO2Drain = 100 - afterTravel.resources.oxygen;
+
+  let camp = acceptAwayTeam(dead, 'olivine_outcrop', ['c1', 'c2']);
+  camp = { ...camp, activeModal: null };
+  const afterCamp = advanceSol(camp);
+  const campO2Drain = 100 - afterCamp.resources.oxygen;
+
+  assert.ok(Math.abs(campO2Drain / travelO2Drain - 3/5) < 0.01,
+    `expected 3/5 (max-crew), got ${(campO2Drain / travelO2Drain).toFixed(3)}`);
 });

--- a/sim/playtest1000.mjs
+++ b/sim/playtest1000.mjs
@@ -1,0 +1,218 @@
+// 1000-game playtest sweep. Compares CURRENT scoring-by-points against
+// the PROPOSED rank-as-checklist from issue #24. Runs several player
+// archetypes × divert modes and reports rank distributions, avg stats,
+// and what % of games would move ranks under the proposal.
+
+import { createInitialState } from '../src/state.js';
+import { advanceSol, canRepair, canClean, repairBattery, cleanPanels } from '../src/systems/travel.js';
+import { applyEventChoice } from '../src/systems/events.js';
+import { applyStageChoice } from '../src/systems/multiStage.js';
+import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from '../src/systems/awayTeam.js';
+import { resolveMedicalStage } from '../src/systems/medicalEmergency.js';
+import { computeScore } from '../src/systems/scoring.js';
+import { makeLandmarkEncounter } from '../src/content/landmarks.js';
+
+// ---- Strategies ----
+
+function pickRandom(_state, event) {
+  return Math.floor(Math.random() * event.modal.choices.length);
+}
+
+function pickFirst(_state, _event) { return 0; }
+
+// "Engaged player": skill check if specialist is alive, else choice 0.
+function pickSmart(state, event) {
+  let best = -1, bestP = 0;
+  event.modal.choices.forEach((c, i) => {
+    if (!c.skillCheck) return;
+    const alive = state.crew.some(cr => cr.role === c.skillCheck.role && cr.alive);
+    const p = alive ? c.skillCheck.successP : Math.max(0.2, c.skillCheck.successP - 0.4);
+    if (p > bestP) { bestP = p; best = i; }
+  });
+  return best === -1 ? 0 : best;
+}
+
+// "Science chaser": prefer choices with sciencePoints on an outcome.
+function pickScience(state, event) {
+  let best = 0, bestSci = -1;
+  event.modal.choices.forEach((c, i) => {
+    const pools = c.skillCheck ? [c.successOutcome, c.failOutcome] : [c.outcome];
+    let sci = 0;
+    for (const o of pools) if (o && typeof o.sciencePoints === 'number') sci += o.sciencePoints;
+    if (c.skillCheck) {
+      const alive = state.crew.some(cr => cr.role === c.skillCheck.role && cr.alive);
+      sci *= alive ? c.skillCheck.successP : 0.35;
+    }
+    if (sci > bestSci) { bestSci = sci; best = i; }
+  });
+  return best;
+}
+
+// ---- Proposed rank gate (issue #24 final table) ----
+
+function proposedRank(state) {
+  const total = (state.routeKm || []).reduce((s, k) => s + k, 0);
+  const pctRoute = total ? state.totalKmTraveled / total : 0;
+  const won = state.status === 'won';
+  const sci = state.sciencePoints;
+  const facts = state.factsLearned.length;
+  const alive = state.crew.filter(c => c.alive).length;
+  const crewCount = state.crew.length;
+
+  if (!won) {
+    if (pctRoute >= 0.8) return 'D';
+    return 'F';
+  }
+  if (sci >= 500 && facts >= 6 && alive === crewCount) return 'S';
+  if (sci >= 300 && facts >= 5 && alive >= 3) return 'A';
+  if (sci >= 150 || facts >= 3) return 'B';
+  return 'C';
+}
+
+// ---- Game loop ----
+
+function playGame({ pickChoice, acceptDiverts, sendCrew = 2 }) {
+  let s = createInitialState();
+  s.activeModal = null;
+  s.pace = 'steady';
+  s.rations = 'standard';
+
+  const MAX = 250;
+  while (s.status === 'active' && s.sol < MAX) {
+    const m = s.activeModal;
+    if (m && m.type === 'event') {
+      const idx = pickChoice(s, m.payload);
+      s = applyEventChoice(s, m.payload, idx).state;
+      continue;
+    }
+    if (m && m.type === 'waypoint_offer') {
+      if (!acceptDiverts) {
+        s = { ...s, firedWaypoints: [...s.firedWaypoints, m.payload.waypoint.id], activeModal: null };
+      } else {
+        s = { ...s, activeModal: { type: 'away_team_picker', payload: m.payload } };
+      }
+      continue;
+    }
+    if (m && m.type === 'away_team_picker') {
+      const aliveIds = s.crew.filter(c => c.alive).map(c => c.id);
+      const toSend = aliveIds.slice(0, Math.min(sendCrew, aliveIds.length - 1));
+      if (toSend.length < 1) { s = { ...s, activeModal: null }; continue; }
+      s = acceptAwayTeam(s, m.payload.waypoint.id, toSend);
+      s = { ...s, firedWaypoints: [...s.firedWaypoints, m.payload.waypoint.id] };
+      const arrivedId = s.route[s.currentLandmarkIndex];
+      s = { ...s, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
+      continue;
+    }
+    if (m && m.type === 'away_team_reunion') {
+      const corpseChoices = {};
+      for (const d of m.payload.deaths) corpseChoices[d.id] = 'bring';
+      s = finalizeReunion(s, corpseChoices);
+      continue;
+    }
+    if (m && m.type === 'multi_stage') {
+      if (m.payload.source === 'medical')   { s = resolveMedicalStage(s, 0); continue; }
+      if (m.payload.source === 'awayTeam')  { s = resolveAwayTeamStage(s, 0); continue; }
+      const { event, stageId } = m.payload;
+      const { state: next, nextStage } = applyStageChoice(s, event, stageId, 0);
+      s = nextStage !== null
+        ? { ...next, activeModal: { type: 'multi_stage', payload: { event, stageId: nextStage } } }
+        : { ...next, activeModal: null };
+      continue;
+    }
+    if (canRepair(s) && s.resources.power < 35) { s = repairBattery(s); continue; }
+    if (canClean(s)  && s.resources.panels < 40) { s = cleanPanels(s);   continue; }
+    s = advanceSol(s, 'travel');
+  }
+  if (s.status === 'active') { s.status = 'lost'; s.lossReason = 'timeout'; }
+  return s;
+}
+
+// ---- Sweep ----
+
+const CONFIGS = [
+  { label: 'Random / decline',       pickChoice: pickRandom,  acceptDiverts: false },
+  { label: 'Random / accept',        pickChoice: pickRandom,  acceptDiverts: true  },
+  { label: 'FirstChoice / decline',  pickChoice: pickFirst,   acceptDiverts: false },
+  { label: 'FirstChoice / accept',   pickChoice: pickFirst,   acceptDiverts: true  },
+  { label: 'Smart / decline',        pickChoice: pickSmart,   acceptDiverts: false },
+  { label: 'Smart / accept',         pickChoice: pickSmart,   acceptDiverts: true  },
+  { label: 'Sci-chaser / decline',   pickChoice: pickScience, acceptDiverts: false },
+  { label: 'Sci-chaser / accept',    pickChoice: pickScience, acceptDiverts: true  }
+];
+
+const N_PER = 125;
+const TOTAL = CONFIGS.length * N_PER;
+const RANKS = ['S', 'A', 'B', 'C', 'D', 'F'];
+
+function blankHist() { return Object.fromEntries(RANKS.map(r => [r, 0])); }
+function pct(n, total) { return total ? ((n / total) * 100).toFixed(1).padStart(5) : '  0.0'; }
+
+const results = [];
+const globalCurrent  = blankHist();
+const globalProposed = blankHist();
+let globalN = 0;
+let rankChanged = 0;
+
+for (const cfg of CONFIGS) {
+  const current = blankHist();
+  const proposed = blankHist();
+  let wins = 0, sumSci = 0, sumFacts = 0, sumCrew = 0, sumSols = 0;
+  for (let i = 0; i < N_PER; i++) {
+    const s = playGame(cfg);
+    const { rank } = computeScore(s);
+    const pRank = proposedRank(s);
+    current[rank]++;
+    proposed[pRank]++;
+    globalCurrent[rank]++;
+    globalProposed[pRank]++;
+    globalN++;
+    if (rank !== pRank) rankChanged++;
+    if (s.status === 'won') wins++;
+    sumSci   += s.sciencePoints;
+    sumFacts += s.factsLearned.length;
+    sumCrew  += s.crew.filter(c => c.alive).length;
+    sumSols  += s.sol;
+  }
+  results.push({
+    cfg, current, proposed,
+    win: wins / N_PER,
+    avgSci: sumSci / N_PER,
+    avgFacts: sumFacts / N_PER,
+    avgCrew: sumCrew / N_PER,
+    avgSol:  sumSols / N_PER
+  });
+}
+
+// ---- Report ----
+
+console.log(`\nRunning ${TOTAL} games across ${CONFIGS.length} configs (${N_PER} each)\n`);
+
+console.log('Per-config rank distributions (% of games at each rank):\n');
+console.log(
+  'config'.padEnd(25) +
+  '  win%  avg_sci  avg_fact  avg_crew  avg_sol' +
+  '  |  CURRENT S/A/B/C/D/F' +
+  '           | PROPOSED S/A/B/C/D/F'
+);
+console.log('-'.repeat(140));
+for (const r of results) {
+  const curStr = RANKS.map(k => pct(r.current[k], N_PER)).join(' ');
+  const propStr = RANKS.map(k => pct(r.proposed[k], N_PER)).join(' ');
+  console.log(
+    r.cfg.label.padEnd(25) +
+    `  ${pct(r.win * N_PER, N_PER)}  ${r.avgSci.toFixed(1).padStart(6)}  ` +
+    `${r.avgFacts.toFixed(2).padStart(7)}  ${r.avgCrew.toFixed(2).padStart(7)}  ` +
+    `${r.avgSol.toFixed(1).padStart(6)}  |  ${curStr}  |  ${propStr}`
+  );
+}
+
+console.log('\n---- Global distributions (all configs combined) ----');
+console.log('rank  |  current  |  proposed');
+console.log('-'.repeat(35));
+for (const rk of RANKS) {
+  console.log(
+    `  ${rk}   |   ${pct(globalCurrent[rk], TOTAL)}%  |  ${pct(globalProposed[rk], TOTAL)}%`
+  );
+}
+console.log('\nrank changed in ' + pct(rankChanged, TOTAL) + '% of games');
+console.log();

--- a/sim/scoring.test.mjs
+++ b/sim/scoring.test.mjs
@@ -1,19 +1,23 @@
 // Tests for src/systems/scoring.js. Run: node --test sim/scoring.test.mjs
+//
+// v0.7.1: rank is a checklist of gates (issue #24), not threshold math.
+// Points still computed (for leaderboard); tests cover point math AND
+// rank gates separately.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { computeScore } from '../src/systems/scoring.js';
+import { computeScore, nextRankGap, loadBestRun, saveBestRun } from '../src/systems/scoring.js';
 
-// --- Helper: build a minimal end-of-run state for tests ---
 function makeState(overrides = {}) {
   return {
     status: 'won',
     sol: 24,
     totalKmTraveled: 2550,
-    currentLandmarkIndex: 7,              // destination reached
+    currentLandmarkIndex: 7,
     route: ['jezero','syrtis','arabia','meridiani','gale','elysium','tharsis','olympus_base'],
     routeKm: [330, 420, 290, 360, 460, 315, 375],   // sum 2550
     sciencePoints: 240,
+    factsLearned: [],
     resources: { oxygen: 40, water: 50, food: 35, power: 80, panels: 100, mech: 1, eva: 1, cell: 1 },
     crew: [
       { id:'c1', alive:true  },
@@ -26,136 +30,190 @@ function makeState(overrides = {}) {
   };
 }
 
-test('won run with 4/5 crew, moderate speed, 240 sci → A rank', () => {
-  const { points, rank, breakdown } = computeScore(makeState());
-  // Expected:
-  //   outcome 500 + crew 400 + sci 240 + resources round((40+50+35+80)/4)=51 cap100 → 51
-  //   + speed max(0, 300-24*10)=60 + landmarks 7*20=140 = 1391
-  assert.equal(rank, 'A');
+// ---- Point math (unchanged from v0.7.0) ----
+
+test('computeScore point math is unchanged: won, 4/5 crew, 240 SCI, sol 24', () => {
+  const { points, breakdown } = computeScore(makeState());
+  // 500 + 400 + 240 + 51 + 60 + 140 = 1391
   assert.equal(points, 1391);
   assert.equal(breakdown.length, 6);
 });
 
-test('perfect won run (5/5 crew, fast, high sci, full resources) → S rank', () => {
-  const s = makeState({
-    sol: 12,
-    sciencePoints: 500,
-    resources: { oxygen: 90, water: 90, food: 90, power: 90, panels: 100, mech: 1, eva: 1, cell: 1 },
+// ---- Rank gates (issue #24) ----
+
+test('rank C: won but no science + no facts → baseline C', () => {
+  const { rank } = computeScore(makeState({
+    sciencePoints: 0,
+    factsLearned: [],
     crew: [
       { id:'c1', alive:true }, { id:'c2', alive:true }, { id:'c3', alive:true },
       { id:'c4', alive:true }, { id:'c5', alive:true }
     ]
-  });
-  const { points, rank } = computeScore(s);
-  // 500 + 500 + 300 (capped) + 90 + 180 (300-120) + 140 = 1710
-  assert.equal(rank, 'S');
-  assert.equal(points, 1710);
-});
-
-test('won run with only 2/5 crew and low sci → B rank', () => {
-  const s = makeState({
-    sciencePoints: 50,
-    crew: [
-      { id:'c1', alive:true }, { id:'c2', alive:true },
-      { id:'c3', alive:false }, { id:'c4', alive:false }, { id:'c5', alive:false }
-    ]
-  });
-  const { points, rank } = computeScore(s);
-  // 500 + 200 + 50 + 51 + 60 + 140 = 1001 → B (≥900)
-  assert.equal(rank, 'B');
-  assert.equal(points, 1001);
-});
-
-test('lost run at >80% distance → C rank (near-miss loss)', () => {
-  const s = makeState({
-    status: 'lost',
-    totalKmTraveled: 2100,                 // 2100/2550 = 82%
-    currentLandmarkIndex: 5,
-    sol: 30,
-    sciencePoints: 180,
-    crew: [
-      { id:'c1', alive:true }, { id:'c2', alive:false }, { id:'c3', alive:false },
-      { id:'c4', alive:false }, { id:'c5', alive:false }
-    ]
-  });
-  const { points, rank } = computeScore(s);
-  // outcome 100 (≥80%) + crew 100 + sci 180 + resources 51 + speed 0 (lost) + landmarks 5*20=100
-  // = 531. Lost with 531 → D (<700).
-  assert.equal(points, 531);
-  assert.equal(rank, 'D');
-});
-
-test('early-wipe lost run → F rank', () => {
-  const s = makeState({
-    status: 'lost',
-    totalKmTraveled: 100,
-    currentLandmarkIndex: 0,
-    sol: 4,
-    sciencePoints: 5,
-    resources: { oxygen: 0, water: 0, food: 0, power: 0, panels: 0, mech: 0, eva: 0, cell: 0 },
-    crew: [ { id:'c1', alive:false }, { id:'c2', alive:false }, { id:'c3', alive:false },
-            { id:'c4', alive:false }, { id:'c5', alive:false } ]
-  });
-  const { points, rank } = computeScore(s);
-  // 0 + 0 + 5 + 0 + 0 (lost) + 0 = 5 → F
-  assert.equal(points, 5);
-  assert.equal(rank, 'F');
-});
-
-test('won run with very low score still at least C', () => {
-  const s = makeState({
-    sol: 80,                               // speed bonus = max(0, 300-800) = 0
-    sciencePoints: 0,
-    resources: { oxygen: 0, water: 0, food: 0, power: 0, panels: 0, mech: 0, eva: 0, cell: 0 },
-    crew: [ { id:'c1', alive:true }, { id:'c2', alive:false }, { id:'c3', alive:false },
-            { id:'c4', alive:false }, { id:'c5', alive:false } ]
-  });
-  const { points, rank } = computeScore(s);
-  // 500 + 100 + 0 + 0 + 0 + 140 = 740 → B (≥900 no), C floor for won
-  assert.equal(points, 740);
+  }));
   assert.equal(rank, 'C');
 });
 
-// ---- SCI floor tests (issue #15) ----
-
-test('A-qualifying points with <100 SCI falls back to B', () => {
-  // Same fixture as the A-rank test (1391 pts) but with 91 SCI instead of 240.
-  // A requires 1200 pts AND 100 SCI; 91 SCI → B.
-  const s = makeState({ sciencePoints: 91 });
-  const { points, rank } = computeScore(s);
-  // Points drop by 149 (240 sci capped at 240 → 91 sci → 91). 1391 - 149 = 1242.
-  assert.equal(points, 1242);
+test('rank B via SCI: won + ≥150 SCI → B', () => {
+  const { rank } = computeScore(makeState({ sciencePoints: 150, factsLearned: [] }));
   assert.equal(rank, 'B');
 });
 
-test('A-qualifying points with exactly 100 SCI still earns A', () => {
-  const s = makeState({ sciencePoints: 100 });
-  const { points, rank } = computeScore(s);
-  // 500 + 400 + 100 + 51 + 60 + 140 = 1251
-  assert.equal(points, 1251);
-  assert.equal(rank, 'A');
+test('rank B via facts: won + ≥3 facts → B (even with low SCI)', () => {
+  const { rank } = computeScore(makeState({
+    sciencePoints: 10,
+    factsLearned: ['a', 'b', 'c']
+  }));
+  assert.equal(rank, 'B');
 });
 
-test('S-qualifying points with 150 SCI downgrades to A', () => {
-  // Fixture same as "perfect won run" but with 150 SCI instead of 500.
-  const s = makeState({
-    sol: 12,
-    sciencePoints: 150,
-    resources: { oxygen: 90, water: 90, food: 90, power: 90, panels: 100, mech: 1, eva: 1, cell: 1 },
+test('rank A requires SCI + facts + ≥3 crew alive', () => {
+  const base = { sciencePoints: 300, factsLearned: ['a','b','c','d','e'] };
+  // 3 alive: A qualifies
+  const a3 = computeScore(makeState({
+    ...base,
+    crew: [{id:'c1',alive:true},{id:'c2',alive:true},{id:'c3',alive:true},
+           {id:'c4',alive:false},{id:'c5',alive:false}]
+  }));
+  assert.equal(a3.rank, 'A');
+
+  // 2 alive: fails crew gate → falls to B
+  const a2 = computeScore(makeState({
+    ...base,
+    crew: [{id:'c1',alive:true},{id:'c2',alive:true},
+           {id:'c3',alive:false},{id:'c4',alive:false},{id:'c5',alive:false}]
+  }));
+  assert.equal(a2.rank, 'B');
+
+  // Missing fact count
+  const fewFacts = computeScore(makeState({
+    ...base,
+    factsLearned: ['a','b','c','d']                // 4 < 5
+  }));
+  assert.equal(fewFacts.rank, 'B');
+
+  // Low SCI
+  const lowSci = computeScore(makeState({ ...base, sciencePoints: 250 }));
+  assert.equal(lowSci.rank, 'B');
+});
+
+test('rank S requires all 5 crew alive + ≥500 SCI + ≥6 facts', () => {
+  const sFixture = makeState({
+    sciencePoints: 500,
+    factsLearned: ['a','b','c','d','e','f'],
     crew: [
       { id:'c1', alive:true }, { id:'c2', alive:true }, { id:'c3', alive:true },
       { id:'c4', alive:true }, { id:'c5', alive:true }
     ]
   });
-  const { points, rank } = computeScore(s);
-  // 500 + 500 + 150 + 90 + 180 + 140 = 1560 ≥ 1500, but SCI < 200 → A.
-  assert.equal(points, 1560);
-  assert.equal(rank, 'A');
+  assert.equal(computeScore(sFixture).rank, 'S');
+
+  // One crew dead → S gate fails, but A gate (3+ alive, 300+ SCI, 5+ facts) holds
+  const oneDead = computeScore(makeState({
+    ...sFixture,
+    crew: sFixture.crew.map((c, i) => i === 0 ? { ...c, alive: false } : c)
+  }));
+  assert.equal(oneDead.rank, 'A');
+
+  // 6 facts + all alive + 499 SCI → A (below S SCI floor)
+  const lowSci = computeScore(makeState({
+    ...sFixture,
+    sciencePoints: 499
+  }));
+  assert.equal(lowSci.rank, 'A');
+
+  // 5 facts (below S gate) + all alive + 500 SCI → A
+  const fewFacts = computeScore(makeState({
+    ...sFixture,
+    factsLearned: ['a','b','c','d','e']
+  }));
+  assert.equal(fewFacts.rank, 'A');
 });
 
-// ---- Persistence tests: stub localStorage before each test ----
+// ---- Loss gates ----
 
-import { loadBestRun, saveBestRun } from '../src/systems/scoring.js';
+test('lost run: ≥80% route traversed → D, else F', () => {
+  const near = computeScore(makeState({
+    status: 'lost',
+    totalKmTraveled: 2100,        // 82%
+    currentLandmarkIndex: 5
+  }));
+  assert.equal(near.rank, 'D');
+
+  const early = computeScore(makeState({
+    status: 'lost',
+    totalKmTraveled: 100,         // 4%
+    currentLandmarkIndex: 0
+  }));
+  assert.equal(early.rank, 'F');
+});
+
+// ---- nextRankGap (directional feedback) ----
+
+test('nextRankGap returns null after S', () => {
+  const s = makeState({
+    sciencePoints: 600,
+    factsLearned: ['a','b','c','d','e','f','g'],
+    crew: [
+      { id:'c1', alive:true }, { id:'c2', alive:true }, { id:'c3', alive:true },
+      { id:'c4', alive:true }, { id:'c5', alive:true }
+    ]
+  });
+  assert.equal(nextRankGap(s), null);
+});
+
+test('nextRankGap returns null for lost runs', () => {
+  const s = makeState({ status: 'lost', totalKmTraveled: 100, currentLandmarkIndex: 0 });
+  assert.equal(nextRankGap(s), null);
+});
+
+test('nextRankGap at C: reports the easier of SCI-to-B or facts-to-B', () => {
+  // Player sitting at C with 140 SCI and 0 facts → 10 more SCI reaches B.
+  const closeSci = nextRankGap(makeState({ sciencePoints: 140, factsLearned: [] }));
+  assert.equal(closeSci.nextRank, 'B');
+  assert.equal(closeSci.needs[0].label, 'science points');
+  assert.equal(closeSci.needs[0].delta, 10);
+
+  // Player sitting at C with 0 SCI and 2 facts → 1 more fact reaches B.
+  const closeFacts = nextRankGap(makeState({ sciencePoints: 0, factsLearned: ['a','b'] }));
+  assert.equal(closeFacts.nextRank, 'B');
+  assert.equal(closeFacts.needs[0].label, 'advanced facts');
+  assert.equal(closeFacts.needs[0].delta, 1);
+});
+
+test('nextRankGap at B lists all A gaps (SCI, facts, crew) that apply', () => {
+  // 200 SCI, 4 facts, 2 crew alive → sits at B; missing 100 SCI, 1 fact, 1 crew.
+  const s = makeState({
+    sciencePoints: 200,
+    factsLearned: ['a','b','c','d'],
+    crew: [{id:'c1',alive:true},{id:'c2',alive:true},{id:'c3',alive:false},
+           {id:'c4',alive:false},{id:'c5',alive:false}]
+  });
+  const gap = nextRankGap(s);
+  assert.equal(gap.nextRank, 'A');
+  const byLabel = Object.fromEntries(gap.needs.map(n => [n.label, n.delta]));
+  assert.equal(byLabel['science points'], 100);
+  assert.equal(byLabel['advanced facts'], 1);
+  assert.equal(byLabel['crew alive'], 1);
+});
+
+test('nextRankGap at A points toward S with hard all-crew gate', () => {
+  // Player earned A but lost 1 crew → S requires all-crew-alive, which is a
+  // permanent fail for this run (flagged hard=true).
+  const s = makeState({
+    sciencePoints: 400,
+    factsLearned: ['a','b','c','d','e','f'],
+    crew: [{id:'c1',alive:true},{id:'c2',alive:true},{id:'c3',alive:true},
+           {id:'c4',alive:true},{id:'c5',alive:false}]
+  });
+  assert.equal(computeScore(s).rank, 'A');
+  const gap = nextRankGap(s);
+  assert.equal(gap.nextRank, 'S');
+  const crewNeed = gap.needs.find(n => n.label === 'all crew alive');
+  assert.ok(crewNeed);
+  assert.equal(crewNeed.hard, true);
+});
+
+// ---- Persistence ----
 
 function installLocalStorage() {
   const store = {};
@@ -180,30 +238,24 @@ test('loadBestRun returns null on malformed JSON (no throw)', () => {
 
 test('saveBestRun writes on first save', () => {
   installLocalStorage();
-  const score = { points: 1200, rank: 'A' };
-  const state = { sol: 24, status: 'won' };
-  saveBestRun(score, state);
+  saveBestRun({ points: 1200, rank: 'A' }, { sol: 24, status: 'won' });
   const loaded = loadBestRun();
   assert.equal(loaded.points, 1200);
   assert.equal(loaded.rank, 'A');
   assert.equal(loaded.sol, 24);
   assert.equal(loaded.won, true);
-  assert.match(loaded.date, /^\d{4}-\d{2}-\d{2}$/);
 });
 
 test('saveBestRun skips when new score is not higher', () => {
   installLocalStorage();
   saveBestRun({ points: 1500, rank: 'S' }, { sol: 12, status: 'won' });
   saveBestRun({ points: 1200, rank: 'A' }, { sol: 24, status: 'won' });
-  const loaded = loadBestRun();
-  assert.equal(loaded.points, 1500);
-  assert.equal(loaded.rank, 'S');
+  assert.equal(loadBestRun().points, 1500);
 });
 
 test('saveBestRun overwrites when new score is higher', () => {
   installLocalStorage();
   saveBestRun({ points: 900, rank: 'B' }, { sol: 35, status: 'won' });
   saveBestRun({ points: 1400, rank: 'A' }, { sol: 20, status: 'won' });
-  const loaded = loadBestRun();
-  assert.equal(loaded.points, 1400);
+  assert.equal(loadBestRun().points, 1400);
 });

--- a/src/systems/scoring.js
+++ b/src/systems/scoring.js
@@ -1,29 +1,96 @@
 // Mars Trail — end-of-run scoring + best-run persistence.
 // Pure module. Import from game systems or UI; no state mutation.
+//
+// Scoring has two pieces:
+// - `computeScore` produces a numeric `points` total + breakdown (unchanged
+//   in v0.7.1; used for the leaderboard and run-vs-run comparison).
+// - Rank is determined by a **checklist of gates** (issue #24), not by point
+//   thresholds. Philosophy: surviving is C. Science + learning earn A.
+//   Science + learning + no-one-left-behind earn S.
 
-const RANK_THRESHOLDS_WON  = [['S', 1500], ['A', 1200], ['B', 900]];  // fall through to 'C'
-const RANK_THRESHOLDS_LOST = [['C', 700], ['D', 400]];                // fall through to 'F'
+const SCI_B = 150;
+const FACTS_B = 3;
+const SCI_A = 300;
+const FACTS_A = 5;
+const CREW_A = 3;
+const SCI_S = 500;
+const FACTS_S = 6;
+const LOST_D_ROUTE_FRACTION = 0.8;
 
 function totalRouteKm(state) {
   return (state.routeKm || []).reduce((sum, km) => sum + km, 0);
 }
 
-// Top ranks gate on minimum science — the mission is a SCIENCE mission, so
-// S and A require real scientific output, not just survival + speed.
-const SCI_FLOOR_S = 200;
-const SCI_FLOOR_A = 100;
+function factsLearnedCount(state) {
+  return (state.factsLearned || []).length;
+}
 
-function rankFor(points, won, sciencePoints) {
+function aliveCrewCount(state) {
+  return state.crew.filter(c => c.alive).length;
+}
+
+function rankFor(state) {
+  const won = state.status === 'won';
   if (!won) {
-    for (const [rank, min] of RANK_THRESHOLDS_LOST) {
-      if (points >= min) return rank;
-    }
-    return 'F';
+    const pctRoute = state.totalKmTraveled / Math.max(1, totalRouteKm(state));
+    return pctRoute >= LOST_D_ROUTE_FRACTION ? 'D' : 'F';
   }
-  if (points >= 1500 && sciencePoints >= SCI_FLOOR_S) return 'S';
-  if (points >= 1200 && sciencePoints >= SCI_FLOOR_A) return 'A';
-  if (points >= 900) return 'B';
+  const sci   = state.sciencePoints || 0;
+  const facts = factsLearnedCount(state);
+  const alive = aliveCrewCount(state);
+  const totalCrew = state.crew.length;
+
+  if (sci >= SCI_S && facts >= FACTS_S && alive === totalCrew)       return 'S';
+  if (sci >= SCI_A && facts >= FACTS_A && alive >= CREW_A)           return 'A';
+  if (sci >= SCI_B || facts >= FACTS_B)                              return 'B';
   return 'C';
+}
+
+// ---- nextRankGap ----
+// Given a finished state, describe what's missing to earn the next rank up.
+// Returns { nextRank, needs: [{label, value}, …] } or null if already S or
+// if the mission was lost (losses don't progress toward rank gates).
+export function nextRankGap(state) {
+  if (state.status !== 'won') return null;
+  const current = rankFor(state);
+  if (current === 'S') return null;
+
+  const sci   = state.sciencePoints || 0;
+  const facts = factsLearnedCount(state);
+  const alive = aliveCrewCount(state);
+  const totalCrew = state.crew.length;
+
+  // Map current → target rank.
+  const target = current === 'C' ? 'B'
+               : current === 'B' ? 'A'
+               : current === 'A' ? 'S'
+               : null;
+  if (!target) return null;
+
+  const needs = [];
+  if (target === 'B') {
+    // B: need ≥ SCI_B SCI OR ≥ FACTS_B facts. Report whichever is closer.
+    const sciGap   = Math.max(0, SCI_B - sci);
+    const factsGap = Math.max(0, FACTS_B - facts);
+    if (sciGap === 0 || factsGap === 0) return null;   // safety
+    if (sciGap * FACTS_B <= factsGap * SCI_B) {
+      needs.push({ label: 'science points', delta: sciGap });
+    } else {
+      needs.push({ label: 'advanced facts', delta: factsGap });
+    }
+  } else if (target === 'A') {
+    if (sci   < SCI_A)   needs.push({ label: 'science points', delta: SCI_A - sci });
+    if (facts < FACTS_A) needs.push({ label: 'advanced facts', delta: FACTS_A - facts });
+    if (alive < CREW_A)  needs.push({ label: 'crew alive',     delta: CREW_A - alive });
+  } else if (target === 'S') {
+    if (sci   < SCI_S)   needs.push({ label: 'science points', delta: SCI_S - sci });
+    if (facts < FACTS_S) needs.push({ label: 'advanced facts', delta: FACTS_S - facts });
+    if (alive < totalCrew) {
+      needs.push({ label: 'all crew alive', delta: totalCrew - alive, hard: true });
+    }
+  }
+  if (needs.length === 0) return null;
+  return { currentRank: current, nextRank: target, needs };
 }
 
 export function computeScore(state) {
@@ -35,7 +102,7 @@ export function computeScore(state) {
     : state.totalKmTraveled >= 0.8 * totalRouteKm(state) ? 100 : 0;
   breakdown.push({ label: 'Mission outcome', value: state.status, points: outcomePts });
 
-  const alive = state.crew.filter(c => c.alive).length;
+  const alive = aliveCrewCount(state);
   breakdown.push({ label: 'Crew survived', value: `${alive}/${state.crew.length}`, points: alive * 100 });
 
   const sciPts = Math.min(state.sciencePoints, 300);
@@ -53,7 +120,7 @@ export function computeScore(state) {
   breakdown.push({ label: 'Landmark stops', value: stops, points: stops * 20 });
 
   const points = breakdown.reduce((sum, b) => sum + b.points, 0);
-  return { points, breakdown, rank: rankFor(points, won, state.sciencePoints) };
+  return { points, breakdown, rank: rankFor(state) };
 }
 
 // ---- Best-run persistence ----

--- a/src/systems/travel.js
+++ b/src/systems/travel.js
@@ -130,11 +130,18 @@ export function advanceSol(state, mode = 'travel') {
   }
 
   // ---- Resource consumption (life support always; travel power only when moving) ----
+  // Camp mode (issue #25): rover life-support scales with rover-side crew share —
+  // the away team runs off EVA-kit supplies, not the shared rover reserve. Uses
+  // crew.length (max) as denominator so permanent deaths don't paradoxically
+  // reduce rover drain.
+  const roverShare = (mode === 'camp' && state.awayTeam)
+    ? (state.crew.length - state.awayTeam.crewIds.length) / state.crew.length
+    : 1;
   const careerLifeMult  = state.careerBonuses?.lifeSupportMult || 1;
-  const lifeSupportMult = LIFE_SUPPORT_MULT_BY_PACE[s.pace] * careerLifeMult;
+  const lifeSupportMult = LIFE_SUPPORT_MULT_BY_PACE[s.pace] * careerLifeMult * roverShare;
   s.resources.oxygen = Math.max(0, s.resources.oxygen - O2_PER_SOL  * lifeSupportMult);
   s.resources.water  = Math.max(0, s.resources.water  - H2O_PER_SOL * lifeSupportMult);
-  s.resources.food   = Math.max(0, s.resources.food   - FOOD_PER_SOL[s.rations]);
+  s.resources.food   = Math.max(0, s.resources.food   - FOOD_PER_SOL[s.rations] * roverShare);
 
   // Net power: RTG baseline + solar bonus (×panel efficiency) − travel − cargo weight.
   const panelMult   = s.resources.panels / 100;

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -3,7 +3,7 @@
 // On choice, calls onChoose(choiceIdx) which the caller wires to apply outcomes.
 
 import { linkifyCodex } from './codex.js';
-import { computeScore, loadBestRun, saveBestRun } from '../systems/scoring.js';
+import { computeScore, nextRankGap, loadBestRun, saveBestRun } from '../systems/scoring.js';
 import { CAREER_TIERS, currentTier, nextTier, addCareerScience, loadCareerScience } from '../systems/career.js';
 import pkg from '../../package.json' with { type: 'json' };
 
@@ -396,11 +396,23 @@ export function showEndOfRunModal(state, onNewMission) {
     : score.rank === 'B' || score.rank === 'C' ? 'rank-neutral'
     : 'rank-red';
 
+  const gap = nextRankGap(state);
+  const gapBlock = gap
+    ? `<div class="eor-rank-gap">
+         To earn <strong>${gap.nextRank}</strong>:
+         ${gap.needs.map(n => {
+            const hardTag = n.hard ? ' <span class="eor-gap-hard">(next run)</span>' : '';
+            return `<span class="eor-gap-need">${n.delta} more ${escapeHtml(n.label)}${hardTag}</span>`;
+          }).join(' · ')}
+       </div>`
+    : (won ? '<div class="eor-rank-gap eor-rank-max">Maximum rank achieved.</div>' : '');
+
   const rankBlock = `
     <div class="eor-rank">
       <div class="eor-rank-label">MISSION RANK</div>
       <div class="eor-rank-letter ${rankClass}">${score.rank}</div>
       <div class="eor-rank-points">${score.points.toLocaleString()} points</div>
+      ${gapBlock}
       <table class="eor-rank-breakdown">
         ${score.breakdown.map(b => `
           <tr>

--- a/styles/components.css
+++ b/styles/components.css
@@ -819,3 +819,34 @@ body[data-theme="lcars"] .crew-bubble::before { display: none; }
   color: #ee99ff;
   margin-bottom: 0.3rem;
 }
+
+/* ---- End-of-run "next rank gap" (issue #24) ---- */
+
+.eor-rank-gap {
+  margin: 0.5rem 0 0.75rem;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  text-align: center;
+  color: var(--fg-dim, #cc99cc);
+  border: 1px dashed var(--accent-dim, #4d3a5c);
+  border-radius: 3px;
+  background: rgba(80, 60, 100, 0.08);
+}
+.eor-rank-gap strong {
+  color: #ee99ff;
+}
+.eor-rank-gap .eor-gap-need {
+  display: inline-block;
+  margin: 0 0.25rem;
+}
+.eor-rank-gap .eor-gap-hard {
+  font-size: 0.75rem;
+  color: #ff9999;
+  letter-spacing: 0.08em;
+}
+.eor-rank-gap.eor-rank-max {
+  color: #ee99ff;
+  border-color: #ee99ff;
+  background: rgba(140, 80, 180, 0.12);
+}


### PR DESCRIPTION
## Summary

Paired balance pass for v0.7.0's away-team mechanic.

- **#25** — Camp-mode life support scales with rover-side crew share. The away team runs off EVA kit, not the shared reserve. Denominator is max crew (not alive) so deaths don't paradoxically reduce drain.
- **#24** — Rank is now a checklist of gates, not a point-threshold sum. Surviving is C. Science + learning earn A. Science + learning + all-crew-alive earn S. Points stay for leaderboard / best-run.
- End-of-run modal surfaces directional feedback: \"To earn A: 80 more science points · 1 more advanced fact · 1 more crew alive.\"

Closes #24 · Closes #25.

## Test plan

- [x] \`node --test sim/*.test.mjs\` → 95/95 green
- [x] \`node sim/playtest1000.mjs\` reports distributions under the new scoring
- [ ] Browser: finish a run, verify the next-rank gap text is accurate and updates per run
- [ ] Browser: accept a divert with 2/5 crew sent, confirm rover drain drops to 3/5 across the camp sols
- [ ] Verify S is not trivially reachable (expected — all-crew-alive gate is hard) but plausible for a careful science-focused run

🤖 Generated with [Claude Code](https://claude.com/claude-code)