### PR TITLE
EOR: NEW MISSION button under the rank block

### DIFF
--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -436,6 +436,7 @@ export function showEndOfRunModal(state, onNewMission) {
         <div class="eor-columns">
           <div class="eor-col eor-col-stats">
             ${rankBlock}
+            <button class="modal-continue primary eor-new-rank" id="eor-new" type="button">NEW MISSION →</button>
             ${careerCreditLine}
             <div class="eor-stats">
               <div class="eor-stat"><span class="eor-stat-label">SOLS</span><span class="eor-stat-value">${state.sol}</span></div>
@@ -449,8 +450,6 @@ export function showEndOfRunModal(state, onNewMission) {
             ${factsBlock}
           </div>
         </div>
-
-        <button class="modal-continue primary" id="eor-new" type="button">NEW MISSION →</button>
       </div>
     </div>
   `;

--- a/styles/components.css
+++ b/styles/components.css
@@ -965,3 +965,11 @@ body[data-theme="lcars"] .eor-col-facts {
   font-size: 1.1em;
   font-weight: 700;
 }
+
+/* ---- New Mission button directly under rank (end-of-run) ---- */
+
+.eor-new-rank {
+  display: block;
+  width: 100%;
+  margin: 0.75rem 0 1rem;
+}


### PR DESCRIPTION
Moved the NEW MISSION button up into the stats column directly after the rank card. Full-width in its slot.