### PR TITLE
EOR modal: two-column layout (fixes #27)

### DIFF
--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -432,17 +432,22 @@ export function showEndOfRunModal(state, onNewMission) {
         <h2 class="modal-title eor-title">${outcomeTitle}</h2>
         ${reasonBlock}
 
-        ${rankBlock}
-        ${careerCreditLine}
-        <div class="eor-stats">
-          <div class="eor-stat"><span class="eor-stat-label">SOLS</span><span class="eor-stat-value">${state.sol}</span></div>
-          <div class="eor-stat"><span class="eor-stat-label">KM TRAVELED</span><span class="eor-stat-value">${km.toLocaleString()}</span></div>
-          <div class="eor-stat"><span class="eor-stat-label">CREW SURVIVED</span><span class="eor-stat-value">${survived}/${total}</span></div>
-          <div class="eor-stat eor-stat-science"><span class="eor-stat-label">SCIENCE</span><span class="eor-stat-value">${state.sciencePoints}</span></div>
+        <div class="eor-columns">
+          <div class="eor-col eor-col-stats">
+            ${rankBlock}
+            ${careerCreditLine}
+            <div class="eor-stats">
+              <div class="eor-stat"><span class="eor-stat-label">SOLS</span><span class="eor-stat-value">${state.sol}</span></div>
+              <div class="eor-stat"><span class="eor-stat-label">KM TRAVELED</span><span class="eor-stat-value">${km.toLocaleString()}</span></div>
+              <div class="eor-stat"><span class="eor-stat-label">CREW SURVIVED</span><span class="eor-stat-value">${survived}/${total}</span></div>
+              <div class="eor-stat eor-stat-science"><span class="eor-stat-label">SCIENCE</span><span class="eor-stat-value">${state.sciencePoints}</span></div>
+            </div>
+            ${deadBlock}
+          </div>
+          <div class="eor-col eor-col-facts">
+            ${factsBlock}
+          </div>
         </div>
-
-        ${deadBlock}
-        ${factsBlock}
 
         <button class="modal-continue primary" id="eor-new" type="button">NEW MISSION →</button>
       </div>

--- a/styles/components.css
+++ b/styles/components.css
@@ -850,3 +850,25 @@ body[data-theme="lcars"] .crew-bubble::before { display: none; }
   border-color: #ee99ff;
   background: rgba(140, 80, 180, 0.12);
 }
+
+/* ---- End-of-run two-column layout (issue #27) ---- */
+
+.eor-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 1.25rem;
+  align-items: start;
+  margin: 0.5rem 0 1rem;
+}
+.eor-col {
+  min-width: 0;   /* allow children to shrink inside the grid cell */
+}
+.eor-col-facts .eor-facts {
+  margin-top: 0;  /* facts block provides its own spacing in single-col mode */
+}
+
+@media (max-width: 720px) {
+  .eor-columns {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Pure reflow. Stats on left, facts on right. Collapses to single column on narrow screens.