### PR TITLE
Radar: center themed radar overlay on player position (closes #61)

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,13 +42,15 @@
 
       <div class="route-section">
         <h3 class="route-section-header">NAVIGATION</h3>
-        <svg class="minimap" viewBox="0 0 200 100" aria-hidden="true">
-          <rect x="0" y="0" width="200" height="100" fill="#001a0a" stroke="#0a8" stroke-width="0.5"/>
-          <path id="minimap-path" d="M20,78 Q60,34 92,58 T160,42 L184,26" fill="none" stroke="#0a8" stroke-width="0.8" stroke-dasharray="2,2"/>
-          <path id="minimap-trail" d="M20,78 Q60,34 92,58 T160,42 L184,26" fill="none" stroke="#0f0" stroke-width="1.6" stroke-dasharray="0 9999" stroke-linecap="round"/>
-          <g id="minimap-landmarks"></g>
-          <circle id="minimap-position" cx="20" cy="78" r="3" fill="#fbbf24" stroke="#000" stroke-width="0.6"/>
-        </svg>
+        <div class="minimap-wrap" id="minimap-wrap">
+          <svg class="minimap" viewBox="0 0 200 100" aria-hidden="true">
+            <rect x="0" y="0" width="200" height="100" fill="#001a0a" stroke="#0a8" stroke-width="0.5"/>
+            <path id="minimap-path" d="M20,78 Q60,34 92,58 T160,42 L184,26" fill="none" stroke="#0a8" stroke-width="0.8" stroke-dasharray="2,2"/>
+            <path id="minimap-trail" d="M20,78 Q60,34 92,58 T160,42 L184,26" fill="none" stroke="#0f0" stroke-width="1.6" stroke-dasharray="0 9999" stroke-linecap="round"/>
+            <g id="minimap-landmarks"></g>
+            <circle id="minimap-position" cx="20" cy="78" r="3" fill="#fbbf24" stroke="#000" stroke-width="0.6"/>
+          </svg>
+        </div>
       </div>
 
       <div class="route-section">

--- a/src/render.js
+++ b/src/render.js
@@ -16,6 +16,7 @@ function bindDom() {
   $.rationsSeg   = document.getElementById('rations-seg');
   $.log          = document.getElementById('log');
   $.minimapPos   = document.getElementById('minimap-position');
+  $.minimapWrap  = document.getElementById('minimap-wrap');
   $.routeImage   = document.getElementById('route-image');
   $.routeName    = document.getElementById('route-location-name');
   $.routeDesc    = document.getElementById('route-location-desc');
@@ -106,6 +107,19 @@ function renderMinimap(state) {
   if ($.minimapPos) {
     $.minimapPos.setAttribute('cx', rover.x.toFixed(1));
     $.minimapPos.setAttribute('cy', rover.y.toFixed(1));
+  }
+
+  // Expose player position as CSS vars on the minimap wrap so themed radar
+  // overlays (e.g. Starfighter) can center themselves on the player.
+  if ($.minimapWrap && $.minimapPos) {
+    const wrapRect = $.minimapWrap.getBoundingClientRect();
+    if (wrapRect.width > 0 && wrapRect.height > 0) {
+      const dotRect = $.minimapPos.getBoundingClientRect();
+      const dotCx = dotRect.left + dotRect.width / 2 - wrapRect.left;
+      const dotCy = dotRect.top + dotRect.height / 2 - wrapRect.top;
+      $.minimapWrap.style.setProperty('--player-x', `${(dotCx / wrapRect.width * 100).toFixed(2)}%`);
+      $.minimapWrap.style.setProperty('--player-y', `${(dotCy / wrapRect.height * 100).toFixed(2)}%`);
+    }
   }
 
   // Trail: solid portion overlaying the dashed base

--- a/styles/components.css
+++ b/styles/components.css
@@ -61,10 +61,17 @@
   margin: 0;
 }
 
+.minimap-wrap {
+  position: relative;
+  margin-bottom: 14px;
+  --player-x: 50%;
+  --player-y: 50%;
+}
+
 .minimap {
   width: 100%;
   height: 120px;
-  margin-bottom: 14px;
+  display: block;
   filter: drop-shadow(0 0 3px rgba(0,255,100,0.5));
 }
 

--- a/styles/theme-starfighter.css
+++ b/styles/theme-starfighter.css
@@ -255,16 +255,16 @@ body[data-theme="starfighter"] .landmark-dot.current { fill: var(--fg-dim); stro
 body[data-theme="starfighter"] .landmark-dot.dest    { stroke: var(--sf-red); stroke-width: 1.2; }
 
 /* Polar overlay: concentric rings + radial spokes + sweep line.
-   Rendered as a CSS background on the route-section that contains the
-   minimap so it reads as a round radar sitting in a rectangular panel. */
-body[data-theme="starfighter"] .route-section:has(.minimap) {
-  position: relative;
+   Rendered as CSS backgrounds on the .minimap-wrap and centered on the
+   player position (issue #61) via --player-x / --player-y set by render.js. */
+body[data-theme="starfighter"] .minimap-wrap {
+  overflow: hidden;
 }
-body[data-theme="starfighter"] .route-section:has(.minimap)::before {
+body[data-theme="starfighter"] .minimap-wrap::before {
   content: '';
   position: absolute;
-  left: 50%;
-  top: 50%;
+  left: var(--player-x, 50%);
+  top: var(--player-y, 50%);
   width: min(80%, 180px);
   aspect-ratio: 1 / 1;
   transform: translate(-50%, -50%);
@@ -284,11 +284,11 @@ body[data-theme="starfighter"] .route-section:has(.minimap)::before {
 }
 
 /* Rotating sweep line */
-body[data-theme="starfighter"] .route-section:has(.minimap)::after {
+body[data-theme="starfighter"] .minimap-wrap::after {
   content: '';
   position: absolute;
-  left: 50%;
-  top: 50%;
+  left: var(--player-x, 50%);
+  top: var(--player-y, 50%);
   width: min(80%, 180px);
   aspect-ratio: 1 / 1;
   transform: translate(-50%, -50%);
@@ -315,7 +315,7 @@ body[data-theme="starfighter"] .route-section:has(.minimap)::after {
 
 /* Respect reduced-motion preference */
 @media (prefers-reduced-motion: reduce) {
-  body[data-theme="starfighter"] .route-section:has(.minimap)::after {
+  body[data-theme="starfighter"] .minimap-wrap::after {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- The Starfighter radar rings sat at the center of the navigation panel while the player dot moved along the route — opposite of how a real radar reads. Player is now the radar's origin; rings/sweep follow the rover as the run progresses.
- Wrap minimap SVG in `.minimap-wrap` so the radar overlay has a container matching the minimap's rendered box.
- `src/render.js` sets `--player-x` / `--player-y` CSS vars (percentages of the wrap) each `renderMinimap`, from the rover dot's actual pixel position.
- `theme-starfighter.css` pseudo-elements anchor on those vars instead of `50% 50%`; `overflow: hidden` keeps rings tidy near minimap edges.
- Reusable by any future radar-style skin — no Starfighter-specific JS.

Missed the PR #59 squash-merge; cherry-picked onto a fresh branch.

## Test plan
- [x] `node --test sim/*.test.mjs` — 103/103 pass
- [ ] Starfighter theme: rings/crosshair/sweep center on the rover, not the panel
- [ ] Rings follow the rover as days advance
- [ ] No awkward clipping at route endpoints
- [ ] Other themes (MC / LCARS / Voltron) visually unchanged

Closes #61.