### PR TITLE
Death dialog modal (fixes #33)

### DIFF
--- a/sim/awayTeam.test.mjs
+++ b/sim/awayTeam.test.mjs
@@ -368,3 +368,24 @@ test('camp supply scaling uses max crew count, not alive count (permanent deaths
   assert.ok(Math.abs(campO2Drain / travelO2Drain - 3/5) < 0.01,
     `expected 3/5 (max-crew), got ${(campO2Drain / travelO2Drain).toFixed(3)}`);
 });
+
+// --- Death queue (issue #33) ---
+
+import { applyDamage } from '../src/systems/crew.js';
+
+test('applyDamage appends to deathQueue when a crew member dies', () => {
+  const s0 = makeState({ deathQueue: [] });
+  const { state: s1 } = applyDamage(s0, 'c1', 999, 'event injuries');
+  assert.equal(s1.crew.find(c => c.id === 'c1').alive, false);
+  assert.equal(s1.deathQueue.length, 1);
+  assert.equal(s1.deathQueue[0].crewId, 'c1');
+  assert.equal(s1.deathQueue[0].cause, 'event injuries');
+  assert.equal(s1.deathQueue[0].role, 'engineer');
+});
+
+test('applyDamage does NOT append to deathQueue when the victim survives', () => {
+  const s0 = makeState({ deathQueue: [] });
+  const { state: s1 } = applyDamage(s0, 'c1', 10, 'fatigue');
+  assert.ok(s1.crew.find(c => c.id === 'c1').alive);
+  assert.equal((s1.deathQueue || []).length, 0);
+});

--- a/src/content/deathNarratives.js
+++ b/src/content/deathNarratives.js
@@ -1,0 +1,49 @@
+// Mars Trail — per-cause death narratives (issue #33).
+// Small lookup used by showDeathDialog to render one-sentence context
+// under the \"[Name] ([ROLE]) is gone.\" headline. Functions receive the
+// death entry so they can weave in the crew member's name.
+
+function n(entry) { return entry.name; }
+
+const NARRATIVES = {
+  fatigue:                  e => `The cumulative wear caught up. ${n(e)} did not wake for the morning watch.`,
+  hypoxia:                  e => `Thin cabin O₂ finally tipped past recoverable. ${n(e)} slipped under during the night.`,
+  dehydration:              e => `Water rationing held until it didn't. ${n(e)}'s kidneys gave out.`,
+  malnutrition:             e => `Weeks of half-rations stripped the reserve. ${n(e)} went quiet mid-conversation.`,
+  'life support failure':   e => `When the power dropped, heat went with it. ${n(e)} was already gone by the time the batteries came back.`,
+  'event injuries':         e => `The injuries from earlier proved too deep. ${n(e)} bled out before the medic could reach them.`,
+  'away-team hazard':       e => `The site had teeth. ${n(e)}'s suit telemetry went flat at the sample face — the rest of the team brought the data back.`,
+  'medical complications':  e => `Triage ran out of options. ${n(e)} was pronounced at ${String((Math.floor(Math.random() * 24)).toString().padStart(2,'0'))}:${String((Math.floor(Math.random() * 60)).toString().padStart(2,'0'))} LMST.`,
+  'surgical complications': e => `The operation found more damage than the diagnosis suggested. ${n(e)} did not come off the table.`,
+  'travel stress':          e => `The push to the next landmark was more than the body could hold. ${n(e)} died in transit.`,
+  'delayed diagnosis':      e => `The Earth-comms lag cost too many minutes. ${n(e)} was beyond help by the time the plan came back.`,
+  'misdiagnosis':           e => `The exam missed the root problem. ${n(e)} crashed while the crew was still treating the wrong thing.`,
+  'adverse reaction':       e => `The improvised dose went wrong. ${n(e)} coded within the hour.`,
+  injuries:                 e => `The wound was more than the kit could hold. ${n(e)} is gone.`
+};
+
+// Lookup with graceful fallback for unknown causes.
+export function deathNarrative(entry) {
+  const fn = NARRATIVES[entry.cause];
+  if (fn) return fn(entry);
+  return `${n(entry)} succumbed to ${entry.cause || 'injuries'} before the crew could intervene.`;
+}
+
+// Specialist-loss strategic reminder. null if the role is fungible or a
+// replacement specialist is still alive.
+export function specialistLossNote(role, state) {
+  const stillAlive = state.crew.some(c => c.role === role && c.alive);
+  if (stillAlive) return null;
+  switch (role) {
+    case 'engineer':
+      return 'No engineer remains — MECH and CELL skill checks take a major penalty.';
+    case 'medic':
+      return 'No medic remains — all background damage applies at full strength; medical emergency surgeries become far harder.';
+    case 'pilot':
+      return 'No pilot remains — travel km/sol loses its bonus and daily variance widens.';
+    case 'biologist':
+      return 'No biologist remains — water and astrobiology skill checks take a major penalty.';
+    default:
+      return null;   // security role is fungible
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { createInitialState, CARGO_BUDGET, PART_TYPES } from './state.js';
 import { render } from './render.js';
 import { advanceSol, setPace, setRations, repairBattery, cleanPanels } from './systems/travel.js';
 import { applyEventChoice } from './systems/events.js';
-import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, showTitleLayer, dimTitleStart, hideTitleLayer, showEndOfRunModal, closeModal, showWaypointOfferModal, showMultiStageModal, showAwayTeamPickerModal, showAwayTeamReunionModal } from './ui/modals.js';
+import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, showTitleLayer, dimTitleStart, hideTitleLayer, showEndOfRunModal, closeModal, showWaypointOfferModal, showMultiStageModal, showAwayTeamPickerModal, showAwayTeamReunionModal, showDeathDialog } from './ui/modals.js';
 import { declineWaypoint } from './systems/waypoints.js';
 import { applyStageChoice } from './systems/multiStage.js';
 import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from './systems/awayTeam.js';
@@ -80,6 +80,18 @@ function renderAll() {
   }
 
   const modal = state.activeModal;
+
+  // Death queue drains before any gameplay modal — setup screens unaffected.
+  const isSetup = modal && ['title', 'briefing', 'loadout'].includes(modal.type);
+  if (!isSetup && state.deathQueue && state.deathQueue.length > 0) {
+    const entry = state.deathQueue[0];
+    showDeathDialog(entry, state, () => {
+      state = { ...state, deathQueue: state.deathQueue.slice(1) };
+      renderAll();
+    });
+    return;
+  }
+
   if (!modal) { closeModal(); return; }
 
   if (modal.type === 'title') {

--- a/src/state.js
+++ b/src/state.js
@@ -85,6 +85,7 @@ export function createInitialState() {
     sciencePoints: 0,
     factsLearned: [],
     firedEvents: [],   // IDs of one-shot events already triggered this run
+    deathQueue:  [],   // [{crewId,name,role,cause,sol}] — drained by UI death dialog (#33)
     waypoints:       [],    // [{ waypointId, segmentIdx }] — rolled at run start
     firedWaypoints:  [],    // ids already resolved or declined
     awayTeam:        null,  // see src/systems/awayTeam.js for shape

--- a/src/systems/crew.js
+++ b/src/systems/crew.js
@@ -45,6 +45,14 @@ export function applyDamage(state, targetSpec, rawAmount, cause) {
       sol: s.sol,
       text: `${target.name} (${target.role.toUpperCase()}) succumbed to ${cause || 'injuries'}.`
     });
+    // Queue a death dialog for the UI dispatcher to surface (issue #33).
+    s.deathQueue = [...(s.deathQueue || []), {
+      crewId: target.id,
+      name:   target.name,
+      role:   target.role,
+      cause:  cause || 'injuries',
+      sol:    s.sol
+    }];
   }
   return { state: s, target, died, dealt };
 }

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -5,6 +5,7 @@
 import { linkifyCodex } from './codex.js';
 import { computeScore, nextRankGap, loadBestRun, saveBestRun } from '../systems/scoring.js';
 import { CAREER_TIERS, currentTier, nextTier, addCareerScience, loadCareerScience } from '../systems/career.js';
+import { deathNarrative, specialistLossNote } from '../content/deathNarratives.js';
 import pkg from '../../package.json' with { type: 'json' };
 
 const root = () => document.getElementById('modal-root');
@@ -460,6 +461,33 @@ export function showEndOfRunModal(state, onNewMission) {
 export function closeModal() {
   const r = root();
   if (r) r.innerHTML = '';
+}
+
+// ---- Death dialog (issue #33) ----
+
+export function showDeathDialog(entry, state, onAcknowledge) {
+  const r = root();
+  if (!r) return;
+
+  const narrative = deathNarrative(entry);
+  const specialistNote = specialistLossNote(entry.role, state);
+  const noteBlock = specialistNote
+    ? `<div class="death-specialist-loss">${escapeHtml(specialistNote)}</div>`
+    : '';
+
+  r.innerHTML = `
+    <div class="modal-backdrop">
+      <div class="modal-panel modal-death" role="dialog" aria-modal="true" aria-labelledby="death-title">
+        <div class="modal-severity severity-death">⚠ CREW LOSS · SOL ${entry.sol}</div>
+        <h2 class="modal-title death-title" id="death-title">${escapeHtml(entry.name)} <span class="death-role">(${entry.role.toUpperCase()})</span> is gone.</h2>
+        <p class="death-cause"><span class="death-cause-label">CAUSE</span> ${escapeHtml(entry.cause)}</p>
+        <p class="death-narrative">${escapeHtml(narrative)}</p>
+        ${noteBlock}
+        <button class="modal-continue primary" id="death-ack" type="button">CONTINUE →</button>
+      </div>
+    </div>
+  `;
+  r.querySelector('#death-ack').addEventListener('click', onAcknowledge);
 }
 
 // ---- Waypoint offer modal (issue #7 part 1) ----

--- a/styles/components.css
+++ b/styles/components.css
@@ -903,3 +903,51 @@ body[data-theme="lcars"] .eor-col-facts {
     max-height: 240px;        /* restore scroll cap for stacked layout */
   }
 }
+
+/* ---- Death dialog (issue #33) ---- */
+
+.modal-panel.modal-death {
+  border-top: 3px solid var(--crit, #ef4444);
+}
+.modal-severity.severity-death {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ff9999;
+  letter-spacing: 0.2em;
+}
+.death-title {
+  color: var(--fg);
+}
+.death-title .death-role {
+  font-size: 0.7em;
+  letter-spacing: 0.15em;
+  color: var(--fg-dim);
+  margin-left: 0.3em;
+}
+.death-cause {
+  margin: 0.5rem 0 0.3rem;
+  font-size: 0.85rem;
+  color: var(--fg-dim);
+}
+.death-cause .death-cause-label {
+  display: inline-block;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  color: #ff9999;
+  margin-right: 0.5em;
+}
+.death-narrative {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--fg);
+  font-style: italic;
+}
+.death-specialist-loss {
+  margin: 0.5rem 0 0.75rem;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.82rem;
+  color: #ffcc99;
+  border-left: 3px solid #ffaa66;
+  background: rgba(255, 170, 102, 0.08);
+  border-radius: 2px;
+}


### PR DESCRIPTION
Dedicated modal when a crew member dies. Cause, narrative, and specialist-loss note. Queue-drained before gameplay modals so deaths can't be missed.