### PR TITLE
Anti-mashing emergencies: punish click-through behavior (closes #63)

### DIFF
--- a/sim/clickMetrics.test.mjs
+++ b/sim/clickMetrics.test.mjs
@@ -1,0 +1,98 @@
+// Tests for src/systems/clickMetrics.js (issue #63).
+// Run: node --test sim/clickMetrics.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CLICK_METRICS_CONFIG,
+  initialClickMetrics,
+  expectedReadMs,
+  classifyDecision,
+  recordDecision,
+  shouldFireEmergency,
+  afterEmergencyFired
+} from '../src/systems/clickMetrics.js';
+
+test('initialClickMetrics starts at zero', () => {
+  const m = initialClickMetrics();
+  assert.equal(m.mashScore, 0);
+  assert.equal(m.emergenciesFired, 0);
+});
+
+test('expectedReadMs respects the min floor for very short text', () => {
+  assert.equal(expectedReadMs(''), CLICK_METRICS_CONFIG.minReadMs);
+  assert.equal(expectedReadMs('hi'), CLICK_METRICS_CONFIG.minReadMs);
+});
+
+test('expectedReadMs scales linearly with longer text', () => {
+  const longText = 'x'.repeat(200);
+  assert.equal(expectedReadMs(longText), 200 * CLICK_METRICS_CONFIG.readMsPerChar);
+});
+
+test('classifyDecision buckets match the documented thresholds', () => {
+  const expected = 10_000;
+  assert.equal(classifyDecision(500,  expected), 'didNotRead');   // <20%
+  assert.equal(classifyDecision(3000, expected), 'skim');         // 30%
+  assert.equal(classifyDecision(6000, expected), 'hurried');      // 60%
+  assert.equal(classifyDecision(9000, expected), 'normal');       // 90%
+  assert.equal(classifyDecision(12000, expected), 'thoughtful');  // >100%
+});
+
+test('recordDecision accumulates mashScore for fast clicks', () => {
+  let m = initialClickMetrics();
+  const body = 'x'.repeat(100);          // expected ~3500ms
+  m = recordDecision(m, 100, body);      // didNotRead → +3
+  assert.equal(m.mashScore, 3);
+  m = recordDecision(m, 100, body);      // +3 again → 6
+  assert.equal(m.mashScore, 6);
+});
+
+test('recordDecision decays mashScore for thoughtful reads and floors at 0', () => {
+  let m = { ...initialClickMetrics(), mashScore: 1 };
+  const body = 'x'.repeat(100);
+  m = recordDecision(m, 10_000, body);   // thoughtful → -1 → 0
+  assert.equal(m.mashScore, 0);
+  m = recordDecision(m, 10_000, body);   // -1 but floored to 0
+  assert.equal(m.mashScore, 0);
+});
+
+test('shouldFireEmergency respects threshold and per-run cap', () => {
+  assert.equal(shouldFireEmergency({ mashScore: 5, emergenciesFired: 0 }), false);
+  assert.equal(shouldFireEmergency({ mashScore: 6, emergenciesFired: 0 }), true);
+  assert.equal(
+    shouldFireEmergency({ mashScore: 99, emergenciesFired: CLICK_METRICS_CONFIG.maxEmergenciesPerRun }),
+    false,
+    'cap prevents runaway chain of emergencies'
+  );
+  assert.equal(shouldFireEmergency(null), false);
+});
+
+test('afterEmergencyFired bumps counter and cools down mashScore', () => {
+  const before = { mashScore: 8, emergenciesFired: 0 };
+  const after = afterEmergencyFired(before);
+  assert.equal(after.emergenciesFired, 1);
+  assert.equal(after.mashScore, 8 + CLICK_METRICS_CONFIG.emergencyCooldownDelta);
+  assert.ok(after.mashScore >= 0);
+});
+
+test('sustained mashing trips emergency, cap stops further fires', () => {
+  let m = initialClickMetrics();
+  const body = 'x'.repeat(50);
+  // Six rapid clicks should reach threshold.
+  for (let i = 0; i < 2; i++) m = recordDecision(m, 50, body);  // +3+3 = 6
+  assert.equal(shouldFireEmergency(m), true);
+
+  // Fire the first emergency.
+  m = afterEmergencyFired(m);
+  assert.equal(m.emergenciesFired, 1);
+
+  // Re-arm and fire a second.
+  for (let i = 0; i < 3; i++) m = recordDecision(m, 50, body);
+  assert.equal(shouldFireEmergency(m), true);
+  m = afterEmergencyFired(m);
+  assert.equal(m.emergenciesFired, 2);
+
+  // Further mashing should not trip a third.
+  for (let i = 0; i < 5; i++) m = recordDecision(m, 50, body);
+  assert.equal(shouldFireEmergency(m), false, 'cap holds');
+});

--- a/sim/clickMetrics.test.mjs
+++ b/sim/clickMetrics.test.mjs
@@ -58,8 +58,9 @@ test('recordDecision decays mashScore for thoughtful reads and floors at 0', () 
 });
 
 test('shouldFireEmergency respects threshold and per-run cap', () => {
-  assert.equal(shouldFireEmergency({ mashScore: 5, emergenciesFired: 0 }), false);
-  assert.equal(shouldFireEmergency({ mashScore: 6, emergenciesFired: 0 }), true);
+  const t = CLICK_METRICS_CONFIG.mashScoreThreshold;
+  assert.equal(shouldFireEmergency({ mashScore: t - 1, emergenciesFired: 0 }), false);
+  assert.equal(shouldFireEmergency({ mashScore: t,     emergenciesFired: 0 }), true);
   assert.equal(
     shouldFireEmergency({ mashScore: 99, emergenciesFired: CLICK_METRICS_CONFIG.maxEmergenciesPerRun }),
     false,
@@ -133,24 +134,21 @@ test('pickEmergency returns a fully-materialized concrete event', () => {
   assert.equal(start.choices.length, 3);
 });
 
-test('sustained mashing trips emergency, cap stops further fires', () => {
+test('sustained mashing trips emergencies until the per-run cap is hit', () => {
+  const cap = CLICK_METRICS_CONFIG.maxEmergenciesPerRun;
   let m = initialClickMetrics();
   const body = 'x'.repeat(50);
-  // Six rapid clicks should reach threshold.
-  for (let i = 0; i < 2; i++) m = recordDecision(m, 50, body);  // +3+3 = 6
-  assert.equal(shouldFireEmergency(m), true);
 
-  // Fire the first emergency.
-  m = afterEmergencyFired(m);
-  assert.equal(m.emergenciesFired, 1);
+  // Fast click trips the heuristic; arm and fire up to the cap.
+  for (let fired = 0; fired < cap; fired++) {
+    while (!shouldFireEmergency(m)) {
+      m = recordDecision(m, 50, body);
+    }
+    m = afterEmergencyFired(m);
+    assert.equal(m.emergenciesFired, fired + 1);
+  }
 
-  // Re-arm and fire a second.
-  for (let i = 0; i < 3; i++) m = recordDecision(m, 50, body);
-  assert.equal(shouldFireEmergency(m), true);
-  m = afterEmergencyFired(m);
-  assert.equal(m.emergenciesFired, 2);
-
-  // Further mashing should not trip a third.
-  for (let i = 0; i < 5; i++) m = recordDecision(m, 50, body);
+  // Further mashing should not exceed the cap.
+  for (let i = 0; i < 10; i++) m = recordDecision(m, 50, body);
   assert.equal(shouldFireEmergency(m), false, 'cap holds');
 });

--- a/sim/clickMetrics.test.mjs
+++ b/sim/clickMetrics.test.mjs
@@ -12,6 +12,7 @@ import {
   shouldFireEmergency,
   afterEmergencyFired
 } from '../src/systems/clickMetrics.js';
+import { EMERGENCY_TEMPLATES, materializeEmergency, pickEmergency } from '../src/content/emergencies.js';
 
 test('initialClickMetrics starts at zero', () => {
   const m = initialClickMetrics();
@@ -73,6 +74,63 @@ test('afterEmergencyFired bumps counter and cools down mashScore', () => {
   assert.equal(after.emergenciesFired, 1);
   assert.equal(after.mashScore, 8 + CLICK_METRICS_CONFIG.emergencyCooldownDelta);
   assert.ok(after.mashScore >= 0);
+});
+
+test('every emergency template has valid structure', () => {
+  for (const t of EMERGENCY_TEMPLATES) {
+    assert.ok(t.id, 'id');
+    assert.ok(t.startStage, 'startStage');
+    assert.ok(t.stages[t.startStage], 'startStage exists in stages');
+    for (const [stageId, stage] of Object.entries(t.stages)) {
+      assert.ok(stage.descriptionTemplate, `${t.id}.${stageId}.descriptionTemplate`);
+      assert.ok(Array.isArray(stage.variants) && stage.variants.length >= 2,
+        `${t.id}.${stageId} must have ≥2 variants for anti-memorization`);
+      assert.ok(Array.isArray(stage.choiceTemplates) && stage.choiceTemplates.length === 3,
+        `${t.id}.${stageId} must have exactly 3 choices`);
+      assert.equal(stage.choiceTemplates.filter(c => c.correct).length, 1,
+        `${t.id}.${stageId} must have exactly one correct choice`);
+    }
+  }
+});
+
+test('materializeEmergency fills templates and preserves the correct choice', () => {
+  const template = EMERGENCY_TEMPLATES.find(t => t.id === 'emer_cabin_breach');
+  const concrete = materializeEmergency(template);
+
+  assert.equal(concrete.multiStage, true);
+  assert.equal(concrete.startStage, template.startStage);
+
+  const breach = concrete.stages.breach;
+  assert.ok(!/\{\{/.test(breach.description), 'no unfilled {{slot}} in description');
+  for (const c of breach.choices) {
+    assert.ok(!/\{\{/.test(c.label), 'no unfilled {{slot}} in label');
+  }
+  assert.equal(breach.choices.filter(c => c.correct).length, 1);
+  const correct = breach.choices.find(c => c.correct);
+  assert.equal(correct.nextStage, 'weld');
+});
+
+test('materializeEmergency produces variety across many fires', () => {
+  const template = EMERGENCY_TEMPLATES.find(t => t.id === 'emer_cabin_breach');
+  const correctLabels = new Set();
+  const firstChoiceLabels = new Set();
+  for (let i = 0; i < 200; i++) {
+    const concrete = materializeEmergency(template);
+    const breach = concrete.stages.breach;
+    correctLabels.add(breach.choices.find(c => c.correct).label);
+    firstChoiceLabels.add(breach.choices[0].label);
+  }
+  assert.ok(correctLabels.size >= 2, `correct choice label should vary across runs (got ${correctLabels.size})`);
+  assert.ok(firstChoiceLabels.size >= 2, `position of the correct choice should vary (got ${firstChoiceLabels.size} first-slot labels)`);
+});
+
+test('pickEmergency returns a fully-materialized concrete event', () => {
+  const e = pickEmergency();
+  assert.ok(e.id && e.id.startsWith('emer_'));
+  assert.equal(e.multiStage, true);
+  const start = e.stages[e.startStage];
+  assert.ok(!/\{\{/.test(start.description));
+  assert.equal(start.choices.length, 3);
 });
 
 test('sustained mashing trips emergency, cap stops further fires', () => {

--- a/sim/mashPlaytest.mjs
+++ b/sim/mashPlaytest.mjs
@@ -1,0 +1,155 @@
+// Mash-playtest (issue #63). Simulates 1000 runs of a player who
+// clicks the first choice on every modal in <100 ms — i.e. the exact
+// behaviour the click-metrics heuristic is meant to punish — and
+// compares it against a "reader" who takes long enough on each choice
+// that mashScore never trips.
+//
+// Run: node sim/mashPlaytest.mjs
+
+import { createInitialState } from '../src/state.js';
+import { advanceSol, canRepair, canClean, repairBattery, cleanPanels } from '../src/systems/travel.js';
+import { applyEventChoice } from '../src/systems/events.js';
+import { applyStageChoice } from '../src/systems/multiStage.js';
+import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from '../src/systems/awayTeam.js';
+import { resolveMedicalStage } from '../src/systems/medicalEmergency.js';
+import { makeLandmarkEncounter } from '../src/content/landmarks.js';
+import { recordDecision } from '../src/systems/clickMetrics.js';
+
+function isEmergency(event) { return typeof event?.id === 'string' && event.id.startsWith('emer_'); }
+
+function playGame({ elapsedMs, pick }) {
+  let s = createInitialState();
+  s.activeModal = null;
+  s.pace = 'steady';
+  s.rations = 'standard';
+
+  const stats = {
+    emergenciesFired: 0,
+    emergencyCorrectPicks: 0,
+    emergencyWrongPicks: 0,
+    crewDeathsDuringEmergency: 0
+  };
+
+  const MAX_SOL = 250;
+  while (s.status === 'active' && s.sol < MAX_SOL) {
+    const m = s.activeModal;
+
+    if (m?.type === 'event') {
+      const event = m.payload;
+      s = { ...s, clickMetrics: recordDecision(s.clickMetrics, elapsedMs, event.modal.description) };
+      const idx = pick(event.modal.choices);
+      s = applyEventChoice(s, event, idx).state;
+      continue;
+    }
+
+    if (m?.type === 'waypoint_offer') {
+      s = { ...s, firedWaypoints: [...s.firedWaypoints, m.payload.waypoint.id], activeModal: null };
+      continue;
+    }
+
+    if (m?.type === 'away_team_picker') {
+      const aliveIds = s.crew.filter(c => c.alive).map(c => c.id);
+      const toSend = aliveIds.slice(0, Math.min(2, aliveIds.length - 1));
+      if (toSend.length < 1) { s = { ...s, activeModal: null }; continue; }
+      s = acceptAwayTeam(s, m.payload.waypoint.id, toSend);
+      s = { ...s, firedWaypoints: [...s.firedWaypoints, m.payload.waypoint.id] };
+      const arrivedId = s.route[s.currentLandmarkIndex];
+      s = { ...s, activeModal: { type: 'event', payload: makeLandmarkEncounter(arrivedId) } };
+      continue;
+    }
+
+    if (m?.type === 'away_team_reunion') {
+      const corpseChoices = {};
+      for (const d of m.payload.deaths) corpseChoices[d.id] = 'bring';
+      s = finalizeReunion(s, corpseChoices);
+      continue;
+    }
+
+    if (m?.type === 'multi_stage') {
+      if (m.payload.source === 'medical')   { s = resolveMedicalStage(s, 0); continue; }
+      if (m.payload.source === 'awayTeam')  { s = resolveAwayTeamStage(s, 0); continue; }
+      const { event, stageId } = m.payload;
+      const stage = event.stages[stageId];
+      s = { ...s, clickMetrics: recordDecision(s.clickMetrics, elapsedMs, stage.description) };
+
+      const emergencyEvent = isEmergency(event);
+      const aliveBefore = s.crew.filter(c => c.alive).length;
+      if (emergencyEvent && stageId === event.startStage) stats.emergenciesFired++;
+
+      const idx = pick(stage.choices);
+      if (emergencyEvent) {
+        if (stage.choices[idx]?.correct) stats.emergencyCorrectPicks++;
+        else stats.emergencyWrongPicks++;
+      }
+
+      const { state: next, nextStage } = applyStageChoice(s, event, stageId, idx);
+      const aliveAfter = next.crew.filter(c => c.alive).length;
+      if (emergencyEvent) stats.crewDeathsDuringEmergency += Math.max(0, aliveBefore - aliveAfter);
+
+      s = nextStage !== null
+        ? { ...next, activeModal: { type: 'multi_stage', payload: { event, stageId: nextStage } } }
+        : { ...next, activeModal: null };
+      continue;
+    }
+
+    if (canRepair(s) && s.resources.power < 35) { s = repairBattery(s); continue; }
+    if (canClean(s)  && s.resources.panels < 40) { s = cleanPanels(s);   continue; }
+    s = advanceSol(s, 'travel');
+  }
+
+  if (s.status === 'active') { s.status = 'lost'; s.lossReason = 'timeout'; }
+  return { state: s, stats };
+}
+
+function summary(label, runs) {
+  const n = runs.length;
+  const won = runs.filter(r => r.state.status === 'won').length;
+  const avgSol = runs.reduce((a, r) => a + r.state.sol, 0) / n;
+  const avgCrew = runs.reduce((a, r) => a + r.state.crew.filter(c => c.alive).length, 0) / n;
+  const lossReasons = {};
+  for (const r of runs) {
+    const reason = r.state.lossReason || 'won';
+    lossReasons[reason] = (lossReasons[reason] || 0) + 1;
+  }
+  const emerFired = runs.reduce((a, r) => a + r.stats.emergenciesFired, 0);
+  const emerCorrect = runs.reduce((a, r) => a + r.stats.emergencyCorrectPicks, 0);
+  const emerWrong = runs.reduce((a, r) => a + r.stats.emergencyWrongPicks, 0);
+  const emerCrewDeaths = runs.reduce((a, r) => a + r.stats.crewDeathsDuringEmergency, 0);
+
+  const pct = (x) => (x * 100).toFixed(1).padStart(5);
+  const pad = (x, w) => String(x).padStart(w);
+
+  console.log(`\n── ${label} (${n} runs) ───────────────────────────`);
+  console.log(`  wins:              ${pct(won / n)}% (${won}/${n})`);
+  console.log(`  avg sol:           ${avgSol.toFixed(1)}`);
+  console.log(`  avg crew alive:    ${avgCrew.toFixed(2)} / 5`);
+  console.log(`  emergencies fired: ${emerFired} total   (${(emerFired / n).toFixed(2)}/run avg)`);
+  console.log(`  emergency picks:   ${emerCorrect} correct · ${emerWrong} wrong   (${pct(emerCorrect / Math.max(1, emerCorrect + emerWrong))}% correct-by-chance)`);
+  console.log(`  crew lost during emergencies: ${emerCrewDeaths}`);
+  console.log(`  loss reasons:`);
+  for (const [k, v] of Object.entries(lossReasons).sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${pad(v, 4)} · ${k}`);
+  }
+}
+
+// ---- Run ----
+
+const N = 1000;
+const pickFirst = (choices) => 0;
+const pickRandom = (choices) => Math.floor(Math.random() * choices.length);
+
+const masher = [];
+for (let i = 0; i < N; i++) masher.push(playGame({ elapsedMs: 50, pick: pickFirst }));
+
+const reader = [];
+for (let i = 0; i < N; i++) reader.push(playGame({ elapsedMs: 20_000, pick: pickFirst }));
+
+const mashRandom = [];
+for (let i = 0; i < N; i++) mashRandom.push(playGame({ elapsedMs: 50, pick: pickRandom }));
+
+summary('MASHER (50ms · first choice)', masher);
+summary('READER (20s · first choice)', reader);
+summary('MASH-RANDOM (50ms · random choice)', mashRandom);
+
+console.log(`\nExpected correct-by-chance with 3 choices: 33.3%`);
+console.log(`Emergency cap per run: 2\n`);

--- a/sim/mashPlaytest.mjs
+++ b/sim/mashPlaytest.mjs
@@ -13,7 +13,7 @@ import { applyStageChoice } from '../src/systems/multiStage.js';
 import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from '../src/systems/awayTeam.js';
 import { resolveMedicalStage } from '../src/systems/medicalEmergency.js';
 import { makeLandmarkEncounter } from '../src/content/landmarks.js';
-import { recordDecision } from '../src/systems/clickMetrics.js';
+import { recordDecision, CLICK_METRICS_CONFIG } from '../src/systems/clickMetrics.js';
 
 function isEmergency(event) { return typeof event?.id === 'string' && event.id.startsWith('emer_'); }
 
@@ -152,4 +152,5 @@ summary('READER (20s · first choice)', reader);
 summary('MASH-RANDOM (50ms · random choice)', mashRandom);
 
 console.log(`\nExpected correct-by-chance with 3 choices: 33.3%`);
-console.log(`Emergency cap per run: 2\n`);
+console.log(`Emergency cap per run: ${CLICK_METRICS_CONFIG.maxEmergenciesPerRun}`);
+console.log(`Mash threshold: ${CLICK_METRICS_CONFIG.mashScoreThreshold}\n`);

--- a/src/content/emergencies.js
+++ b/src/content/emergencies.js
@@ -1,135 +1,330 @@
 // Mars Trail — emergency events (issue #63).
-// Fired only when the click-metrics heuristic flags sustained mash-through
-// behavior. Each event has exactly one "correct" choice whose clue is buried
-// in the description text — the wrong choices are catastrophic. If the
-// player is still mashing, they will almost certainly die. If they read
-// carefully, survival is likely but not free.
+// Multi-stage scenarios fired only when the click-metrics heuristic flags
+// sustained mash-through behavior. In each stage, the correct option is
+// spelled out in the description text; the wrong choices are catastrophic
+// (stage-1 wrong ends the scenario immediately with heavy losses).
+// A reader who slows down and pays attention can survive; a masher almost
+// certainly cannot.
 
 export const EMERGENCIES = [
+
+  // ── 1. Cabin breach ────────────────────────────────────────────────
   {
     id: 'emer_cabin_breach',
+    multiStage: true,
     severity: 'emergency',
     oneShot: false,
-    modal: {
-      title: 'CABIN BREACH — SECTION 4',
-      description:
-        'Klaxons. Section 4 is venting atmosphere. Alex is already at the lockers, shouting: ' +
-        '"The patch is in the GREEN locker. The red one is the oxygen bottle — if you grab that, ' +
-        'it ruptures and we all die." Pressure drop warning. You have seconds.',
-      choices: [
-        {
-          label: 'Grab the red locker',
-          outcome: {
-            oxygen: -35,
-            crewDamage: { amount: 55 },
-            narrative:
-              'The oxygen bottle ruptures. Shrapnel and a pressure wave tear through the cabin. ' +
-              'Crew take blunt-force injuries before the bulkhead seals.'
-          }
-        },
-        {
-          label: 'Grab the green locker',
-          correct: true,
-          outcome: {
-            oxygen: -8,
-            narrative:
-              'You slap the patch over the breach. Hull holds. Atmospherics stabilize after a long minute.'
-          }
-        },
-        {
-          label: 'Suit up first and re-assess',
-          outcome: {
-            oxygen: -22,
-            crewDamage: { amount: 25 },
-            narrative:
-              'Too slow. Half the cabin vents before the patch goes on. Crew take decompression injuries.'
-          }
-        }
-      ]
+    startStage: 'breach',
+    stages: {
+      breach: {
+        title: 'CABIN BREACH — SECTION 4',
+        description:
+          'Klaxons. Section 4 is venting atmosphere. Alex is already at the lockers, shouting: ' +
+          '"The patch is in the GREEN locker. The red one is the oxygen bottle — if you grab that ' +
+          'one it ruptures and we lose the cabin." Pressure drop warning. You have seconds.',
+        choices: [
+          { label: 'Grab the red locker',
+            outcome: {
+              oxygen: -35, crewDamage: { amount: 55 },
+              narrative: 'The oxygen bottle ruptures. Shrapnel tears through the cabin before the bulkhead seals.'
+            }, nextStage: null },
+          { label: 'Grab the green locker', correct: true,
+            outcome: { oxygen: -6, narrative: 'Patch on. Now the weld.' },
+            nextStage: 'weld' },
+          { label: 'Suit up first and re-assess',
+            outcome: {
+              oxygen: -22, crewDamage: { amount: 25 },
+              narrative: 'Too slow. Half the cabin vents before you get the patch on. Crew take decompression injuries.'
+            }, nextStage: null }
+        ]
+      },
+      weld: {
+        title: 'SEAL THE BREACH',
+        description:
+          'Patch is on but weeping. Riya at the scrubber console: "Cycle the O₂ scrubbers to MAX before ' +
+          'you strike the torch — sparks in high-O₂ atmosphere will ignite the seals. MAX first, then weld."',
+        choices: [
+          { label: 'Strike the torch now',
+            outcome: {
+              oxygen: -18, crewDamage: { amount: 30 },
+              narrative: 'Flash-fire. Two crew take burn injuries before the halon kicks in.'
+            }, nextStage: null },
+          { label: 'Scrubbers to MAX, then weld', correct: true,
+            outcome: { oxygen: -4, narrative: 'Weld holds. Atmospherics stabilize.' },
+            nextStage: null },
+          { label: 'Skip the weld — let the patch ride',
+            outcome: {
+              oxygen: -12,
+              narrative: 'Seal leaks for the rest of the sol. You lose atmosphere until a later repair.'
+            }, nextStage: null }
+        ]
+      }
     }
   },
 
+  // ── 2. Reactor flux excursion ──────────────────────────────────────
   {
-    id: 'emer_reactor_anomaly',
+    id: 'emer_reactor_flux',
+    multiStage: true,
     severity: 'emergency',
     oneShot: false,
-    modal: {
-      title: 'REACTOR — FLUX EXCURSION',
-      description:
-        'Power core warning. Mei reads the board out loud: "Neutron flux climbing. Manual override ' +
-        'is the LEFT handle. Do NOT pull the right handle — that dumps the coolant and we lose the core ' +
-        'for the rest of the run." You can hear the shielding ticking.',
-      choices: [
-        {
-          label: 'Pull the right handle',
-          outcome: {
-            power: -45,
-            cell: -2,
-            narrative:
-              'Coolant dumps. The core scrams cold and half your stored charge bleeds away trying to stabilize the bus.'
-          }
-        },
-        {
-          label: 'Pull the left handle',
-          correct: true,
-          outcome: {
-            power: -10,
-            narrative:
-              'Override engages. Flux drops into the green. A scare, nothing more.'
-          }
-        },
-        {
-          label: 'Shut it all down and wait',
-          outcome: {
-            power: -28,
-            crewDamage: { amount: 18 },
-            narrative:
-              'The flux keeps climbing while you stall. Shielding barely holds. Crew take a radiation dose before it settles.'
-          }
-        }
-      ]
+    startStage: 'handle',
+    stages: {
+      handle: {
+        title: 'REACTOR — FLUX EXCURSION',
+        description:
+          'Power core warning. Mei reads the board: "Neutron flux climbing. Manual override is the LEFT ' +
+          'handle. Do NOT pull the right handle — that dumps the coolant and we lose the core for the run." ' +
+          'Shielding is ticking.',
+        choices: [
+          { label: 'Pull the right handle',
+            outcome: {
+              power: -45, cell: -2,
+              narrative: 'Coolant dumps. Core cold-scrams; stored charge bleeds trying to hold the bus.'
+            }, nextStage: null },
+          { label: 'Pull the left handle', correct: true,
+            outcome: { power: -5, narrative: 'Override engages. Flux drops. Now bleed the poisons out.' },
+            nextStage: 'rods' },
+          { label: 'Shut everything down and wait',
+            outcome: {
+              power: -28, crewDamage: { amount: 18 },
+              narrative: 'Flux keeps climbing while you stall. Shielding barely holds. Crew take a dose.'
+            }, nextStage: null }
+        ]
+      },
+      rods: {
+        title: 'FLUSH THE POISONS',
+        description:
+          'Flux is down but xenon is accumulating. Mei at the control panel: "Drop control rods THIRTY ' +
+          'percent — not sixty. Sixty kills the core and we run on panels for the rest of the trip."',
+        choices: [
+          { label: 'Drop rods 60%',
+            outcome: {
+              power: -35, cell: -1,
+              narrative: 'Core goes subcritical. The rover limps on panels alone.'
+            }, nextStage: null },
+          { label: 'Drop rods 30%', correct: true,
+            outcome: { power: -6, narrative: 'Xenon burns off. Core stable.' },
+            nextStage: null },
+          { label: 'Leave the rods alone',
+            outcome: {
+              power: -20,
+              narrative: 'Xenon poisons the core overnight. Half the output for a day before it clears.'
+            }, nextStage: null }
+        ]
+      }
     }
   },
 
+  // ── 3. Nav blackout / dust storm ───────────────────────────────────
   {
     id: 'emer_dust_nav',
+    multiStage: true,
     severity: 'emergency',
     oneShot: false,
-    modal: {
-      title: 'NAV BLACKOUT — DUST STORM',
-      description:
-        'Primary nav cuts out mid-drive. Tomás is hunched over the backup chart: "Cliff two hundred meters ' +
-        'ahead on the current heading. Swing WEST along the ridge — NOT east, east drops into a boulder field. ' +
-        'West, now." Visibility is nothing.',
-      choices: [
-        {
-          label: 'Hold heading',
-          outcome: {
-            mech: -2,
-            crewDamage: { amount: 45 },
-            narrative:
-              'Rover tips over the cliff edge. Three crew take blunt-force trauma before the roll cage arrests the tumble.'
-          }
-        },
-        {
-          label: 'Swing east',
-          outcome: {
-            mech: -1,
-            crewDamage: { amount: 20 },
-            narrative:
-              'East slope is worse. Rover slams a boulder and slides. Minor injuries, bent chassis.'
-          }
-        },
-        {
-          label: 'Swing west',
-          correct: true,
-          outcome: {
-            power: -6,
-            narrative:
-              'Ridge holds. You crawl down through the dust, comms garbled, until the storm passes.'
-          }
-        }
-      ]
+    startStage: 'heading',
+    stages: {
+      heading: {
+        title: 'NAV BLACKOUT — DUST STORM',
+        description:
+          'Primary nav cuts out mid-drive. Tomás on the backup chart: "Cliff two hundred meters ahead ' +
+          'on current heading. Swing WEST along the ridge — NOT east, east drops into a boulder field. ' +
+          'West. Now."',
+        choices: [
+          { label: 'Hold heading',
+            outcome: {
+              mech: -2, crewDamage: { amount: 45 },
+              narrative: 'Rover tips over the cliff. Roll cage arrests the tumble; three crew hurt.'
+            }, nextStage: null },
+          { label: 'Swing east',
+            outcome: {
+              mech: -1, crewDamage: { amount: 20 },
+              narrative: 'East slope is worse. Rover slams a boulder. Minor injuries, bent chassis.'
+            }, nextStage: null },
+          { label: 'Swing west', correct: true,
+            outcome: { power: -4, narrative: 'Ridge holds. Now re-establish comms.' },
+            nextStage: 'relay' }
+        ]
+      },
+      relay: {
+        title: 'RAISE THE RELAY',
+        description:
+          'Through the ridge, dust thinning. Tomás: "Use the LONG passphrase from briefing — the short ' +
+          'one is an old decoy left in the log. Long unlock first, then ping Earth."',
+        choices: [
+          { label: 'Enter the short passphrase',
+            outcome: {
+              power: -8, sciencePoints: -5,
+              narrative: 'Decoy triggers lockout. Two sols of comms blackout; one data cache lost.'
+            }, nextStage: null },
+          { label: 'Enter the long passphrase', correct: true,
+            outcome: { power: -3, narrative: 'Relay live. Earth acknowledges.' },
+            nextStage: null },
+          { label: 'Skip it, drive through quiet',
+            outcome: { power: -6, narrative: 'No comms for a sol. Minor navigation drift until uplink is restored.' },
+            nextStage: null }
+        ]
+      }
+    }
+  },
+
+  // ── 4. NEW: Airlock jam with crew outside ──────────────────────────
+  {
+    id: 'emer_airlock_jam',
+    multiStage: true,
+    severity: 'emergency',
+    oneShot: false,
+    startStage: 'vent',
+    stages: {
+      vent: {
+        title: 'AIRLOCK JAMMED — SAM OUTSIDE',
+        description:
+          'Outer seal stuck. Sam is on tether, O₂ bleeding. Alex at the panel: "Cycle the MANUAL vent ' +
+          'three times — do NOT hit the emergency purge. Purge blows the hatch outward and takes Sam ' +
+          'with it. Manual vent, three cycles, now."',
+        choices: [
+          { label: 'Emergency purge',
+            outcome: {
+              oxygen: -20, crewDamage: { role: 'security', amount: 80 },
+              narrative: 'Hatch blows. Sam takes the full decompression; tether holds but barely.'
+            }, nextStage: null },
+          { label: 'Manual vent, three cycles', correct: true,
+            outcome: { oxygen: -4, narrative: 'Seal breaks. Sam is stumbling through the inner hatch.' },
+            nextStage: 'stabilize' },
+          { label: 'Call Sam to re-tether and wait',
+            outcome: {
+              oxygen: -10, crewDamage: { role: 'security', amount: 35 },
+              narrative: 'Sam runs out of O₂ on the tether before you can re-cycle. Brain-hypoxia injury.'
+            }, nextStage: null }
+        ]
+      },
+      stabilize: {
+        title: 'STABILIZE SAM',
+        description:
+          'Sam is in, unconscious. Tomás readies the kit: "Blue injector FIRST — it opens the airway. ' +
+          'Then oxygen. Reverse the order and you trigger a seizure."',
+        choices: [
+          { label: 'Oxygen first, then blue injector',
+            outcome: {
+              crewDamage: { role: 'security', amount: 40 },
+              narrative: 'Seizure. Sam survives, but with lasting damage.'
+            }, nextStage: null },
+          { label: 'Blue injector first, then oxygen', correct: true,
+            outcome: { crewDamage: { role: 'security', amount: 8 }, narrative: 'Airway opens. Sam stabilizes.' },
+            nextStage: null },
+          { label: 'Skip the injector — O₂ should be enough',
+            outcome: {
+              crewDamage: { role: 'security', amount: 25 },
+              narrative: 'Airway stays half-closed. Sam gets enough O₂ to live but coughs blood for a sol.'
+            }, nextStage: null }
+        ]
+      }
+    }
+  },
+
+  // ── 5. NEW: Radiation storm spike ──────────────────────────────────
+  {
+    id: 'emer_radiation_storm',
+    multiStage: true,
+    severity: 'emergency',
+    oneShot: false,
+    startStage: 'shelter',
+    stages: {
+      shelter: {
+        title: 'RADIATION STORM — INCOMING',
+        description:
+          'Flare alert. Mei over the intercom: "Head to the STARBOARD shelter — the port shelter\'s ' +
+          'lead liner cracked last week. Starboard. Not port. Starboard."',
+        choices: [
+          { label: 'Run to the port shelter',
+            outcome: {
+              crewDamage: { amount: 50 },
+              narrative: 'Liner leaks. Half the crew take a heavy dose before you relocate.'
+            }, nextStage: null },
+          { label: 'Run to the starboard shelter', correct: true,
+            outcome: { power: -3, narrative: 'Shielding holds. Now wait it out.' },
+            nextStage: 'wait' },
+          { label: 'Shelter in the rover cab instead',
+            outcome: {
+              crewDamage: { amount: 25 },
+              narrative: 'Cab shielding is thin. Crew dose is manageable but will cost you later.'
+            }, nextStage: null }
+        ]
+      },
+      wait: {
+        title: 'WAIT OUT THE FLARE',
+        description:
+          'Dosimeters flickering. Tomás: "We wait NINETY minutes — not forty-five. Early exit kills the ' +
+          'bone marrow. Ninety. Even if it feels fine."',
+        choices: [
+          { label: 'Exit at 45 minutes',
+            outcome: {
+              crewDamage: { amount: 35 },
+              narrative: 'Secondary flare catches the crew in the open. Marrow damage; HP loss across the roster.'
+            }, nextStage: null },
+          { label: 'Wait 90 minutes', correct: true,
+            outcome: { water: -4, food: -4, narrative: 'Flare passes. Everyone out healthy. Morale hit, but alive.' },
+            nextStage: null },
+          { label: 'Wait indefinitely to be safe',
+            outcome: {
+              water: -10, food: -10, oxygen: -8,
+              narrative: 'Extra hours burn resources you needed for the next leg.'
+            }, nextStage: null }
+        ]
+      }
+    }
+  },
+
+  // ── 6. NEW: Software lockup (nav freeze) ───────────────────────────
+  {
+    id: 'emer_software_lockup',
+    multiStage: true,
+    severity: 'emergency',
+    oneShot: false,
+    startStage: 'reboot',
+    stages: {
+      reboot: {
+        title: 'SOFTWARE LOCKUP — CONTROL FROZEN',
+        description:
+          'Main control unresponsive. Alex working the diagnostic: "WARM reboot — hold the AMBER key ' +
+          'for ten seconds. Do NOT hit the red key — that cold-boots us and wipes the waypoint cache."',
+        choices: [
+          { label: 'Hit the red key',
+            outcome: {
+              sciencePoints: -10, power: -8,
+              narrative: 'Cold boot. Waypoint cache scrubbed. You lose a batch of cached science.'
+            }, nextStage: null },
+          { label: 'Hold the amber key ten seconds', correct: true,
+            outcome: { power: -2, narrative: 'Warm reboot. Systems coming back. One more step.' },
+            nextStage: 'autopilot' },
+          { label: 'Pull the battery and wait',
+            outcome: {
+              power: -15,
+              narrative: 'Hard shutdown. Boot takes the better part of an hour.'
+            }, nextStage: null }
+        ]
+      },
+      autopilot: {
+        title: 'RE-ENABLE AUTOPILOT',
+        description:
+          'Control back. Riya from the copilot seat: "Disable motion-learning BEFORE you re-arm autopilot. ' +
+          'If autopilot ingests the garbage from the freeze window, it\'ll steer us sideways for a sol."',
+        choices: [
+          { label: 'Re-arm autopilot as-is',
+            outcome: {
+              mech: -1, power: -10,
+              narrative: 'Autopilot corrects for phantom obstacles all sol. Drift costs you distance.'
+            }, nextStage: null },
+          { label: 'Disable motion-learning, then re-arm', correct: true,
+            outcome: { power: -2, narrative: 'Clean re-arm. Rover runs straight.' },
+            nextStage: null },
+          { label: 'Drive manual the rest of the sol',
+            outcome: {
+              crewDamage: { role: 'pilot', amount: 10 },
+              narrative: 'Long shift in the seat. Mei takes a neck strain but the trip is uneventful.'
+            }, nextStage: null }
+        ]
+      }
     }
   }
 ];

--- a/src/content/emergencies.js
+++ b/src/content/emergencies.js
@@ -1,62 +1,70 @@
 // Mars Trail — emergency events (issue #63).
 // Multi-stage scenarios fired only when the click-metrics heuristic flags
-// sustained mash-through behavior. In each stage, the correct option is
-// spelled out in the description text; the wrong choices are catastrophic
-// (stage-1 wrong ends the scenario immediately with heavy losses).
-// A reader who slows down and pays attention can survive; a masher almost
-// certainly cannot.
+// sustained mash-through behavior.
+//
+// Each stage is a TEMPLATE: a description with {{slot}} placeholders, choice
+// templates (labels also using placeholders), and a list of variants. At
+// fire time we pick a fresh variant per stage and shuffle choice order so
+// the player can't memorize the "right button" across runs. A reader who
+// slows down and follows the clue survives; a masher almost certainly does
+// not.
 
-export const EMERGENCIES = [
+export const EMERGENCY_TEMPLATES = [
 
   // ── 1. Cabin breach ────────────────────────────────────────────────
   {
     id: 'emer_cabin_breach',
-    multiStage: true,
     severity: 'emergency',
-    oneShot: false,
     startStage: 'breach',
     stages: {
       breach: {
         title: 'CABIN BREACH — SECTION 4',
-        description:
+        descriptionTemplate:
           'Klaxons. Section 4 is venting atmosphere. Alex is already at the lockers, shouting: ' +
-          '"The patch is in the GREEN locker. The red one is the oxygen bottle — if you grab that ' +
-          'one it ruptures and we lose the cabin." Pressure drop warning. You have seconds.',
-        choices: [
-          { label: 'Grab the red locker',
-            outcome: {
-              oxygen: -35, crewDamage: { amount: 55 },
-              narrative: 'The oxygen bottle ruptures. Shrapnel tears through the cabin before the bulkhead seals.'
-            }, nextStage: null },
-          { label: 'Grab the green locker', correct: true,
+          '"The patch is in the {{correct}} locker. The {{wrong1}} one is the oxygen bottle — if you ' +
+          'grab that it ruptures and we lose the cabin." Pressure drop warning. You have seconds.',
+        variants: [
+          { correct: 'GREEN',  wrong1: 'red',    wrong2: 'yellow' },
+          { correct: 'BLUE',   wrong1: 'amber',  wrong2: 'grey'   },
+          { correct: 'SILVER', wrong1: 'black',  wrong2: 'orange' }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Grab the {{wrong1}} locker',
+            outcome: { oxygen: -35, crewDamage: { amount: 55 },
+              narrative: 'The oxygen bottle ruptures. Shrapnel tears through the cabin before the bulkhead seals.' },
+            nextStage: null },
+          { labelTemplate: 'Grab the {{correct}} locker', correct: true,
             outcome: { oxygen: -6, narrative: 'Patch on. Now the weld.' },
             nextStage: 'weld' },
-          { label: 'Suit up first and re-assess',
-            outcome: {
-              oxygen: -22, crewDamage: { amount: 25 },
-              narrative: 'Too slow. Half the cabin vents before you get the patch on. Crew take decompression injuries.'
-            }, nextStage: null }
+          { labelTemplate: 'Grab the {{wrong2}} locker',
+            outcome: { oxygen: -22, crewDamage: { amount: 25 },
+              narrative: 'Wrong locker. Half the cabin vents before you get the right one out.' },
+            nextStage: null }
         ]
       },
       weld: {
         title: 'SEAL THE BREACH',
-        description:
-          'Patch is on but weeping. Riya at the scrubber console: "Cycle the O₂ scrubbers to MAX before ' +
-          'you strike the torch — sparks in high-O₂ atmosphere will ignite the seals. MAX first, then weld."',
-        choices: [
-          { label: 'Strike the torch now',
-            outcome: {
-              oxygen: -18, crewDamage: { amount: 30 },
-              narrative: 'Flash-fire. Two crew take burn injuries before the halon kicks in.'
-            }, nextStage: null },
-          { label: 'Scrubbers to MAX, then weld', correct: true,
+        descriptionTemplate:
+          'Patch is on but weeping. Riya at the scrubber console: "Cycle the O₂ scrubbers to {{correct}} ' +
+          'before you strike the torch — sparks in a higher-O₂ atmosphere will ignite the seals. ' +
+          '{{correct}} first, then weld. Not {{wrong1}}."',
+        variants: [
+          { correct: 'MAX',     wrong1: 'MIN',     wrong2: 'AUTO'    },
+          { correct: 'LEVEL 3', wrong1: 'LEVEL 1', wrong2: 'STANDBY' },
+          { correct: 'PURGE',   wrong1: 'IDLE',    wrong2: 'CYCLE'   }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Scrubbers to {{wrong1}}, then weld',
+            outcome: { oxygen: -18, crewDamage: { amount: 30 },
+              narrative: 'Flash-fire. Two crew take burn injuries before the halon kicks in.' },
+            nextStage: null },
+          { labelTemplate: 'Scrubbers to {{correct}}, then weld', correct: true,
             outcome: { oxygen: -4, narrative: 'Weld holds. Atmospherics stabilize.' },
             nextStage: null },
-          { label: 'Skip the weld — let the patch ride',
-            outcome: {
-              oxygen: -12,
-              narrative: 'Seal leaks for the rest of the sol. You lose atmosphere until a later repair.'
-            }, nextStage: null }
+          { labelTemplate: 'Skip the weld — let the patch ride',
+            outcome: { oxygen: -12,
+              narrative: 'Seal leaks the rest of the sol. You bleed atmosphere until a later repair.' },
+            nextStage: null }
         ]
       }
     }
@@ -65,52 +73,57 @@ export const EMERGENCIES = [
   // ── 2. Reactor flux excursion ──────────────────────────────────────
   {
     id: 'emer_reactor_flux',
-    multiStage: true,
     severity: 'emergency',
-    oneShot: false,
     startStage: 'handle',
     stages: {
       handle: {
         title: 'REACTOR — FLUX EXCURSION',
-        description:
-          'Power core warning. Mei reads the board: "Neutron flux climbing. Manual override is the LEFT ' +
-          'handle. Do NOT pull the right handle — that dumps the coolant and we lose the core for the run." ' +
-          'Shielding is ticking.',
-        choices: [
-          { label: 'Pull the right handle',
-            outcome: {
-              power: -45, cell: -2,
-              narrative: 'Coolant dumps. Core cold-scrams; stored charge bleeds trying to hold the bus.'
-            }, nextStage: null },
-          { label: 'Pull the left handle', correct: true,
+        descriptionTemplate:
+          'Power core warning. Mei reads the board: "Neutron flux climbing. Manual override is the ' +
+          '{{correct}} handle. Do NOT pull the {{wrong1}} handle — that dumps the coolant and we lose ' +
+          'the core for the run." Shielding is ticking.',
+        variants: [
+          { correct: 'LEFT',  wrong1: 'RIGHT', wrong2: 'CENTER' },
+          { correct: 'UPPER', wrong1: 'LOWER', wrong2: 'SIDE'   },
+          { correct: 'NEAR',  wrong1: 'FAR',   wrong2: 'REAR'   }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Pull the {{wrong1}} handle',
+            outcome: { power: -45, cell: -2,
+              narrative: 'Coolant dumps. Core cold-scrams; stored charge bleeds trying to hold the bus.' },
+            nextStage: null },
+          { labelTemplate: 'Pull the {{correct}} handle', correct: true,
             outcome: { power: -5, narrative: 'Override engages. Flux drops. Now bleed the poisons out.' },
             nextStage: 'rods' },
-          { label: 'Shut everything down and wait',
-            outcome: {
-              power: -28, crewDamage: { amount: 18 },
-              narrative: 'Flux keeps climbing while you stall. Shielding barely holds. Crew take a dose.'
-            }, nextStage: null }
+          { labelTemplate: 'Pull the {{wrong2}} handle',
+            outcome: { power: -25, crewDamage: { amount: 20 },
+              narrative: 'Wrong handle. Flux spike holds long enough for crew to take a dose.' },
+            nextStage: null }
         ]
       },
       rods: {
         title: 'FLUSH THE POISONS',
-        description:
-          'Flux is down but xenon is accumulating. Mei at the control panel: "Drop control rods THIRTY ' +
-          'percent — not sixty. Sixty kills the core and we run on panels for the rest of the trip."',
-        choices: [
-          { label: 'Drop rods 60%',
-            outcome: {
-              power: -35, cell: -1,
-              narrative: 'Core goes subcritical. The rover limps on panels alone.'
-            }, nextStage: null },
-          { label: 'Drop rods 30%', correct: true,
+        descriptionTemplate:
+          'Flux is down but xenon is accumulating. Mei at the control panel: "Drop control rods ' +
+          '{{correct}} — not {{wrong1}}. {{wrong1}} kills the core and we run on panels for the rest ' +
+          'of the trip."',
+        variants: [
+          { correct: '30%', wrong1: '60%', wrong2: '10%' },
+          { correct: '25%', wrong1: '50%', wrong2: '75%' },
+          { correct: '40%', wrong1: '80%', wrong2: '15%' }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Drop rods {{wrong1}}',
+            outcome: { power: -35, cell: -1,
+              narrative: 'Core goes subcritical. The rover limps on panels alone.' },
+            nextStage: null },
+          { labelTemplate: 'Drop rods {{correct}}', correct: true,
             outcome: { power: -6, narrative: 'Xenon burns off. Core stable.' },
             nextStage: null },
-          { label: 'Leave the rods alone',
-            outcome: {
-              power: -20,
-              narrative: 'Xenon poisons the core overnight. Half the output for a day before it clears.'
-            }, nextStage: null }
+          { labelTemplate: 'Drop rods {{wrong2}}',
+            outcome: { power: -18,
+              narrative: 'Too little. Xenon keeps climbing overnight. Half output for a sol.' },
+            nextStage: null }
         ]
       }
     }
@@ -119,217 +132,286 @@ export const EMERGENCIES = [
   // ── 3. Nav blackout / dust storm ───────────────────────────────────
   {
     id: 'emer_dust_nav',
-    multiStage: true,
     severity: 'emergency',
-    oneShot: false,
     startStage: 'heading',
     stages: {
       heading: {
         title: 'NAV BLACKOUT — DUST STORM',
-        description:
+        descriptionTemplate:
           'Primary nav cuts out mid-drive. Tomás on the backup chart: "Cliff two hundred meters ahead ' +
-          'on current heading. Swing WEST along the ridge — NOT east, east drops into a boulder field. ' +
-          'West. Now."',
-        choices: [
-          { label: 'Hold heading',
-            outcome: {
-              mech: -2, crewDamage: { amount: 45 },
-              narrative: 'Rover tips over the cliff. Roll cage arrests the tumble; three crew hurt.'
-            }, nextStage: null },
-          { label: 'Swing east',
-            outcome: {
-              mech: -1, crewDamage: { amount: 20 },
-              narrative: 'East slope is worse. Rover slams a boulder. Minor injuries, bent chassis.'
-            }, nextStage: null },
-          { label: 'Swing west', correct: true,
+          'on current heading. Swing {{correct}} along the ridge — NOT {{wrong1}}, {{wrong1}} drops ' +
+          'into a boulder field. {{correct}}. Now."',
+        variants: [
+          { correct: 'WEST',  wrong1: 'east',  wrong2: 'south' },
+          { correct: 'NORTH', wrong1: 'south', wrong2: 'east'  },
+          { correct: 'UPHILL', wrong1: 'downhill', wrong2: 'straight' }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Hold heading',
+            outcome: { mech: -2, crewDamage: { amount: 45 },
+              narrative: 'Rover tips over the cliff edge. Three crew take blunt-force trauma.' },
+            nextStage: null },
+          { labelTemplate: 'Swing {{wrong1}}',
+            outcome: { mech: -1, crewDamage: { amount: 20 },
+              narrative: 'Wrong side. Rover slams a boulder and slides. Minor injuries, bent chassis.' },
+            nextStage: null },
+          { labelTemplate: 'Swing {{correct}}', correct: true,
             outcome: { power: -4, narrative: 'Ridge holds. Now re-establish comms.' },
             nextStage: 'relay' }
         ]
       },
       relay: {
         title: 'RAISE THE RELAY',
-        description:
-          'Through the ridge, dust thinning. Tomás: "Use the LONG passphrase from briefing — the short ' +
-          'one is an old decoy left in the log. Long unlock first, then ping Earth."',
-        choices: [
-          { label: 'Enter the short passphrase',
-            outcome: {
-              power: -8, sciencePoints: -5,
-              narrative: 'Decoy triggers lockout. Two sols of comms blackout; one data cache lost.'
-            }, nextStage: null },
-          { label: 'Enter the long passphrase', correct: true,
+        descriptionTemplate:
+          'Through the ridge, dust thinning. Tomás: "Use the {{correct}} passphrase from briefing — ' +
+          '{{wrong1}} is an old decoy left in the log. {{correct}} unlock first, then ping Earth."',
+        variants: [
+          { correct: 'LONG',    wrong1: 'short',   wrong2: 'legacy' },
+          { correct: 'PRIMARY', wrong1: 'backup',  wrong2: 'test'   },
+          { correct: 'SIGMA',   wrong1: 'OMEGA',   wrong2: 'THETA'  }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Enter the {{wrong1}} passphrase',
+            outcome: { power: -8, sciencePoints: -5,
+              narrative: 'Decoy triggers lockout. Two sols of comms blackout; one data cache lost.' },
+            nextStage: null },
+          { labelTemplate: 'Enter the {{correct}} passphrase', correct: true,
             outcome: { power: -3, narrative: 'Relay live. Earth acknowledges.' },
             nextStage: null },
-          { label: 'Skip it, drive through quiet',
-            outcome: { power: -6, narrative: 'No comms for a sol. Minor navigation drift until uplink is restored.' },
+          { labelTemplate: 'Skip it — drive through quiet',
+            outcome: { power: -6,
+              narrative: 'No comms for a sol. Minor nav drift until the uplink is restored.' },
             nextStage: null }
         ]
       }
     }
   },
 
-  // ── 4. NEW: Airlock jam with crew outside ──────────────────────────
+  // ── 4. Airlock jam with crew outside ───────────────────────────────
   {
     id: 'emer_airlock_jam',
-    multiStage: true,
     severity: 'emergency',
-    oneShot: false,
     startStage: 'vent',
     stages: {
       vent: {
         title: 'AIRLOCK JAMMED — SAM OUTSIDE',
-        description:
-          'Outer seal stuck. Sam is on tether, O₂ bleeding. Alex at the panel: "Cycle the MANUAL vent ' +
-          'three times — do NOT hit the emergency purge. Purge blows the hatch outward and takes Sam ' +
-          'with it. Manual vent, three cycles, now."',
-        choices: [
-          { label: 'Emergency purge',
-            outcome: {
-              oxygen: -20, crewDamage: { role: 'security', amount: 80 },
-              narrative: 'Hatch blows. Sam takes the full decompression; tether holds but barely.'
-            }, nextStage: null },
-          { label: 'Manual vent, three cycles', correct: true,
+        descriptionTemplate:
+          'Outer seal stuck. Sam is on tether, O₂ bleeding. Alex at the panel: "Cycle the {{correct}} ' +
+          'vent three times — do NOT hit the {{wrong1}}. {{wrong1}} blows the hatch outward and takes ' +
+          'Sam with it. {{correct}} vent. Three cycles. Now."',
+        variants: [
+          { correct: 'MANUAL',  wrong1: 'emergency purge', wrong2: 'override' },
+          { correct: 'SECONDARY', wrong1: 'blast vent',   wrong2: 'primary'  },
+          { correct: 'SLOW',    wrong1: 'full purge',     wrong2: 'rapid'    }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Hit the {{wrong1}}',
+            outcome: { oxygen: -20, crewDamage: { role: 'security', amount: 80 },
+              narrative: 'Hatch blows. Sam takes the full decompression; tether holds but barely.' },
+            nextStage: null },
+          { labelTemplate: '{{correct}} vent, three cycles', correct: true,
             outcome: { oxygen: -4, narrative: 'Seal breaks. Sam is stumbling through the inner hatch.' },
             nextStage: 'stabilize' },
-          { label: 'Call Sam to re-tether and wait',
-            outcome: {
-              oxygen: -10, crewDamage: { role: 'security', amount: 35 },
-              narrative: 'Sam runs out of O₂ on the tether before you can re-cycle. Brain-hypoxia injury.'
-            }, nextStage: null }
+          { labelTemplate: 'Hit the {{wrong2}}',
+            outcome: { oxygen: -10, crewDamage: { role: 'security', amount: 35 },
+              narrative: 'Sam runs out of O₂ on the tether before you cycle through. Brain-hypoxia injury.' },
+            nextStage: null }
         ]
       },
       stabilize: {
         title: 'STABILIZE SAM',
-        description:
-          'Sam is in, unconscious. Tomás readies the kit: "Blue injector FIRST — it opens the airway. ' +
-          'Then oxygen. Reverse the order and you trigger a seizure."',
-        choices: [
-          { label: 'Oxygen first, then blue injector',
-            outcome: {
-              crewDamage: { role: 'security', amount: 40 },
-              narrative: 'Seizure. Sam survives, but with lasting damage.'
-            }, nextStage: null },
-          { label: 'Blue injector first, then oxygen', correct: true,
+        descriptionTemplate:
+          'Sam is in, unconscious. Tomás readies the kit: "{{correct}} injector FIRST — it opens the ' +
+          'airway. Then oxygen. Reverse the order and you trigger a seizure. {{correct}} before ' +
+          'oxygen. Not {{wrong1}}."',
+        variants: [
+          { correct: 'BLUE',    wrong1: 'red',    wrong2: 'the large' },
+          { correct: 'AMBER',   wrong1: 'clear',  wrong2: 'secondary' },
+          { correct: 'LABELED-A', wrong1: 'labeled-B', wrong2: 'unlabeled' }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Oxygen first, then the {{correct}} injector',
+            outcome: { crewDamage: { role: 'security', amount: 40 },
+              narrative: 'Seizure. Sam survives, but with lasting damage.' },
+            nextStage: null },
+          { labelTemplate: '{{correct}} injector first, then oxygen', correct: true,
             outcome: { crewDamage: { role: 'security', amount: 8 }, narrative: 'Airway opens. Sam stabilizes.' },
             nextStage: null },
-          { label: 'Skip the injector — O₂ should be enough',
-            outcome: {
-              crewDamage: { role: 'security', amount: 25 },
-              narrative: 'Airway stays half-closed. Sam gets enough O₂ to live but coughs blood for a sol.'
-            }, nextStage: null }
+          { labelTemplate: '{{wrong1}} injector first, then oxygen',
+            outcome: { crewDamage: { role: 'security', amount: 55 },
+              narrative: 'Wrong drug. Cardiac arrest. Tomás restarts the heart, but damage is done.' },
+            nextStage: null }
         ]
       }
     }
   },
 
-  // ── 5. NEW: Radiation storm spike ──────────────────────────────────
+  // ── 5. Radiation storm spike ───────────────────────────────────────
   {
     id: 'emer_radiation_storm',
-    multiStage: true,
     severity: 'emergency',
-    oneShot: false,
     startStage: 'shelter',
     stages: {
       shelter: {
         title: 'RADIATION STORM — INCOMING',
-        description:
-          'Flare alert. Mei over the intercom: "Head to the STARBOARD shelter — the port shelter\'s ' +
-          'lead liner cracked last week. Starboard. Not port. Starboard."',
-        choices: [
-          { label: 'Run to the port shelter',
-            outcome: {
-              crewDamage: { amount: 50 },
-              narrative: 'Liner leaks. Half the crew take a heavy dose before you relocate.'
-            }, nextStage: null },
-          { label: 'Run to the starboard shelter', correct: true,
+        descriptionTemplate:
+          'Flare alert. Mei over the intercom: "Head to the {{correct}} shelter — the {{wrong1}} ' +
+          'shelter\'s lead liner cracked last week. {{correct}}. Not {{wrong1}}. {{correct}}."',
+        variants: [
+          { correct: 'STARBOARD', wrong1: 'port',     wrong2: 'forward' },
+          { correct: 'UPPER',     wrong1: 'lower',    wrong2: 'aft'     },
+          { correct: 'AFT',       wrong1: 'forward',  wrong2: 'central' }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Run to the {{wrong1}} shelter',
+            outcome: { crewDamage: { amount: 50 },
+              narrative: 'Cracked liner leaks. Half the crew take a heavy dose before you relocate.' },
+            nextStage: null },
+          { labelTemplate: 'Run to the {{correct}} shelter', correct: true,
             outcome: { power: -3, narrative: 'Shielding holds. Now wait it out.' },
             nextStage: 'wait' },
-          { label: 'Shelter in the rover cab instead',
-            outcome: {
-              crewDamage: { amount: 25 },
-              narrative: 'Cab shielding is thin. Crew dose is manageable but will cost you later.'
-            }, nextStage: null }
+          { labelTemplate: 'Shelter in the rover cab',
+            outcome: { crewDamage: { amount: 25 },
+              narrative: 'Cab shielding is thin. Dose is manageable but will cost you later.' },
+            nextStage: null }
         ]
       },
       wait: {
         title: 'WAIT OUT THE FLARE',
-        description:
-          'Dosimeters flickering. Tomás: "We wait NINETY minutes — not forty-five. Early exit kills the ' +
-          'bone marrow. Ninety. Even if it feels fine."',
-        choices: [
-          { label: 'Exit at 45 minutes',
-            outcome: {
-              crewDamage: { amount: 35 },
-              narrative: 'Secondary flare catches the crew in the open. Marrow damage; HP loss across the roster.'
-            }, nextStage: null },
-          { label: 'Wait 90 minutes', correct: true,
-            outcome: { water: -4, food: -4, narrative: 'Flare passes. Everyone out healthy. Morale hit, but alive.' },
+        descriptionTemplate:
+          'Dosimeters flickering. Tomás: "We wait {{correct}} minutes — not {{wrong1}}. Early exit ' +
+          'kills the bone marrow. {{correct}}. Even if it feels fine."',
+        variants: [
+          { correct: '90',  wrong1: '45',  wrong2: '180' },
+          { correct: '120', wrong1: '60',  wrong2: '240' },
+          { correct: '75',  wrong1: '30',  wrong2: '150' }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Exit at {{wrong1}} minutes',
+            outcome: { crewDamage: { amount: 35 },
+              narrative: 'Secondary flare catches the crew in the open. Marrow damage across the roster.' },
             nextStage: null },
-          { label: 'Wait indefinitely to be safe',
-            outcome: {
-              water: -10, food: -10, oxygen: -8,
-              narrative: 'Extra hours burn resources you needed for the next leg.'
-            }, nextStage: null }
+          { labelTemplate: 'Wait {{correct}} minutes', correct: true,
+            outcome: { water: -4, food: -4, narrative: 'Flare passes. Everyone out healthy.' },
+            nextStage: null },
+          { labelTemplate: 'Wait {{wrong2}} minutes to be safe',
+            outcome: { water: -10, food: -10, oxygen: -8,
+              narrative: 'Extra hours burn resources you needed for the next leg.' },
+            nextStage: null }
         ]
       }
     }
   },
 
-  // ── 6. NEW: Software lockup (nav freeze) ───────────────────────────
+  // ── 6. Software lockup ─────────────────────────────────────────────
   {
     id: 'emer_software_lockup',
-    multiStage: true,
     severity: 'emergency',
-    oneShot: false,
     startStage: 'reboot',
     stages: {
       reboot: {
         title: 'SOFTWARE LOCKUP — CONTROL FROZEN',
-        description:
-          'Main control unresponsive. Alex working the diagnostic: "WARM reboot — hold the AMBER key ' +
-          'for ten seconds. Do NOT hit the red key — that cold-boots us and wipes the waypoint cache."',
-        choices: [
-          { label: 'Hit the red key',
-            outcome: {
-              sciencePoints: -10, power: -8,
-              narrative: 'Cold boot. Waypoint cache scrubbed. You lose a batch of cached science.'
-            }, nextStage: null },
-          { label: 'Hold the amber key ten seconds', correct: true,
+        descriptionTemplate:
+          'Main control unresponsive. Alex working the diagnostic: "WARM reboot — hold the {{correct}} ' +
+          'key for ten seconds. Do NOT hit the {{wrong1}} key — that cold-boots us and wipes the ' +
+          'waypoint cache."',
+        variants: [
+          { correct: 'AMBER', wrong1: 'red',    wrong2: 'green' },
+          { correct: 'BLUE',  wrong1: 'yellow', wrong2: 'white' },
+          { correct: 'F7',    wrong1: 'F12',    wrong2: 'F2'    }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Hit the {{wrong1}} key',
+            outcome: { sciencePoints: -10, power: -8,
+              narrative: 'Cold boot. Waypoint cache scrubbed. You lose a batch of cached science.' },
+            nextStage: null },
+          { labelTemplate: 'Hold the {{correct}} key ten seconds', correct: true,
             outcome: { power: -2, narrative: 'Warm reboot. Systems coming back. One more step.' },
             nextStage: 'autopilot' },
-          { label: 'Pull the battery and wait',
-            outcome: {
-              power: -15,
-              narrative: 'Hard shutdown. Boot takes the better part of an hour.'
-            }, nextStage: null }
+          { labelTemplate: 'Pull the battery and wait',
+            outcome: { power: -15,
+              narrative: 'Hard shutdown. Boot takes the better part of an hour.' },
+            nextStage: null }
         ]
       },
       autopilot: {
         title: 'RE-ENABLE AUTOPILOT',
-        description:
-          'Control back. Riya from the copilot seat: "Disable motion-learning BEFORE you re-arm autopilot. ' +
-          'If autopilot ingests the garbage from the freeze window, it\'ll steer us sideways for a sol."',
-        choices: [
-          { label: 'Re-arm autopilot as-is',
-            outcome: {
-              mech: -1, power: -10,
-              narrative: 'Autopilot corrects for phantom obstacles all sol. Drift costs you distance.'
-            }, nextStage: null },
-          { label: 'Disable motion-learning, then re-arm', correct: true,
+        descriptionTemplate:
+          'Control back. Riya from the copilot seat: "Disable {{correct}} BEFORE you re-arm autopilot. ' +
+          'If autopilot ingests the garbage from the freeze window, it will steer us sideways for a sol. ' +
+          '{{correct}} off first."',
+        variants: [
+          { correct: 'motion-learning', wrong1: 'all autopilot settings', wrong2: 'autopilot entirely' },
+          { correct: 'adaptive-nav',    wrong1: 'the full sensor stack',  wrong2: 'autopilot entirely' },
+          { correct: 'terrain-predict', wrong1: 'the cached map',         wrong2: 'autopilot entirely' }
+        ],
+        choiceTemplates: [
+          { labelTemplate: 'Re-arm autopilot as-is',
+            outcome: { mech: -1, power: -10,
+              narrative: 'Autopilot corrects for phantom obstacles all sol. Drift costs you distance.' },
+            nextStage: null },
+          { labelTemplate: 'Disable {{correct}}, then re-arm', correct: true,
             outcome: { power: -2, narrative: 'Clean re-arm. Rover runs straight.' },
             nextStage: null },
-          { label: 'Drive manual the rest of the sol',
-            outcome: {
-              crewDamage: { role: 'pilot', amount: 10 },
-              narrative: 'Long shift in the seat. Mei takes a neck strain but the trip is uneventful.'
-            }, nextStage: null }
+          { labelTemplate: 'Disable {{wrong1}}',
+            outcome: { power: -12, crewDamage: { role: 'pilot', amount: 10 },
+              narrative: 'You cut too much. Mei drives manually while the stack reboots.' },
+            nextStage: null }
         ]
       }
     }
   }
 ];
 
-// Pick an emergency event at random. Pure function.
+// ---- Materialization ----
+
+function fillTemplate(str, vars) {
+  return String(str).replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
+}
+
+function shuffled(arr) {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function materializeStage(stageTemplate) {
+  const variant = stageTemplate.variants[Math.floor(Math.random() * stageTemplate.variants.length)];
+  const choices = stageTemplate.choiceTemplates.map(c => ({
+    label: fillTemplate(c.labelTemplate, variant),
+    outcome: c.outcome,
+    nextStage: c.nextStage,
+    correct: !!c.correct
+  }));
+  return {
+    title: stageTemplate.title,
+    description: fillTemplate(stageTemplate.descriptionTemplate, variant),
+    choices: shuffled(choices)
+  };
+}
+
+export function materializeEmergency(template) {
+  const stages = {};
+  for (const [stageId, stageTemplate] of Object.entries(template.stages)) {
+    stages[stageId] = materializeStage(stageTemplate);
+  }
+  return {
+    id: template.id,
+    multiStage: true,
+    severity: template.severity,
+    oneShot: false,
+    startStage: template.startStage,
+    stages
+  };
+}
+
+// Pick an emergency template at random and materialize it (fresh variant
+// per stage + shuffled choices). Returns a concrete event consumable by
+// applyStageChoice/showMultiStageModal.
 export function pickEmergency() {
-  return EMERGENCIES[Math.floor(Math.random() * EMERGENCIES.length)];
+  const template = EMERGENCY_TEMPLATES[Math.floor(Math.random() * EMERGENCY_TEMPLATES.length)];
+  return materializeEmergency(template);
 }

--- a/src/content/emergencies.js
+++ b/src/content/emergencies.js
@@ -1,0 +1,140 @@
+// Mars Trail — emergency events (issue #63).
+// Fired only when the click-metrics heuristic flags sustained mash-through
+// behavior. Each event has exactly one "correct" choice whose clue is buried
+// in the description text — the wrong choices are catastrophic. If the
+// player is still mashing, they will almost certainly die. If they read
+// carefully, survival is likely but not free.
+
+export const EMERGENCIES = [
+  {
+    id: 'emer_cabin_breach',
+    severity: 'emergency',
+    oneShot: false,
+    modal: {
+      title: 'CABIN BREACH — SECTION 4',
+      description:
+        'Klaxons. Section 4 is venting atmosphere. Alex is already at the lockers, shouting: ' +
+        '"The patch is in the GREEN locker. The red one is the oxygen bottle — if you grab that, ' +
+        'it ruptures and we all die." Pressure drop warning. You have seconds.',
+      choices: [
+        {
+          label: 'Grab the red locker',
+          outcome: {
+            oxygen: -35,
+            crewDamage: { amount: 55 },
+            narrative:
+              'The oxygen bottle ruptures. Shrapnel and a pressure wave tear through the cabin. ' +
+              'Crew take blunt-force injuries before the bulkhead seals.'
+          }
+        },
+        {
+          label: 'Grab the green locker',
+          correct: true,
+          outcome: {
+            oxygen: -8,
+            narrative:
+              'You slap the patch over the breach. Hull holds. Atmospherics stabilize after a long minute.'
+          }
+        },
+        {
+          label: 'Suit up first and re-assess',
+          outcome: {
+            oxygen: -22,
+            crewDamage: { amount: 25 },
+            narrative:
+              'Too slow. Half the cabin vents before the patch goes on. Crew take decompression injuries.'
+          }
+        }
+      ]
+    }
+  },
+
+  {
+    id: 'emer_reactor_anomaly',
+    severity: 'emergency',
+    oneShot: false,
+    modal: {
+      title: 'REACTOR — FLUX EXCURSION',
+      description:
+        'Power core warning. Mei reads the board out loud: "Neutron flux climbing. Manual override ' +
+        'is the LEFT handle. Do NOT pull the right handle — that dumps the coolant and we lose the core ' +
+        'for the rest of the run." You can hear the shielding ticking.',
+      choices: [
+        {
+          label: 'Pull the right handle',
+          outcome: {
+            power: -45,
+            cell: -2,
+            narrative:
+              'Coolant dumps. The core scrams cold and half your stored charge bleeds away trying to stabilize the bus.'
+          }
+        },
+        {
+          label: 'Pull the left handle',
+          correct: true,
+          outcome: {
+            power: -10,
+            narrative:
+              'Override engages. Flux drops into the green. A scare, nothing more.'
+          }
+        },
+        {
+          label: 'Shut it all down and wait',
+          outcome: {
+            power: -28,
+            crewDamage: { amount: 18 },
+            narrative:
+              'The flux keeps climbing while you stall. Shielding barely holds. Crew take a radiation dose before it settles.'
+          }
+        }
+      ]
+    }
+  },
+
+  {
+    id: 'emer_dust_nav',
+    severity: 'emergency',
+    oneShot: false,
+    modal: {
+      title: 'NAV BLACKOUT — DUST STORM',
+      description:
+        'Primary nav cuts out mid-drive. Tomás is hunched over the backup chart: "Cliff two hundred meters ' +
+        'ahead on the current heading. Swing WEST along the ridge — NOT east, east drops into a boulder field. ' +
+        'West, now." Visibility is nothing.',
+      choices: [
+        {
+          label: 'Hold heading',
+          outcome: {
+            mech: -2,
+            crewDamage: { amount: 45 },
+            narrative:
+              'Rover tips over the cliff edge. Three crew take blunt-force trauma before the roll cage arrests the tumble.'
+          }
+        },
+        {
+          label: 'Swing east',
+          outcome: {
+            mech: -1,
+            crewDamage: { amount: 20 },
+            narrative:
+              'East slope is worse. Rover slams a boulder and slides. Minor injuries, bent chassis.'
+          }
+        },
+        {
+          label: 'Swing west',
+          correct: true,
+          outcome: {
+            power: -6,
+            narrative:
+              'Ridge holds. You crawl down through the dust, comms garbled, until the storm passes.'
+          }
+        }
+      ]
+    }
+  }
+];
+
+// Pick an emergency event at random. Pure function.
+export function pickEmergency() {
+  return EMERGENCIES[Math.floor(Math.random() * EMERGENCIES.length)];
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { createInitialState, CARGO_BUDGET, PART_TYPES } from './state.js';
 import { render } from './render.js';
 import { advanceSol, setPace, setRations, repairBattery, cleanPanels } from './systems/travel.js';
 import { applyEventChoice } from './systems/events.js';
+import { recordDecision } from './systems/clickMetrics.js';
 import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, showTitleLayer, dimTitleStart, hideTitleLayer, showEndOfRunModal, closeModal, showWaypointOfferModal, showMultiStageModal, showAwayTeamPickerModal, showAwayTeamReunionModal, showDeathDialog } from './ui/modals.js';
 import { declineWaypoint } from './systems/waypoints.js';
 import { applyStageChoice } from './systems/multiStage.js';
@@ -247,7 +248,14 @@ function renderAll() {
       return;
     }
 
+    const stageOpenedAt = performance.now();
     showMultiStageModal(event, stageId, (choiceIdx) => {
+      const elapsed = performance.now() - stageOpenedAt;
+      const stageText = event.stages?.[stageId]?.description || '';
+      state = {
+        ...state,
+        clickMetrics: recordDecision(state.clickMetrics, elapsed, stageText)
+      };
       const { state: next, nextStage, skillResult, damageTarget, applied } = applyStageChoice(state, event, stageId, choiceIdx);
       state = next;
       render(state);
@@ -272,7 +280,13 @@ function renderAll() {
 
   if (modal.type === 'event') {
     const event = modal.payload;
+    const openedAt = performance.now();
     showEventModal(event, (choiceIdx) => {
+      const elapsed = performance.now() - openedAt;
+      state = {
+        ...state,
+        clickMetrics: recordDecision(state.clickMetrics, elapsed, event.modal.description)
+      };
       const { state: next, resolution } = applyEventChoice(state, event, choiceIdx);
       state = next;
       render(state);   // dashboard reflects the change behind the outcome modal

--- a/src/state.js
+++ b/src/state.js
@@ -4,6 +4,7 @@
 import { rollWaypoints } from './systems/waypoints.js';
 import { loadCareerScience, computeActiveBonuses } from './systems/career.js';
 import { EVENTS } from './content/events.js';
+import { initialClickMetrics } from './systems/clickMetrics.js';
 
 const LANDMARK_NAMES = {
   jezero:       'Jezero Crater',
@@ -93,6 +94,9 @@ export function createInitialState() {
     log: [
       { sol: 1, text: 'Mission begins. Crew nominal. Departing Jezero Crater.' }
     ],
+
+    // Click-through detection (issue #63).
+    clickMetrics: initialClickMetrics(),
 
     // Career science (cross-run progression).
     careerSci,

--- a/src/systems/clickMetrics.js
+++ b/src/systems/clickMetrics.js
@@ -6,15 +6,15 @@
 export const CLICK_METRICS_CONFIG = {
   minReadMs: 1200,              // floor below which any decision is "too fast to read"
   readMsPerChar: 35,            // ~28 wpm slow-reader rate; scales expected time with body length
-  mashScoreThreshold: 6,        // at or above this score, an emergency fires on the next event
-  maxEmergenciesPerRun: 2,      // cap so a single run can't chain-die from this alone
-  emergencyCooldownDelta: -4,   // mashScore reduction applied when an emergency fires
+  mashScoreThreshold: 3,        // at or above this score, an emergency fires on the next event
+  maxEmergenciesPerRun: 5,      // cap so a single run can't chain-die from this alone
+  emergencyCooldownDelta: -2,   // mashScore reduction applied when an emergency fires
   scoreDelta: {
-    didNotRead: 3,   // elapsed < 0.2 * expected
-    skim:       2,   // elapsed < 0.5 * expected
+    didNotRead: 3,   // elapsed < 0.2 * expected — one fast click is enough to flag
+    skim:       2,   // elapsed < 0.5 * expected — two skims trip the heuristic
     hurried:    1,   // elapsed < 0.75 * expected
     normal:     0,   // elapsed < expected
-    thoughtful: -1   // elapsed >= expected
+    thoughtful: -1   // elapsed >= expected — slow reads decay the score
   }
 };
 

--- a/src/systems/clickMetrics.js
+++ b/src/systems/clickMetrics.js
@@ -1,0 +1,74 @@
+// Mars Trail — click-through / mash-detection heuristic.
+// Pure functions. The game uses these to decide when a player is smashing
+// through event modals without reading and should face an "emergency" event
+// they can only survive by actually reading the text (issue #63).
+
+export const CLICK_METRICS_CONFIG = {
+  minReadMs: 1200,              // floor below which any decision is "too fast to read"
+  readMsPerChar: 35,            // ~28 wpm slow-reader rate; scales expected time with body length
+  mashScoreThreshold: 6,        // at or above this score, an emergency fires on the next event
+  maxEmergenciesPerRun: 2,      // cap so a single run can't chain-die from this alone
+  emergencyCooldownDelta: -4,   // mashScore reduction applied when an emergency fires
+  scoreDelta: {
+    didNotRead: 3,   // elapsed < 0.2 * expected
+    skim:       2,   // elapsed < 0.5 * expected
+    hurried:    1,   // elapsed < 0.75 * expected
+    normal:     0,   // elapsed < expected
+    thoughtful: -1   // elapsed >= expected
+  }
+};
+
+export function initialClickMetrics() {
+  return {
+    mashScore: 0,
+    emergenciesFired: 0,
+    lastBucket: null,
+    lastElapsedMs: null,
+    lastExpectedMs: null
+  };
+}
+
+export function expectedReadMs(text, cfg = CLICK_METRICS_CONFIG) {
+  const len = (text || '').length;
+  return Math.max(cfg.minReadMs, len * cfg.readMsPerChar);
+}
+
+export function classifyDecision(elapsedMs, expectedMs) {
+  if (elapsedMs < expectedMs * 0.2)  return 'didNotRead';
+  if (elapsedMs < expectedMs * 0.5)  return 'skim';
+  if (elapsedMs < expectedMs * 0.75) return 'hurried';
+  if (elapsedMs < expectedMs)        return 'normal';
+  return 'thoughtful';
+}
+
+export function recordDecision(metrics, elapsedMs, descText, cfg = CLICK_METRICS_CONFIG) {
+  const base = metrics || initialClickMetrics();
+  const expected = expectedReadMs(descText, cfg);
+  const bucket = classifyDecision(elapsedMs, expected);
+  const delta = cfg.scoreDelta[bucket] ?? 0;
+  const mashScore = Math.max(0, (base.mashScore || 0) + delta);
+  return {
+    ...base,
+    mashScore,
+    lastBucket: bucket,
+    lastElapsedMs: elapsedMs,
+    lastExpectedMs: expected
+  };
+}
+
+export function shouldFireEmergency(metrics, cfg = CLICK_METRICS_CONFIG) {
+  if (!metrics) return false;
+  return (metrics.mashScore || 0) >= cfg.mashScoreThreshold &&
+         (metrics.emergenciesFired || 0) < cfg.maxEmergenciesPerRun;
+}
+
+// Apply the "an emergency just fired" bookkeeping: bump the counter and
+// pull mashScore down so the player gets a cooldown before the next fire.
+export function afterEmergencyFired(metrics, cfg = CLICK_METRICS_CONFIG) {
+  const base = metrics || initialClickMetrics();
+  return {
+    ...base,
+    emergenciesFired: (base.emergenciesFired || 0) + 1,
+    mashScore: Math.max(0, (base.mashScore || 0) + cfg.emergencyCooldownDelta)
+  };
+}

--- a/src/systems/travel.js
+++ b/src/systems/travel.js
@@ -254,7 +254,7 @@ export function advanceSol(state, mode = 'travel') {
     // click-metrics heuristic has flagged sustained click-through behavior.
     if (shouldFireEmergency(s.clickMetrics)) {
       const emergency = pickEmergency();
-      s.activeModal = { type: 'event', payload: emergency };
+      s.activeModal = { type: 'multi_stage', payload: { event: emergency, stageId: emergency.startStage } };
       s.clickMetrics = afterEmergencyFired(s.clickMetrics);
       s.log = [...s.log, { sol: s.sol, text: '⚠ ANOMALY — systems flag inattentive operator. Emergency scenario.' }];
     } else {

--- a/src/systems/travel.js
+++ b/src/systems/travel.js
@@ -4,6 +4,8 @@
 import { landmarkName, PART_TYPES } from '../state.js';
 import { rollEvent } from './events.js';
 import { rollMultiStageEvent } from './multiStage.js';
+import { shouldFireEmergency, afterEmergencyFired } from './clickMetrics.js';
+import { pickEmergency } from '../content/emergencies.js';
 import { applyDamage, checkAllDead } from './crew.js';
 import { makeLandmarkEncounter } from '../content/landmarks.js';
 import { WAYPOINTS } from '../content/waypoints.js';
@@ -248,18 +250,27 @@ export function advanceSol(state, mode = 'travel') {
 
   // ---- Roll for random event (travel sols only, only if not already in a modal) ----
   if (mode === 'travel' && s.status === 'active' && !s.activeModal) {
-    const event = rollEvent(s);
-    if (event) {
-      s.activeModal = { type: 'event', payload: event };
-      if (event.oneShot) s.firedEvents = [...s.firedEvents, event.id];
+    // Mash-detection emergency: pre-empts the normal event roll when the
+    // click-metrics heuristic has flagged sustained click-through behavior.
+    if (shouldFireEmergency(s.clickMetrics)) {
+      const emergency = pickEmergency();
+      s.activeModal = { type: 'event', payload: emergency };
+      s.clickMetrics = afterEmergencyFired(s.clickMetrics);
+      s.log = [...s.log, { sol: s.sol, text: '⚠ ANOMALY — systems flag inattentive operator. Emergency scenario.' }];
     } else {
-      const msEvent = rollMultiStageEvent(s);
-      if (msEvent) {
-        if (msEvent.customResolver === 'medical') {
-          s = beginMedicalEmergency(s);
-        } else {
-          s.activeModal = { type: 'multi_stage', payload: { event: msEvent, stageId: msEvent.startStage } };
-          if (msEvent.oneShot) s.firedEvents = [...s.firedEvents, msEvent.id];
+      const event = rollEvent(s);
+      if (event) {
+        s.activeModal = { type: 'event', payload: event };
+        if (event.oneShot) s.firedEvents = [...s.firedEvents, event.id];
+      } else {
+        const msEvent = rollMultiStageEvent(s);
+        if (msEvent) {
+          if (msEvent.customResolver === 'medical') {
+            s = beginMedicalEmergency(s);
+          } else {
+            s.activeModal = { type: 'multi_stage', payload: { event: msEvent, stageId: msEvent.startStage } };
+            if (msEvent.oneShot) s.firedEvents = [...s.firedEvents, msEvent.id];
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
You could previously mash the first choice on every event without reading and finish runs comfortably. Now the UI measures decision time per modal, and sustained click-through triggers a catastrophic emergency whose correct response is buried in the description text.

## What changed
- **`src/systems/clickMetrics.js`** — pure heuristic with one tunable config. Expected read time scales with description length (floor `minReadMs = 1200`, then `35ms/char`). Five buckets from *didNotRead* → *thoughtful* drive a `mashScore` that accumulates on fast clicks and decays on thoughtful ones.
- **`src/content/emergencies.js`** — three scenarios: **cabin breach**, **reactor flux excursion**, **dust-storm nav blackout**. Each has one correct choice signaled only in the body text (e.g. *"green locker — NOT red"*). Wrong choices inflict heavy crew damage and resource loss.
- **`src/systems/travel.js`** — before rolling a normal event, checks `shouldFireEmergency(state.clickMetrics)`. Emergencies cap at 2 per run to avoid chain death. Logs an in-world anomaly line.
- **`src/main.js`** — timestamps the event and multi-stage modals on open, calls `recordDecision` in the choice callback.
- **`src/state.js`** — seeds `state.clickMetrics` on new runs.
- **`sim/clickMetrics.test.mjs`** — 9 tests for thresholds, accumulation, cooldown, and the per-run cap.

## Accessibility
The `minReadMs` floor and `readMsPerChar` rate are tunable in one place. Default (1200ms + 35ms/char) is generous — a 200-char event expects ~7s of reading, and hitting "didNotRead" (<20% of expected) requires clicking in under 1.4s. Raise both if playtests flag false positives.

## Test plan
- [x] `node --test sim/*.test.mjs` — 112/112 pass (9 new)
- [x] `node sim/playtest1000.mjs` — rank distributions unchanged (sim bypasses UI timing, so emergencies correctly do not trip in simulated runs)
- [ ] In-browser: mash-click first choice across ~3 events → emergency event fires with the "⚠ ANOMALY" log line
- [ ] In-browser: the wrong choice on an emergency is catastrophic (crew hurt, big resource hit)
- [ ] In-browser: the correct choice (matches the body text clue) is survivable
- [ ] In-browser: reading through normal events keeps mashScore at 0 → no emergencies fire
- [ ] In-browser: no more than 2 emergencies per run

## Open questions (not blockers for merge)
- Add a soft warning event before the first catastrophe, or jump straight in? (Currently: jump straight in.)
- Worth a dedicated red-alert modal skin for emergencies? (Currently reuses normal event modal with `severity: 'emergency'`.)
- End-of-run scoring callout when the flag fired?

Closes #63.