### PR TITLE
Waypoints: floor of 2 per run (fixes #34)

### DIFF
--- a/sim/waypoints.test.mjs
+++ b/sim/waypoints.test.mjs
@@ -10,7 +10,8 @@ import assert from 'node:assert/strict';
 import {
   rollWaypoints,
   declineWaypoint,
-  WAYPOINT_ROLL_PROB
+  WAYPOINT_ROLL_PROB,
+  MIN_WAYPOINTS_PER_RUN
 } from '../src/systems/waypoints.js';
 
 function makeState(overrides = {}) {
@@ -32,10 +33,10 @@ function makeState(overrides = {}) {
 
 // --- rollWaypoints ---
 
-test('rollWaypoints produces 0–6 waypoints on a standard route', () => {
+test('rollWaypoints produces between MIN and 6 waypoints on a standard route', () => {
   for (let i = 0; i < 50; i++) {
     const s = rollWaypoints(makeState());
-    assert.ok(s.waypoints.length >= 0 && s.waypoints.length <= 6,
+    assert.ok(s.waypoints.length >= MIN_WAYPOINTS_PER_RUN && s.waypoints.length <= 6,
       `waypoints.length=${s.waypoints.length} out of range`);
     const segs = s.waypoints.map(w => w.segmentIdx);
     assert.equal(new Set(segs).size, segs.length, 'duplicate segmentIdx');
@@ -46,6 +47,16 @@ test('rollWaypoints produces 0–6 waypoints on a standard route', () => {
         `segmentIdx ${entry.segmentIdx} out of range [1, ${s.route.length - 1})`);
     }
   }
+});
+
+test('rollWaypoints enforces the per-run floor across many runs (issue #34)', () => {
+  let minSeen = Infinity;
+  for (let i = 0; i < 500; i++) {
+    const s = rollWaypoints(makeState());
+    if (s.waypoints.length < minSeen) minSeen = s.waypoints.length;
+  }
+  assert.equal(minSeen, MIN_WAYPOINTS_PER_RUN,
+    `min waypoints seen across 500 runs was ${minSeen}; floor was not enforced`);
 });
 
 test('rollWaypoints gives every eligible landmark a fair chance over many runs', () => {

--- a/src/systems/waypoints.js
+++ b/src/systems/waypoints.js
@@ -9,23 +9,48 @@
 import { WAYPOINTS } from '../content/waypoints.js';
 
 export const WAYPOINT_ROLL_PROB = 0.4;   // per non-final segment
+export const MIN_WAYPOINTS_PER_RUN = 2;  // issue #34
 
 // ---- Run-start roll ----
 // Picks at most one waypoint per eligible segment. segmentIdx matches the
 // currentLandmarkIndex at which the offer fires (arrival at landmark N →
 // offer segment N waypoint). Skip 0 (origin — never "arrived at") and the
 // final landmark (mission complete — no encounter). Issue #22.
+//
+// Two-pass roll: probabilistic per-segment pass as normal, then a top-up
+// pass that fills empty segments until MIN_WAYPOINTS_PER_RUN is reached
+// (issue #34) — a run without a science path would lock the player at B.
 export function rollWaypoints(state) {
-  const used = new Set();
+  const usedIds = new Set();
+  const usedSegments = new Set();
   const waypoints = [];
+
+  // Pass 1: probabilistic roll per eligible segment.
   for (let segmentIdx = 1; segmentIdx < state.route.length - 1; segmentIdx++) {
     if (Math.random() >= WAYPOINT_ROLL_PROB) continue;
-    const candidates = WAYPOINTS.filter(w => !used.has(w.id));
+    const candidates = WAYPOINTS.filter(w => !usedIds.has(w.id));
     if (candidates.length === 0) break;
     const pick = candidates[Math.floor(Math.random() * candidates.length)];
-    used.add(pick.id);
+    usedIds.add(pick.id);
+    usedSegments.add(segmentIdx);
     waypoints.push({ waypointId: pick.id, segmentIdx });
   }
+
+  // Pass 2: top-up until we hit the per-run floor (or run out of room).
+  while (waypoints.length < MIN_WAYPOINTS_PER_RUN) {
+    const empty = [];
+    for (let segmentIdx = 1; segmentIdx < state.route.length - 1; segmentIdx++) {
+      if (!usedSegments.has(segmentIdx)) empty.push(segmentIdx);
+    }
+    const candidates = WAYPOINTS.filter(w => !usedIds.has(w.id));
+    if (empty.length === 0 || candidates.length === 0) break;
+    const segmentIdx = empty[Math.floor(Math.random() * empty.length)];
+    const pick = candidates[Math.floor(Math.random() * candidates.length)];
+    usedIds.add(pick.id);
+    usedSegments.add(segmentIdx);
+    waypoints.push({ waypointId: pick.id, segmentIdx });
+  }
+
   return { ...state, waypoints };
 }
 


### PR DESCRIPTION
Top-up pass in rollWaypoints guarantees the minimum floor. Science path always available.