### PR TITLE
Expanded medical emergency (fixes #32)

### DIFF
--- a/sim/medicalEmergency.test.mjs
+++ b/sim/medicalEmergency.test.mjs
@@ -4,11 +4,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   pickPatient,
+  pickAilment,
   beginMedicalEmergency,
   resolveMedicalStage,
+  getMedicalStageView,
   MEDICAL_EMERGENCY_ID
 } from '../src/systems/medicalEmergency.js';
-import { MEDICAL_EMERGENCY } from '../src/content/medicalEmergency.js';
+import { MEDICAL_EMERGENCY, AILMENTS } from '../src/content/medicalEmergency.js';
 
 function makeState(overrides = {}) {
   return {
@@ -40,8 +42,7 @@ function withRandom(values, fn) {
   finally { Math.random = original; }
 }
 
-// A medical modal with an explicit patient (skips the random patient pick).
-function openAt(state, stageId, patientId = 'c2', selfTreat = false) {
+function openAt(state, stageId, patientId = 'c2', selfTreat = false, ailmentId = 'appendicitis') {
   return {
     ...state,
     activeModal: {
@@ -50,40 +51,42 @@ function openAt(state, stageId, patientId = 'c2', selfTreat = false) {
         event:   MEDICAL_EMERGENCY,
         stageId,
         source:  'medical',
-        context: { patientId, selfTreat }
+        context: { patientId, selfTreat, ailmentId }
       }
     }
   };
 }
 
-function choiceIdx(stageId, key) {
-  return MEDICAL_EMERGENCY.stages[stageId].choices.findIndex(c => c.key === key);
+function idx(state, stageId, key, patientId = 'c2', selfTreat = false, ailmentId = 'appendicitis') {
+  const view = getMedicalStageView(state, stageId, { patientId, selfTreat, ailmentId });
+  return view.choices.findIndex(c => c.key === key);
 }
 
-// --- Shape / registry ---
+// --- Registry ---
 
-test('event id is stable', () => {
+test('event id stable; one-shot; severity=medical', () => {
   assert.equal(MEDICAL_EMERGENCY_ID, 'medical_emergency');
   assert.equal(MEDICAL_EMERGENCY.oneShot, true);
+  assert.equal(MEDICAL_EMERGENCY.severity, 'medical');
 });
 
-test('stages have choices with keys; no dangling nextStage refs', () => {
-  for (const [stageId, stage] of Object.entries(MEDICAL_EMERGENCY.stages)) {
-    assert.ok(stage.choices.length > 0, `${stageId} has no choices`);
-    for (const c of stage.choices) assert.ok(c.key, `${stageId}: choice missing key`);
+test('AILMENTS pool has ≥6 entries, each with id/label/symptom/cause', () => {
+  assert.ok(AILMENTS.length >= 6);
+  for (const a of AILMENTS) {
+    assert.ok(a.id && a.label && a.symptom && a.cause,
+      `ailment ${a.id || '?'} missing a field`);
   }
 });
 
-// --- pickPatient ---
+// --- Patient + ailment selection ---
 
 test('pickPatient selects a non-medic when one is alive', () => {
-  const s = makeState();
-  const pick = withRandom([0.0], () => pickPatient(s));
-  assert.notEqual(pick.id, 'c3');  // medic
+  const pick = withRandom([0.0], () => pickPatient(makeState()));
+  assert.notEqual(pick.id, 'c3');
   assert.equal(pick.selfTreat, false);
 });
 
-test('pickPatient selects the medic only when medic is the only alive crew', () => {
+test('pickPatient selects the medic only when medic is the sole survivor', () => {
   const s = makeState({
     crew: [
       { id: 'c1', name: 'A', role: 'engineer', health: 0, status: 'dead', alive: false },
@@ -98,86 +101,67 @@ test('pickPatient selects the medic only when medic is the only alive crew', () 
   assert.equal(pick.selfTreat, true);
 });
 
+test('pickAilment returns an entry from AILMENTS', () => {
+  const a = pickAilment();
+  assert.ok(AILMENTS.some(e => e.id === a.id));
+});
+
 // --- beginMedicalEmergency ---
 
-test('beginMedicalEmergency opens the diagnose stage and marks fired', () => {
-  const s0 = makeState();
-  const s1 = beginMedicalEmergency(s0);
-  assert.equal(s1.activeModal.type, 'multi_stage');
-  assert.equal(s1.activeModal.payload.source, 'medical');
-  assert.equal(s1.activeModal.payload.stageId, 'diagnose');
+test('beginMedicalEmergency opens diagnose with full context', () => {
+  const s1 = beginMedicalEmergency(makeState());
+  const p = s1.activeModal.payload;
+  assert.equal(p.source, 'medical');
+  assert.equal(p.stageId, 'diagnose');
+  assert.ok(p.context.patientId);
+  assert.ok(AILMENTS.some(a => a.id === p.context.ailmentId));
   assert.ok(s1.firedEvents.includes(MEDICAL_EMERGENCY_ID));
 });
 
-// --- diagnose stage ---
+// --- Stage view ---
 
-test('diagnose: consult-medic success goes to treat with no damage', () => {
+test('diagnose view weaves patient name + ailment symptom into description', () => {
+  const s = makeState();
+  const view = getMedicalStageView(s, 'diagnose', { patientId: 'c2', selfTreat: false, ailmentId: 'appendicitis' });
+  assert.ok(view.description.includes('Riya'));
+  const ailment = AILMENTS.find(a => a.id === 'appendicitis');
+  assert.ok(view.description.includes(ailment.symptom));
+  assert.equal(view.title, `Medical Emergency — ${ailment.label}`);
+});
+
+test('diagnose view swaps medic→self_triage when selfTreat', () => {
+  const s = makeState();
+  const normal = getMedicalStageView(s, 'diagnose', { patientId: 'c2', selfTreat: false, ailmentId: 'cardiac_arrhythmia' });
+  assert.ok(normal.choices.some(c => c.key === 'medic'));
+  assert.ok(!normal.choices.some(c => c.key === 'self_triage'));
+
+  const self = getMedicalStageView(s, 'diagnose', { patientId: 'c3', selfTreat: true, ailmentId: 'cardiac_arrhythmia' });
+  assert.ok(!self.choices.some(c => c.key === 'medic'));
+  assert.ok(self.choices.some(c => c.key === 'self_triage'));
+});
+
+test('treat view swaps surgery→crew_surgery when selfTreat', () => {
+  const s = makeState();
+  const normal = getMedicalStageView(s, 'treat', { patientId: 'c2', selfTreat: false, ailmentId: 'appendicitis' });
+  assert.ok(normal.choices.some(c => c.key === 'surgery'));
+
+  const self = getMedicalStageView(s, 'treat', { patientId: 'c3', selfTreat: true, ailmentId: 'appendicitis' });
+  assert.ok(!self.choices.some(c => c.key === 'surgery'));
+  assert.ok(self.choices.some(c => c.key === 'crew_surgery'));
+});
+
+// --- Diagnose resolver ---
+
+test('diagnose: consult-medic success routes to treat with no damage', () => {
   const s0 = openAt(makeState(), 'diagnose');
-  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'medic')));
+  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, idx(s0, 'diagnose', 'medic')));
   assert.equal(s1.activeModal.payload.stageId, 'treat');
-  const patient = s1.crew.find(c => c.id === 'c2');
-  assert.equal(patient.health, 100);
+  assert.equal(s1.crew.find(c => c.id === 'c2').health, 100);
 });
 
-test('diagnose: consult-medic fail damages patient', () => {
-  const s0 = openAt(makeState(), 'diagnose');
-  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'medic')));
-  assert.equal(s1.activeModal.payload.stageId, 'treat');
-  const patient = s1.crew.find(c => c.id === 'c2');
-  assert.equal(patient.health, 90);
-});
-
-test('diagnose: consult-earth drains resources and worsens patient', () => {
-  const s0 = openAt(makeState(), 'diagnose');
-  const s1 = resolveMedicalStage(s0, choiceIdx('diagnose', 'earth'));
-  assert.equal(s1.activeModal.payload.stageId, 'treat');
-  assert.ok(s1.resources.oxygen < 80);
-  assert.ok(s1.resources.water < 80);
-  const patient = s1.crew.find(c => c.id === 'c2');
-  assert.equal(patient.health, 80);
-});
-
-test('diagnose: hope stabilizes 40% (ends chain)', () => {
-  const s0 = openAt(makeState(), 'diagnose');
-  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'hope')));
-  assert.equal(s1.activeModal, null);
-});
-
-test('diagnose: hope fail worsens patient heavily, routes to treat', () => {
-  const s0 = openAt(makeState(), 'diagnose');
-  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('diagnose', 'hope')));
-  assert.equal(s1.activeModal.payload.stageId, 'treat');
-  const patient = s1.crew.find(c => c.id === 'c2');
-  assert.equal(patient.health, 70);
-});
-
-// --- treat stage ---
-
-test('treat: surgery success ends chain with patient stable', () => {
-  const s0 = openAt(makeState(), 'treat');
-  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
-  assert.equal(s1.activeModal, null);
-  const patient = s1.crew.find(c => c.id === 'c2');
-  assert.ok(patient.alive);
-});
-
-test('treat: surgery fail kills patient and routes to dispose', () => {
-  const s0 = openAt(makeState(), 'treat');
-  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
-  assert.equal(s1.activeModal.payload.stageId, 'dispose');
-  const patient = s1.crew.find(c => c.id === 'c2');
-  assert.equal(patient.alive, false);
-});
-
-test('treat: surgery fail with medic alive & not patient appends the medic flavor line', () => {
-  const s0 = openAt(makeState(), 'treat', 'c2', /* selfTreat */ false);
-  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
-  assert.ok(s1.log.some(l => l.text === 'Well, there goes paradise.'));
-});
-
-test('treat: surgery fail when medic is the patient does NOT emit the flavor line', () => {
-  // Only medic is alive → selfTreat path. Patient is the medic.
-  const s0 = openAt(makeState({
+test('diagnose: self-triage uses lower P (0.45)', () => {
+  // Solo medic, self_triage, rand=0.50 → above 0.45 → fail → patient damaged.
+  const base = makeState({
     crew: [
       { id: 'c1', name: 'A', role: 'engineer', health: 0, status: 'dead', alive: false },
       { id: 'c2', name: 'B', role: 'biologist',health: 0, status: 'dead', alive: false },
@@ -185,81 +169,98 @@ test('treat: surgery fail when medic is the patient does NOT emit the flavor lin
       { id: 'c4', name: 'D', role: 'pilot',    health: 0, status: 'dead', alive: false },
       { id: 'c5', name: 'E', role: 'security', health: 0, status: 'dead', alive: false }
     ]
-  }), 'treat', 'c3', /* selfTreat */ true);
-  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
+  });
+  const s0 = openAt(base, 'diagnose', 'c3', true, 'cardiac_arrhythmia');
+  const s1 = withRandom([0.50], () => resolveMedicalStage(s0, idx(s0, 'diagnose', 'self_triage', 'c3', true, 'cardiac_arrhythmia')));
+  assert.equal(s1.activeModal.payload.stageId, 'treat');
+  assert.equal(s1.crew.find(c => c.id === 'c3').health, 90);
+});
+
+// --- Treat resolver ---
+
+test('treat: surgery success stabilizes patient', () => {
+  const s0 = openAt(makeState(), 'treat');
+  const s1 = withRandom([0.01], () => resolveMedicalStage(s0, idx(s0, 'treat', 'surgery')));
+  assert.equal(s1.activeModal, null);
+  assert.ok(s1.crew.find(c => c.id === 'c2').alive);
+});
+
+test('treat: surgery fail kills patient, routes to dispose, flavor line appended', () => {
+  const s0 = openAt(makeState(), 'treat');
+  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, idx(s0, 'treat', 'surgery')));
+  assert.equal(s1.activeModal.payload.stageId, 'dispose');
+  assert.equal(s1.crew.find(c => c.id === 'c2').alive, false);
+  assert.ok(s1.log.some(l => l.text === 'Well, there goes paradise.'));
+});
+
+test('treat: crew_surgery (medic is patient) has lower P (0.30), no flavor line', () => {
+  const base = makeState({
+    crew: [
+      { id: 'c1', name: 'A', role: 'engineer', health: 0, status: 'dead', alive: false },
+      { id: 'c2', name: 'B', role: 'biologist',health: 0, status: 'dead', alive: false },
+      { id: 'c3', name: 'C', role: 'medic',    health: 100, status: 'healthy', alive: true },
+      { id: 'c4', name: 'D', role: 'pilot',    health: 0, status: 'dead', alive: false },
+      { id: 'c5', name: 'E', role: 'security', health: 0, status: 'dead', alive: false }
+    ]
+  });
+  const s0 = openAt(base, 'treat', 'c3', true, 'cardiac_arrhythmia');
+  // rand=0.35 > 0.30 threshold → fail
+  const s1 = withRandom([0.35], () => resolveMedicalStage(s0, idx(s0, 'treat', 'crew_surgery', 'c3', true, 'cardiac_arrhythmia')));
+  assert.equal(s1.activeModal.payload.stageId, 'dispose');
   assert.ok(!s1.log.some(l => l.text === 'Well, there goes paradise.'));
 });
 
-test('treat: stabilize-push damages patient; survival ends chain, death routes to dispose', () => {
-  // Survives (starts at 100, takes 15 → 85).
-  const s0 = openAt(makeState(), 'treat');
-  const s1 = resolveMedicalStage(s0, choiceIdx('treat', 'push'));
-  assert.equal(s1.activeModal, null);
-  const p1 = s1.crew.find(c => c.id === 'c2');
-  assert.equal(p1.health, 85);
-
-  // Dies (starts at 10, takes 15 → 0).
-  const s2Base = makeState({
+test('treat: stabilize-push damages patient; dies routes to dispose', () => {
+  const weak = makeState({
     crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 10 } : c)
   });
-  const s2 = openAt(s2Base, 'treat');
-  const s3 = resolveMedicalStage(s2, choiceIdx('treat', 'push'));
-  assert.equal(s3.activeModal?.payload.stageId, 'dispose');
-  const p2 = s3.crew.find(c => c.id === 'c2');
-  assert.equal(p2.alive, false);
+  const s0 = openAt(weak, 'treat');
+  const s1 = resolveMedicalStage(s0, idx(s0, 'treat', 'push'));
+  assert.equal(s1.activeModal?.payload.stageId, 'dispose');
 });
 
-test('treat: coma burns resources, keeps patient alive, ends chain', () => {
+test('treat: coma burns resources, ends chain', () => {
   const s0 = openAt(makeState(), 'treat');
-  const s1 = resolveMedicalStage(s0, choiceIdx('treat', 'coma'));
+  const s1 = resolveMedicalStage(s0, idx(s0, 'treat', 'coma'));
   assert.equal(s1.activeModal, null);
   assert.ok(s1.resources.power < 80);
-  assert.ok(s1.resources.oxygen < 80);
-  const patient = s1.crew.find(c => c.id === 'c2');
-  assert.ok(patient.alive);
 });
 
-// --- dispose stage ---
+// --- Dispose resolver ---
 
-test('dispose: bury ends chain, no corpse, grants SCI', () => {
+test('dispose: bury ends chain, no corpse', () => {
   const deadBase = makeState({
-    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 0, alive: false, status: 'dead' } : c)
+    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, alive: false, health: 0, status: 'dead' } : c)
   });
   const s0 = openAt(deadBase, 'dispose');
-  const s1 = resolveMedicalStage(s0, choiceIdx('dispose', 'bury'));
-  assert.equal(s1.activeModal, null);
+  const s1 = resolveMedicalStage(s0, idx(s0, 'dispose', 'bury'));
   assert.equal(s1.corpses.length, 0);
   assert.ok(s1.sciencePoints > 0);
 });
 
 test('dispose: keep adds the corpse', () => {
   const deadBase = makeState({
-    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 0, alive: false, status: 'dead' } : c)
+    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, alive: false, health: 0, status: 'dead' } : c)
   });
   const s0 = openAt(deadBase, 'dispose');
-  const s1 = resolveMedicalStage(s0, choiceIdx('dispose', 'keep'));
-  assert.equal(s1.activeModal, null);
+  const s1 = resolveMedicalStage(s0, idx(s0, 'dispose', 'keep'));
   assert.equal(s1.corpses.length, 1);
   assert.equal(s1.corpses[0].crewId, 'c2');
-  assert.equal(s1.corpses[0].weightLbs, 180);
 });
 
-test('dispose: jettison ends chain with no corpse and a specific log line', () => {
+test('dispose: jettison ends chain with specific log line', () => {
   const deadBase = makeState({
-    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, health: 0, alive: false, status: 'dead' } : c)
+    crew: makeState().crew.map(c => c.id === 'c2' ? { ...c, alive: false, health: 0, status: 'dead' } : c)
   });
   const s0 = openAt(deadBase, 'dispose');
-  const s1 = resolveMedicalStage(s0, choiceIdx('dispose', 'jettison'));
-  assert.equal(s1.activeModal, null);
-  assert.equal(s1.corpses.length, 0);
+  const s1 = resolveMedicalStage(s0, idx(s0, 'dispose', 'jettison'));
   assert.ok(s1.log.some(l => l.text.toLowerCase().includes('jettisoned')));
 });
 
-// --- Self-treat penalty: skill-check success P is lower (0.65 → 0.45). ---
+// --- Death queue integration (#33) ---
 
-test('treat: selfTreat surgery at rand=0.55 fails (above 0.45 cap)', () => {
-  const s0 = openAt(makeState(), 'treat', 'c3', /* selfTreat */ true);
-  const s1 = withRandom([0.55], () => resolveMedicalStage(s0, choiceIdx('treat', 'surgery')));
-  // 0.55 > 0.45 selfTreat threshold → fail → patient dies → dispose
-  assert.equal(s1.activeModal?.payload.stageId, 'dispose');
+test('patient death queues a death-dialog entry', () => {
+  const s0 = openAt(makeState(), 'treat');
+  const s1 = withRandom([0.99], () => resolveMedicalStage(s0, idx(s0, 'treat', 'surgery')));
+  assert.ok((s1.deathQueue || []).some(e => e.crewId === 'c2'));
 });

--- a/src/content/medicalEmergency.js
+++ b/src/content/medicalEmergency.js
@@ -1,50 +1,67 @@
-// Mars Trail — medical emergency event (issue #6).
-// A 3-stage multi-stage event: diagnose → treat → (only if patient dies) dispose.
+// Mars Trail — medical emergency content (issue #6, expanded #32).
 //
-// Stage logic is authored here as data, but resolution runs through
-// src/systems/medicalEmergency.js (not the generic applyStageChoice) so
-// that outcomes can target the specific patient crew member, route
-// conditionally on death, and handle addCorpse for the "keep body" path.
+// The medical event is a 3-stage chain resolved by the custom resolver
+// in src/systems/medicalEmergency.js. Stage VIEWS (title/description/
+// choices) are built per-run by getMedicalStageView so each instance
+// can weave in the specific patient + the rolled ailment + whether the
+// medic is the patient (selfTreat path).
 //
-// Patient is picked at event-fire time by pickPatient(state):
-// first alive non-medic crew member. If only the medic is alive,
-// the medic is the patient and selfTreat=true (skill-check penalty).
+// The static structure below only defines the stage-key skeleton and
+// the ailment pool. All visible text comes from the view builder.
 
 export const MEDICAL_EMERGENCY = {
   id:             'medical_emergency',
   multiStage:     true,
-  customResolver: 'medical',   // opens via beginMedicalEmergency, resolves via resolveMedicalStage
+  customResolver: 'medical',
   weight:         3,
-  severity:       'severe',
+  severity:       'medical',
   oneShot:        true,
   startStage:     'diagnose',
   stages: {
-    diagnose: {
-      title:       'Medical Emergency',
-      description: 'Vitals are dropping. Pain localized. You need a diagnosis — fast.',
-      choices: [
-        { label: 'Consult the medic',           key: 'medic'  },
-        { label: 'Query Earth (comms delay)',   key: 'earth'  },
-        { label: 'Dose from med kit and hope',  key: 'hope'   }
-      ]
-    },
-    treat: {
-      title:       'Treatment Window',
-      description: 'Diagnosis in hand, or close to it. Pick the treatment plan.',
-      choices: [
-        { label: 'Surgery in the rover',         key: 'surgery' },
-        { label: 'Stabilize and push to landmark', key: 'push'   },
-        { label: 'Induced coma — buy time',      key: 'coma'    }
-      ]
-    },
-    dispose: {
-      title:       'Body Disposal',
-      description: 'The patient did not make it. The body is 180 LB of suited mass. Call it.',
-      choices: [
-        { label: 'Bury at next landmark',  key: 'bury'     },
-        { label: 'Keep the body with us',  key: 'keep'     },
-        { label: 'Jettison the suit now',  key: 'jettison' }
-      ]
-    }
+    diagnose: { choices: [] },    // rendered by getMedicalStageView
+    treat:    { choices: [] },
+    dispose:  { choices: [] }
   }
 };
+
+// ---- Ailment pool (#32) ----
+// Each entry carries a headline label, a symptom string woven into the
+// diagnose-stage description, and a short cause for log lines.
+export const AILMENTS = [
+  {
+    id:      'appendicitis',
+    label:   'Appendicitis',
+    symptom: 'Sharp pain, lower right quadrant. Fever spiking. Abdomen rigid to touch.',
+    cause:   'appendix rupture'
+  },
+  {
+    id:      'crush_injury',
+    label:   'Crush Injury',
+    symptom: 'Compression trauma to the torso. Shallow breathing. Internal bleeding likely.',
+    cause:   'EVA rigging accident'
+  },
+  {
+    id:      'radiation_sickness',
+    label:   'Acute Radiation Sickness',
+    symptom: 'Nausea, skin erythema, platelet count dropping. Dosimeter logged a spike during last EVA.',
+    cause:   'solar particle event exposure'
+  },
+  {
+    id:      'cardiac_arrhythmia',
+    label:   'Cardiac Arrhythmia',
+    symptom: 'Irregular rhythm on the monitor. Chest pain, cold sweat, pallor.',
+    cause:   'ischemic cardiac event'
+  },
+  {
+    id:      'perchlorate_exposure',
+    label:   'Perchlorate Exposure',
+    symptom: 'Thyroid panic, dizziness, respiratory distress. Suit log shows a dust breach at the last airlock cycle.',
+    cause:   'perchlorate ingestion'
+  },
+  {
+    id:      'decompression_trauma',
+    label:   'Decompression Trauma',
+    symptom: 'Joint pain, disorientation, skin mottling. Pressure log shows a six-second drop during EVA.',
+    cause:   'suit-pressure fluctuation'
+  }
+];

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, 
 import { declineWaypoint } from './systems/waypoints.js';
 import { applyStageChoice } from './systems/multiStage.js';
 import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from './systems/awayTeam.js';
-import { resolveMedicalStage } from './systems/medicalEmergency.js';
+import { resolveMedicalStage, getMedicalStageView } from './systems/medicalEmergency.js';
 import { WAYPOINTS } from './content/waypoints.js';
 import { makeLandmarkEncounter } from './content/landmarks.js';
 import './ui/codex.js';   // registers global click handler for codex terms
@@ -223,10 +223,14 @@ function renderAll() {
     const { event, stageId, source } = modal.payload;
 
     // Medical emergency uses a custom resolver (patient-targeted damage,
-    // conditional Stage 3, addCorpse). No generic outcome modal — the
-    // resolver emits log lines directly.
+    // conditional Stage 3, addCorpse). Stage view is built per-run from
+    // the payload context (patient + ailment + selfTreat), so we
+    // synthesize an event shape for the modal renderer.
     if (source === 'medical') {
-      showMultiStageModal(event, stageId, (choiceIdx) => {
+      const view = getMedicalStageView(state, stageId, modal.payload.context);
+      if (!view) { state = { ...state, activeModal: null }; renderAll(); return; }
+      const stageEvent = { id: 'medical_emergency', severity: 'medical', stages: { [stageId]: view } };
+      showMultiStageModal(stageEvent, stageId, (choiceIdx) => {
         state = resolveMedicalStage(state, choiceIdx);
         renderAll();
       });

--- a/src/systems/medicalEmergency.js
+++ b/src/systems/medicalEmergency.js
@@ -1,12 +1,14 @@
-// Mars Trail — medical emergency resolver (issue #6).
-// Pure. Custom resolver for the medical_emergency event because the
-// generic applyStageChoice can't target a specific crew member by ID
-// nor conditionally route Stage 3 on the patient's death. Event data
-// lives in src/content/medicalEmergency.js.
+// Mars Trail — medical emergency resolver (issue #6, expanded #32).
+// Pure. Custom resolver because the generic applyStageChoice can't
+// target a specific patient by ID or conditionally route on death.
+// Event data + ailment pool live in src/content/medicalEmergency.js.
 //
-// Flow: pickPatient at fire time → diagnose → treat → (if died) dispose.
+// Flow: pickPatient + pickAilment at fire time → diagnose → treat →
+// (if died) dispose. Stage views are built per-run by
+// getMedicalStageView so text + choices reflect patient, ailment, and
+// whether the medic is themselves the patient (selfTreat path).
 
-import { MEDICAL_EMERGENCY } from '../content/medicalEmergency.js';
+import { MEDICAL_EMERGENCY, AILMENTS } from '../content/medicalEmergency.js';
 import { applyOutcome } from './events.js';
 import { deriveStatus } from './crew.js';
 import { addCorpse } from './corpse.js';
@@ -15,8 +17,6 @@ export const MEDICAL_EMERGENCY_ID = MEDICAL_EMERGENCY.id;
 const MEDIC_FLAVOR_LINE = 'Well, there goes paradise.';
 
 // ---- Patient selection ----
-// First alive non-medic. If only the medic is alive, medic is the patient
-// (selfTreat=true → any subsequent medic skill checks take a -20pp penalty).
 export function pickPatient(state) {
   const alive = state.crew.filter(c => c.alive);
   if (alive.length === 0) return null;
@@ -28,11 +28,16 @@ export function pickPatient(state) {
   return { id: alive[0].id, selfTreat: true };
 }
 
-// ---- Begin the event (called when rolled) ----
-// Sets firedEvents + opens the first stage modal with the patient context.
+// ---- Ailment selection ----
+export function pickAilment() {
+  return AILMENTS[Math.floor(Math.random() * AILMENTS.length)];
+}
+
+// ---- Begin the event ----
 export function beginMedicalEmergency(state) {
   const patient = pickPatient(state);
   if (!patient) return state;
+  const ailment = pickAilment();
   return {
     ...state,
     firedEvents: [...state.firedEvents, MEDICAL_EMERGENCY_ID],
@@ -42,10 +47,73 @@ export function beginMedicalEmergency(state) {
         event:    MEDICAL_EMERGENCY,
         stageId:  MEDICAL_EMERGENCY.startStage,
         source:   'medical',
-        context:  { patientId: patient.id, selfTreat: patient.selfTreat }
+        context:  { patientId: patient.id, selfTreat: patient.selfTreat, ailmentId: ailment.id }
       }
     }
   };
+}
+
+// ---- Stage view (title/description/choices, built per-run) ----
+// Returns { title, description, choices } where each choice has
+// { label, key }. The resolver dispatches on key.
+export function getMedicalStageView(state, stageId, context) {
+  const patient = state.crew.find(c => c.id === context.patientId);
+  const ailment = AILMENTS.find(a => a.id === context.ailmentId) || AILMENTS[0];
+  if (!patient) return null;
+
+  const roleCode = (patient.role || '').toUpperCase();
+  const patientTag = `${patient.name} (${roleCode})`;
+
+  if (stageId === 'diagnose') {
+    const intro = context.selfTreat
+      ? `${patientTag} — your medic — is in trouble. ${ailment.symptom} The crew is on their own.`
+      : `${patientTag} is in trouble. ${ailment.symptom} You have to act.`;
+    const choices = context.selfTreat
+      ? [
+          { label: 'Self-triage (medic impaired)',        key: 'self_triage' },
+          { label: 'Query Earth (comms delay)',           key: 'earth' },
+          { label: 'Dose from med kit and hope',          key: 'hope' }
+        ]
+      : [
+          { label: 'Consult the medic',                    key: 'medic' },
+          { label: 'Query Earth (comms delay)',            key: 'earth' },
+          { label: 'Dose from med kit and hope',           key: 'hope' }
+        ];
+    return { title: `Medical Emergency — ${ailment.label}`, description: intro, choices };
+  }
+
+  if (stageId === 'treat') {
+    const surgeryLabel = context.selfTreat
+      ? 'Crew attempts surgery (no surgeon)'
+      : 'Surgery in the rover';
+    const surgeryKey = context.selfTreat ? 'crew_surgery' : 'surgery';
+    const description = context.selfTreat
+      ? `Treatment has to happen without the medic. ${patient.name} is coaching through the pain — barely.`
+      : `Diagnosis in hand. Choose the treatment plan for ${patient.name}.`;
+    return {
+      title:       'Treatment Window',
+      description,
+      choices: [
+        { label: surgeryLabel,                       key: surgeryKey },
+        { label: 'Stabilize and push to landmark',   key: 'push' },
+        { label: 'Induced coma — buy time',          key: 'coma' }
+      ]
+    };
+  }
+
+  if (stageId === 'dispose') {
+    return {
+      title:       'Body Disposal',
+      description: `${patient.name} did not make it. The body is 180 LB of suited mass. Call it.`,
+      choices: [
+        { label: 'Bury at next landmark',  key: 'bury' },
+        { label: 'Keep the body with us',  key: 'keep' },
+        { label: 'Jettison the suit now',  key: 'jettison' }
+      ]
+    };
+  }
+
+  return null;
 }
 
 // ---- Helpers ----
@@ -72,6 +140,10 @@ function damagePatient(state, patientId, amount, cause) {
       sol: s.sol,
       text: `${after.name} (${after.role.toUpperCase()}) succumbed to ${cause || 'medical complications'}.`
     });
+    s.deathQueue = [...(s.deathQueue || []), {
+      crewId: after.id, name: after.name, role: after.role,
+      cause:  cause || 'medical complications', sol: s.sol
+    }];
   }
   return s;
 }
@@ -80,10 +152,9 @@ function medicAliveExcluding(state, excludeId) {
   return state.crew.some(c => c.role === 'medic' && c.alive && c.id !== excludeId);
 }
 
-function rollSkill(state, successP, selfTreat) {
-  const base = selfTreat ? Math.max(0.2, successP - 0.2) : successP;
+function rollSkill(state, successP) {
   const bonus = state.careerBonuses?.skillBonus || 0;
-  const effP = Math.min(0.95, base + bonus);
+  const effP = Math.min(0.95, successP + bonus);
   return Math.random() < effP;
 }
 
@@ -101,39 +172,43 @@ function nextStage(state, stageId, context) {
   };
 }
 
-// ---- Stage: diagnose ----
+// ---- Stage resolvers ----
 
-function resolveDiagnose(state, choiceKey, context) {
-  const { patientId, selfTreat } = context;
-  const patient = getCrew(state, patientId);
+function resolveDiagnose(state, key, context) {
+  const patient = getCrew(state, context.patientId);
   if (!patient) return closeModal(state);
 
-  if (choiceKey === 'medic') {
-    const success = rollSkill(state, 0.75, selfTreat);
+  if (key === 'medic' || key === 'self_triage') {
+    // medic: 0.75; self_triage: 0.45 (medic impaired by their own symptoms).
+    const successP = key === 'self_triage' ? 0.45 : 0.75;
+    const success = rollSkill(state, successP);
     let s = state;
-    if (!success) {
-      s = damagePatient(s, patientId, 10, 'misdiagnosis');
-    }
-    s = { ...s, log: [...s.log, { sol: s.sol, text: success
-      ? `Medic confident on diagnosis for ${patient.name}.`
-      : `Medic exam inconclusive. ${patient.name} worsens.` }] };
+    if (!success) s = damagePatient(s, context.patientId, 10, 'misdiagnosis');
+    const msg = success
+      ? (key === 'self_triage'
+           ? `${patient.name} self-diagnoses through the haze.`
+           : `Medic confident on diagnosis for ${patient.name}.`)
+      : (key === 'self_triage'
+           ? `${patient.name} can't get a clean read on themselves. Worsens.`
+           : `Medic exam inconclusive. ${patient.name} worsens.`);
+    s = { ...s, log: [...s.log, { sol: s.sol, text: msg }] };
     return nextStage(s, 'treat', context);
   }
 
-  if (choiceKey === 'earth') {
+  if (key === 'earth') {
     let s = applyOutcome(state, { oxygen: -3, water: -3 }).state;
-    s = damagePatient(s, patientId, 20, 'delayed diagnosis');
+    s = damagePatient(s, context.patientId, 20, 'delayed diagnosis');
     s = { ...s, log: [...s.log, { sol: s.sol, text: `Earth comms lag cost 20 minutes. ${patient.name} worsens.` }] };
     return nextStage(s, 'treat', context);
   }
 
-  if (choiceKey === 'hope') {
+  if (key === 'hope') {
     const stabilized = Math.random() < 0.4;
     if (stabilized) {
       const s = { ...state, log: [...state.log, { sol: state.sol, text: `Med-kit dose held. ${patient.name} is stable — for now.` }] };
       return closeModal(s);
     }
-    let s = damagePatient(state, patientId, 30, 'adverse reaction');
+    let s = damagePatient(state, context.patientId, 30, 'adverse reaction');
     s = { ...s, log: [...s.log, { sol: s.sol, text: `Dose went wrong. ${patient.name} is in worse shape.` }] };
     return nextStage(s, 'treat', context);
   }
@@ -141,46 +216,48 @@ function resolveDiagnose(state, choiceKey, context) {
   return closeModal(state);
 }
 
-// ---- Stage: treat ----
-
-function resolveTreat(state, choiceKey, context) {
-  const { patientId, selfTreat } = context;
-  const patient = getCrew(state, patientId);
+function resolveTreat(state, key, context) {
+  const patient = getCrew(state, context.patientId);
   if (!patient) return closeModal(state);
 
-  if (choiceKey === 'surgery') {
+  if (key === 'surgery' || key === 'crew_surgery') {
     let s = applyOutcome(state, { eva: -1, power: -15 }).state;
-    const success = rollSkill(s, 0.65, selfTreat);
+    // surgery: 0.65 (medic). crew_surgery: 0.30 (no surgeon).
+    const successP = key === 'crew_surgery' ? 0.30 : 0.65;
+    const success = rollSkill(s, successP);
     if (success) {
       s = {
         ...s,
-        crew: s.crew.map(c => c.id === patientId
+        crew: s.crew.map(c => c.id === context.patientId
           ? { ...c, health: Math.max(60, c.health), status: deriveStatus(Math.max(60, c.health)) }
           : c),
-        log: [...s.log, { sol: s.sol, text: `Surgery successful. ${patient.name} is stable.` }]
+        log: [...s.log, { sol: s.sol, text: key === 'crew_surgery'
+          ? `Improvised surgery held. ${patient.name} is stable.`
+          : `Surgery successful. ${patient.name} is stable.` }]
       };
       return closeModal(s);
     }
     // Fail → patient dies.
-    const medicCanFlavor = !selfTreat && medicAliveExcluding(s, patientId);
-    s = damagePatient(s, patientId, 999, 'surgical complications');
+    const medicCanFlavor = !context.selfTreat && medicAliveExcluding(s, context.patientId);
+    const cause = key === 'crew_surgery' ? 'surgical complications' : 'surgical complications';
+    s = damagePatient(s, context.patientId, 999, cause);
     if (medicCanFlavor) {
       s = { ...s, log: [...s.log, { sol: s.sol, text: MEDIC_FLAVOR_LINE }] };
     }
     return nextStage(s, 'dispose', context);
   }
 
-  if (choiceKey === 'push') {
+  if (key === 'push') {
     let s = applyOutcome(state, { eva: -1 }).state;
-    s = damagePatient(s, patientId, 15, 'travel stress');
-    const died = !getCrew(s, patientId).alive;
+    s = damagePatient(s, context.patientId, 15, 'travel stress');
+    const died = !getCrew(s, context.patientId).alive;
     s = { ...s, log: [...s.log, { sol: s.sol, text: died
       ? `${patient.name} did not survive the push.`
       : `Stabilized for travel. ${patient.name} is hanging on.` }] };
     return died ? nextStage(s, 'dispose', context) : closeModal(s);
   }
 
-  if (choiceKey === 'coma') {
+  if (key === 'coma') {
     let s = applyOutcome(state, { power: -15, oxygen: -10, eva: -1 }).state;
     s = { ...s, log: [...s.log, { sol: s.sol, text: `${patient.name} placed in induced coma. Vitals held, resources burning.` }] };
     return closeModal(s);
@@ -189,14 +266,11 @@ function resolveTreat(state, choiceKey, context) {
   return closeModal(state);
 }
 
-// ---- Stage: dispose ----
-
-function resolveDispose(state, choiceKey, context) {
-  const { patientId } = context;
-  const patient = state.crew.find(c => c.id === patientId);
+function resolveDispose(state, key, context) {
+  const patient = state.crew.find(c => c.id === context.patientId);
   if (!patient) return closeModal(state);
 
-  if (choiceKey === 'bury') {
+  if (key === 'bury') {
     const s = applyOutcome(state, { sciencePoints: 10 }).state;
     return {
       ...s,
@@ -204,37 +278,32 @@ function resolveDispose(state, choiceKey, context) {
       activeModal: null
     };
   }
-
-  if (choiceKey === 'keep') {
-    const s = addCorpse(state, patientId);
+  if (key === 'keep') {
+    const s = addCorpse(state, context.patientId);
     return {
       ...s,
       log: [...s.log, { sol: s.sol, text: `${patient.name}'s body secured. +180 LB cargo.` }],
       activeModal: null
     };
   }
-
-  if (choiceKey === 'jettison') {
+  if (key === 'jettison') {
     return {
       ...state,
       log: [...state.log, { sol: state.sol, text: `${patient.name}'s suit jettisoned. The crew will remember.` }],
       activeModal: null
     };
   }
-
   return closeModal(state);
 }
 
 // ---- Top-level resolver ----
-// state.activeModal must be { type: 'multi_stage', payload: { source: 'medical', ... } }.
-// choiceIdx is the index into the authored stage's choices.
 export function resolveMedicalStage(state, choiceIdx) {
   const modal = state.activeModal;
   if (modal?.type !== 'multi_stage' || modal.payload?.source !== 'medical') return state;
 
   const { stageId, context } = modal.payload;
-  const stage = MEDICAL_EMERGENCY.stages[stageId];
-  const choice = stage?.choices[choiceIdx];
+  const view = getMedicalStageView(state, stageId, context);
+  const choice = view?.choices[choiceIdx];
   if (!choice) return state;
 
   const key = choice.key;

--- a/styles/components.css
+++ b/styles/components.css
@@ -951,3 +951,17 @@ body[data-theme="lcars"] .eor-col-facts {
   background: rgba(255, 170, 102, 0.08);
   border-radius: 2px;
 }
+
+/* ---- Medical emergency severity (issue #32) ---- */
+
+.modal-severity.severity-medical {
+  color: #ff99aa;
+  background: rgba(255, 153, 170, 0.12);
+  letter-spacing: 0.2em;
+}
+.modal-severity.severity-medical::before {
+  content: '⚕';
+  margin-right: 0.5em;
+  font-size: 1.1em;
+  font-weight: 700;
+}


### PR DESCRIPTION
6-ailment pool with symptoms & cause woven into the diagnose-stage description. ⚕ icon in modal header. Medic-as-patient swaps two choices: "Consult the medic" → "Self-triage" (P 0.45), "Surgery" → "Crew surgery" (P 0.30). Medic flavor line gated to non-self cases.