### PR TITLE
Music shuffle + Starfighter bars + player-centered radar

### DIFF
--- a/src/audio.js
+++ b/src/audio.js
@@ -1,5 +1,6 @@
 // Mars Trail — music manager.
-// Single <audio> element, looped. Track selection + mute persisted to localStorage.
+// Title loops. Gameplay plays a shuffled queue that reshuffles each run
+// and avoids back-to-back repeats across cycle boundaries.
 
 const STORAGE_KEY_TRACK = 'marsTrail.musicTrack';
 const STORAGE_KEY_MUTE  = 'marsTrail.musicMute';
@@ -19,11 +20,48 @@ export const GAMEPLAY_TRACKS = [
 ];
 
 const audio = new Audio();
-audio.loop = true;
 audio.volume = 0.4;
 
 let currentTrackId = null;
 let unlocked = false;   // audio context unlocked by first user interaction
+let shuffleQueue = [];  // remaining gameplay tracks in current shuffled cycle
+
+const trackChangeListeners = [];
+export function onTrackChange(cb) { trackChangeListeners.push(cb); }
+function notifyTrackChange(id) { trackChangeListeners.forEach(cb => { try { cb(id); } catch {} }); }
+
+function buildShuffleQueue(avoidFirstId = null) {
+  const ids = GAMEPLAY_TRACKS.map(t => t.id);
+  for (let i = ids.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [ids[i], ids[j]] = [ids[j], ids[i]];
+  }
+  // Avoid back-to-back repeat across cycle boundary.
+  if (avoidFirstId && ids.length > 1 && ids[0] === avoidFirstId) {
+    [ids[0], ids[1]] = [ids[1], ids[0]];
+  }
+  return ids;
+}
+
+function nextShuffledId() {
+  if (shuffleQueue.length === 0) {
+    shuffleQueue = buildShuffleQueue(currentTrackId);
+  }
+  let next = shuffleQueue.shift();
+  // Defensive: if the user jumped to a track that's also next in queue,
+  // swap so we don't play it twice in a row.
+  if (next === currentTrackId && shuffleQueue.length > 0) {
+    const after = shuffleQueue.shift();
+    shuffleQueue.unshift(next);
+    next = after;
+  }
+  return next;
+}
+
+audio.addEventListener('ended', () => {
+  if (currentTrackId === 'title') return; // title loops; shouldn't fire
+  play(nextShuffledId());
+});
 
 export function getSelectedTrackId() {
   return localStorage.getItem(STORAGE_KEY_TRACK) || GAMEPLAY_TRACKS[0].id;
@@ -42,9 +80,11 @@ export function play(trackId) {
 
   currentTrackId = track.id;
   audio.src = track.file;
+  audio.loop = (track.id === 'title'); // title loops; gameplay advances via 'ended'
   audio.muted = isMuted();
   audio.play().catch(() => {});
   unlocked = true;
+  notifyTrackChange(track.id);
 }
 
 export function stop() {
@@ -84,7 +124,9 @@ export function playTitle() {
 }
 
 export function playGameplay() {
-  play(getSelectedTrackId());
+  // Start a fresh shuffled cycle each time gameplay music begins.
+  shuffleQueue = buildShuffleQueue(currentTrackId);
+  play(shuffleQueue.shift());
 }
 
 // Shared fade timer so a new fade cancels any in-flight fade.
@@ -116,14 +158,18 @@ export function fadeOut(durationMs = 1500) {
 
 export function fadeInGameplay(durationMs = 1500) {
   clearFade();
-  const trackId = getSelectedTrackId();
+  // New run: reshuffle track order.
+  shuffleQueue = buildShuffleQueue(currentTrackId);
+  const trackId = shuffleQueue.shift();
   const track = GAMEPLAY_TRACKS.find(t => t.id === trackId);
   if (!track) return;
   currentTrackId = track.id;
   audio.src = track.file;
+  audio.loop = false;
   audio.muted = isMuted();
   audio.volume = 0;
   audio.play().catch(() => {});
+  notifyTrackChange(track.id);
   const targetVol = 0.4;
   const steps = 30;
   const interval = durationMs / steps;

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ import { resolveMedicalStage, getMedicalStageView } from './systems/medicalEmerg
 import { WAYPOINTS } from './content/waypoints.js';
 import { makeLandmarkEncounter } from './content/landmarks.js';
 import './ui/codex.js';   // registers global click handler for codex terms
-import { GAMEPLAY_TRACKS, getSelectedTrackId, isMuted, playTitle, playGameplay, selectTrack, toggleMute, fadeOut, fadeInGameplay, cycleTrack } from './audio.js';
+import { GAMEPLAY_TRACKS, getSelectedTrackId, isMuted, playTitle, playGameplay, selectTrack, toggleMute, fadeOut, fadeInGameplay, cycleTrack, onTrackChange } from './audio.js';
 
 let state = createInitialState();
 renderAll();
@@ -304,6 +304,11 @@ musicMute.classList.toggle('muted', isMuted());
 
 musicSelect.addEventListener('change', () => {
   selectTrack(musicSelect.value);
+});
+
+// Keep dropdown in sync with shuffle-driven track changes.
+onTrackChange((id) => {
+  if (id !== 'title') musicSelect.value = id;
 });
 
 musicMute.addEventListener('click', () => {

--- a/styles/theme-starfighter.css
+++ b/styles/theme-starfighter.css
@@ -124,34 +124,47 @@ body[data-theme="starfighter"] .panel-title {
   font-weight: 600;
 }
 
-/* ---- Segmented telemetry bars ---- */
-
+/* ---- Segmented telemetry bars (issue #57) ----
+   Each bar reads as 10 discrete cells that switch on/off as the value
+   changes — cells keep a constant width at any fill level. Achieved by
+   layering:
+   1. `.bar` paints a full-width dim 10-cell template (visible at rest).
+   2. `.bar-fill` paints solid lit color; JS sizes its width to the value.
+   3. `.bar::after` overlays black stripes at every cell boundary,
+      anchored to the container's width — so gap positions are fixed
+      regardless of fill, creating the segmented illusion. */
 body[data-theme="starfighter"] .bar {
-  background: transparent;
+  background: repeating-linear-gradient(
+    to right,
+    rgba(59, 255, 122, 0.14) 0 8%,
+    transparent 8% 10%
+  );
   border: 1px solid rgba(59, 255, 122, 0.4);
   border-radius: 0;
   box-shadow: none;
-  /* cells drawn with a 10-segment gradient mask on .bar-fill */
+  position: relative;
+}
+body[data-theme="starfighter"] .bar::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to right,
+    transparent 0 8%,
+    #000 8% 10%
+  );
 }
 body[data-theme="starfighter"] .bar-fill {
-  background:
-    repeating-linear-gradient(
-      to right,
-      var(--fg-dim) 0,
-      var(--fg-dim) 8%,
-      transparent 8%,
-      transparent 10%
-    );
+  background: var(--fg-dim);
   box-shadow: 0 0 4px rgba(59, 255, 122, 0.6);
 }
 body[data-theme="starfighter"] .readout.warn .bar-fill {
-  background:
-    repeating-linear-gradient(to right, var(--warn) 0, var(--warn) 8%, transparent 8%, transparent 10%);
+  background: var(--warn);
   box-shadow: 0 0 4px rgba(255, 210, 26, 0.6);
 }
 body[data-theme="starfighter"] .readout.crit .bar-fill {
-  background:
-    repeating-linear-gradient(to right, var(--crit) 0, var(--crit) 8%, transparent 8%, transparent 10%);
+  background: var(--crit);
   box-shadow: 0 0 4px rgba(255, 40, 64, 0.7);
 }
 body[data-theme="starfighter"] .readout-label {


### PR DESCRIPTION
## Summary
Three fixes on this branch:

**Music shuffle (closes #60)**
- Gameplay tracks play as a shuffled queue (Fisher-Yates) that reshuffles each run.
- Auto-advance on track end via `'ended'` listener; title theme still loops.
- No back-to-back repeats across shuffle cycle boundaries.
- Dropdown stays in sync via a new `onTrackChange` pub-sub.

**Starfighter telemetry bars (closes #57)**
- `.bar` paints a dim 10-cell template; `.bar-fill` is a solid lit color; `.bar::after` overlays black cell-boundary stripes anchored to full width.
- Low values show *fewer* lit cells at full width instead of the gradient squeezing into a shorter space.

**Player-centered radar (closes #61)**
- Minimap SVG wrapped in `.minimap-wrap`; render.js sets `--player-x` / `--player-y` from the rover dot's pixel position each render.
- Starfighter radar rings/crosshair/sweep now anchor on those vars, so the player is the radar's origin and the route moves under the sweep as the run progresses.
- Reusable by any future radar-style skin — no Starfighter-specific JS.

## Test plan
- [x] `node --test sim/*.test.mjs` — 103/103 pass
- [x] Starfighter bars: 10 constant-width cells at 0 / 50 / 100% fill
- [ ] Gameplay music auto-advances on track end, order varies across runs, dropdown updates live
- [ ] Mute / up-down skip / dropdown jump still work
- [ ] Starfighter radar: rings/sweep center on the rover and follow it across the route
- [ ] Other themes (MC / LCARS / Voltron) visually unchanged

Closes #57, closes #60, closes #61.