### PR TITLE
Dashboard margins: desktop breathing room

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -10,7 +10,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 16px;
+  padding: 8px 24px;
   border-bottom: 1px solid var(--fg-faint);
   background: var(--bg-panel);
   font-size: 11px;
@@ -84,9 +84,14 @@ body {
     "route   telemetry crew"
     "route   log       log"
     "action  action    action";
-  gap: 8px;
-  padding: 8px;
+  gap: 12px;
+  padding: 16px 24px 24px;
   min-height: 0;
+}
+
+@media (max-width: 720px) {
+  .dashboard { padding: 8px 10px 12px; gap: 8px; }
+  .topbar    { padding: 8px 12px; }
 }
 
 .panel-route     { grid-area: route; }


### PR DESCRIPTION
16px top, 24px sides on the dashboard grid. Topbar horizontal padding matched. Narrow-viewport fallback preserves existing layout.