### PR TITLE
Interactive code tour slideshow (closes #65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .superpowers/
+.worktrees/
 .DS_Store
 node_modules/
 *.log

--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 A browser-based Mars colony survival game — Oregon Trail in space. No build step; open `index.html` in a browser to play.
 
-**New to this repo?** Open [`docs/walkthrough/index.html`](docs/walkthrough/index.html) for an interactive code tour.
+**New to this repo?** Serve the repo over HTTP and open `/docs/walkthrough/` for an interactive code tour.
 
 ## Running locally
 
-- Play the game: open `index.html` directly, or serve the repo root (e.g. `python3 -m http.server`) and visit `/`.
-- Run the sim test suite: `node --test sim/*.test.mjs`.
+Browsers block ES-module imports from `file://` URLs, so both the game and the code tour need to be served over HTTP.
+
+```bash
+python3 -m http.server 8765
+```
+
+Then:
+- Play the game: http://localhost:8765/
+- Take the code tour: http://localhost:8765/docs/walkthrough/
+
+Run the sim test suite: `node --test sim/*.test.mjs`.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Tractus Martis · Mission Control
+
+A browser-based Mars colony survival game — Oregon Trail in space. No build step; open `index.html` in a browser to play.
+
+**New to this repo?** Open [`docs/walkthrough/index.html`](docs/walkthrough/index.html) for an interactive code tour.
+
+## Running locally
+
+- Play the game: open `index.html` directly, or serve the repo root (e.g. `python3 -m http.server`) and visit `/`.
+- Run the sim test suite: `node --test sim/*.test.mjs`.
+
+## Layout
+
+- `src/` — game modules (systems, UI, content, state).
+- `styles/` — theme and component CSS (four themes: Mission Control, LCARS, Voltron, Starfighter).
+- `sim/` — headless Node tests and playtest scripts.
+- `docs/walkthrough/` — interactive code tour that introduces the architecture slide by slide.
+- `docs/superpowers/plans/` — design plans for larger features.

--- a/docs/superpowers/plans/2026-04-21-code-tour-glossary.md
+++ b/docs/superpowers/plans/2026-04-21-code-tour-glossary.md
@@ -1,0 +1,495 @@
+# Code-Tour Glossary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add inline clickable term definitions to the Mars Trail code-tour slideshow so entry-level devs can expand 1–3-sentence definitions on any marked term in slide prose.
+
+**Architecture:** A new trusted in-repo data file (`glossary.js`) holds `{ slug: { term, def } }` entries. Slide prose marks terms via `<span class="term" data-term="slug">…</span>`. A new wire helper in `tour.js` renders those spans as `<button class="term">` at render time, and on click toggles a sibling `<div class="term-def">` with the definition. Theming via `currentColor` + existing CSS variables. Smoke-test extension asserts the data shape.
+
+**Tech Stack:** Vanilla JS (ES modules), vanilla CSS, `node --test`. No build step.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-code-tour-glossary-design.md`
+**Issue:** #67 (extends #65 / PR #66)
+
+---
+
+## File structure
+
+**New:**
+- `docs/walkthrough/glossary.js` — exports `GLOSSARY` object.
+
+**Modified:**
+- `docs/walkthrough/tour.js` — import `GLOSSARY`; add `wireGlossaryTerms(stage)`; call from `render()`.
+- `docs/walkthrough/tour.css` — `.term` + `.term-def` styles.
+- `docs/walkthrough/slides.js` — mark up term occurrences.
+- `sim/walkthroughSmoke.test.mjs` — extend with glossary-shape test.
+
+**Untouched:** everything under `src/`, `styles/`, other sim tests, the game.
+
+---
+
+## Task 1: Create `glossary.js` with initial terms
+
+**Files:**
+- Create: `docs/walkthrough/glossary.js`
+
+- [ ] **Step 1: Author the file with the full initial term set**
+
+Create `docs/walkthrough/glossary.js`:
+
+```js
+// Glossary for the code-tour slideshow.
+// Each entry's `def` is trusted HTML — rendered unescaped when a term is clicked.
+// Definitions authored in-repo for entry-level devs: 1–3 sentences, plain language.
+// Keys are kebab-case; `term` is the display label; `def` is short HTML.
+
+export const GLOSSARY = {
+  'es-modules': {
+    term: 'ES modules',
+    def: `<p>The official JavaScript module system (<code>import</code> / <code>export</code>). Each file is its own scope, and the browser loads imports on demand. No bundler or build step needed.</p>`,
+  },
+  'dom': {
+    term: 'DOM',
+    def: `<p>The "Document Object Model" — the live tree of HTML elements in your browser tab. JavaScript reads and mutates it to change what the user sees.</p>`,
+  },
+  'pure-function': {
+    term: 'pure function',
+    def: `<p>A function whose output depends only on its arguments and that doesn't touch the outside world. Same inputs always give the same outputs, which makes them trivial to unit-test.</p>`,
+  },
+  'single-source-of-truth': {
+    term: 'single source of truth',
+    def: `<p>A pattern where one object (here, <code>state.js</code>'s state tree) is the only place a given piece of data lives. Everything else reads from it and writes through well-defined paths, so there's never a "which copy is right?" question.</p>`,
+  },
+  'virtual-dom': {
+    term: 'virtual DOM',
+    def: `<p>A technique popularized by React where the framework keeps a JS-object copy of the DOM, diffs new versus old on each change, and applies only the minimum updates. Mars Trail deliberately doesn't use one — it just rebuilds from scratch.</p>`,
+  },
+  'reactive-framework': {
+    term: 'reactive framework',
+    def: `<p>A library (React, Vue, Svelte, Solid, …) that automatically re-renders UI when the data it depends on changes. Mars Trail doesn't use one; <code>render(state)</code> is called manually after every state change.</p>`,
+  },
+  'css-variable': {
+    term: 'CSS variable',
+    def: `<p>Also called a "custom property." A value you define once (<code>--panel-border: #0a8;</code>) and reuse with <code>var(--panel-border)</code>. Themes override the variables so every element using them repaints automatically.</p>`,
+  },
+  'hash-routing': {
+    term: 'hash-based routing',
+    def: `<p>Using the part of a URL after <code>#</code> (like <code>#slide-5</code>) as the page's current "location." It never hits the server, works with browser back/forward, and needs no backend — perfect for a single-file app.</p>`,
+  },
+  'factory-function': {
+    term: 'factory function',
+    def: `<p>A plain function that builds and returns a fresh object. <code>createInitialState()</code> is the example here: call it to get a new game state without touching any existing ones.</p>`,
+  },
+  'dispatch': {
+    term: 'dispatch',
+    def: `<p>In this codebase, a callback passed down into UI so it can say "the user chose X." The UI doesn't mutate state directly — it calls <code>dispatch</code> and lets the system decide what to do. Keeps the flow one-directional.</p>`,
+  },
+  'local-storage': {
+    term: 'localStorage',
+    def: `<p>A browser key-value store that persists across tabs and page reloads on the same origin. The game uses it for theme choice and best-run score; the tour intentionally does not.</p>`,
+  },
+  'dynamic-import': {
+    term: 'dynamic import',
+    def: `<p>An <code>import()</code> call inside a function (not at the top of the file). It returns a promise, so the module only loads when that code runs — useful for demos that shouldn't load until the user opens the slide.</p>`,
+  },
+  'try-finally': {
+    term: 'try/finally',
+    def: `<p>A JS block that guarantees the <code>finally</code> branch runs whether the <code>try</code> succeeded or threw. The tour uses it to restore DOM ids even if a real game modal blows up while rendering a demo.</p>`,
+  },
+  'heuristic': {
+    term: 'heuristic',
+    def: `<p>A rule-of-thumb that's usually right but not guaranteed. The anti-mashing detector uses heuristics (response time + bucket patterns) — it might flag a thoughtful-but-fast player, but in aggregate it catches careless clicking.</p>`,
+  },
+  'multi-stage-event': {
+    term: 'multi-stage event',
+    def: `<p>An in-game event with more than one screen: each choice can point to another stage (e.g., diagnose → treat → dispose), rather than resolving immediately. The engine that walks these chains is <code>src/systems/multiStage.js</code>.</p>`,
+  },
+  'sol': {
+    term: 'sol',
+    def: `<p>A Martian day — about 24 hours 39 minutes. The game's turn unit. "Sol 5" = day 5 of the mission.</p>`,
+  },
+  'eva': {
+    term: 'EVA',
+    def: `<p>Extravehicular activity — a crewed trip outside the rover (spacewalk, surface work). The game tracks EVA suit charges as a limited resource.</p>`,
+  },
+  'lmst': {
+    term: 'LMST',
+    def: `<p>Local Mean Solar Time — the clock that keeps the rover's day aligned with the Martian sun, used by NASA mission planners. Shown in the tour's header clock for flavor.</p>`,
+  },
+  'waypoint': {
+    term: 'waypoint',
+    def: `<p>An optional off-route detour along the mission path. Accepting one dispatches an "away team" of 1–3 crew while the rover camps; the chain plays out over a few sols, then the team returns (or doesn't).</p>`,
+  },
+  'anti-mashing': {
+    term: 'anti-mashing',
+    def: `<p>Detection that a player is clicking through event modals too fast or always-first to actually have read them. If the score gets high enough, the game rolls a punitive emergency — the only path you can't button-mash through.</p>`,
+  },
+};
+```
+
+- [ ] **Step 2: Verify the file parses and imports**
+
+Run:
+```bash
+node --check docs/walkthrough/glossary.js
+node --input-type=module -e "import('./docs/walkthrough/glossary.js').then(m => console.log('entries:', Object.keys(m.GLOSSARY).length))"
+```
+Expected: no syntax errors; prints `entries: 20`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/walkthrough/glossary.js
+git commit -m "Code tour: glossary data with 20 initial term definitions (refs #67)"
+```
+
+---
+
+## Task 2: Smoke-test the glossary shape
+
+**Files:**
+- Modify: `sim/walkthroughSmoke.test.mjs`
+
+- [ ] **Step 1: Append the glossary test block**
+
+Add these tests at the bottom of `sim/walkthroughSmoke.test.mjs` (before the last closing brace of whatever existing file structure — just append at EOF, the file is a flat list of `test()` calls):
+
+```js
+test('glossary module imports and exposes a non-empty GLOSSARY object', async () => {
+  const mod = await import('../docs/walkthrough/glossary.js');
+  assert.equal(typeof mod.GLOSSARY, 'object');
+  assert.ok(mod.GLOSSARY !== null);
+  const keys = Object.keys(mod.GLOSSARY);
+  assert.ok(keys.length > 0, 'GLOSSARY must have at least one entry');
+});
+
+test('every glossary entry has non-empty term + def strings', async () => {
+  const { GLOSSARY } = await import('../docs/walkthrough/glossary.js');
+  for (const [slug, entry] of Object.entries(GLOSSARY)) {
+    assert.equal(typeof entry.term, 'string', `${slug}: term must be a string`);
+    assert.ok(entry.term.length > 0, `${slug}: term must be non-empty`);
+    assert.equal(typeof entry.def, 'string', `${slug}: def must be a string`);
+    assert.ok(entry.def.length > 0, `${slug}: def must be non-empty`);
+  }
+});
+
+test('every glossary slug is kebab-case (lowercase letters, digits, hyphens)', async () => {
+  const { GLOSSARY } = await import('../docs/walkthrough/glossary.js');
+  const kebab = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+  for (const slug of Object.keys(GLOSSARY)) {
+    assert.match(slug, kebab, `${slug} is not kebab-case`);
+  }
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run:
+```bash
+node --test sim/walkthroughSmoke.test.mjs
+```
+Expected: all smoke tests pass (previously 5; now 8).
+
+Run the full suite:
+```bash
+node --test sim/*.test.mjs
+```
+Expected: 136 + 3 = **139 tests**, all passing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/walkthroughSmoke.test.mjs
+git commit -m "Code tour: smoke-test the glossary data shape (refs #67)"
+```
+
+---
+
+## Task 3: Wire the glossary into `tour.js` + add CSS
+
+**Files:**
+- Modify: `docs/walkthrough/tour.js`
+- Modify: `docs/walkthrough/tour.css`
+
+- [ ] **Step 1: Add CSS for `.term` and `.term-def`**
+
+Append to `docs/walkthrough/tour.css`:
+
+```css
+/* Glossary term buttons. Inherit the themed text color. */
+.term {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: currentColor;
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.term:hover,
+.term:focus-visible {
+  opacity: 0.75;
+  outline: none;
+}
+
+.term[aria-expanded="true"] {
+  font-weight: 600;
+}
+
+.term-def {
+  margin: 6px 0 10px 14px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--panel-border, currentColor);
+  opacity: 0.9;
+  font-size: 0.95em;
+}
+
+.term-def p:first-child { margin-top: 0; }
+.term-def p:last-child  { margin-bottom: 0; }
+```
+
+- [ ] **Step 2: Import `GLOSSARY` in tour.js**
+
+Add near the top of `docs/walkthrough/tour.js`, after the existing imports:
+
+```js
+import { GLOSSARY } from './glossary.js';
+```
+
+- [ ] **Step 3: Add `wireGlossaryTerms` helper**
+
+Insert this function in `docs/walkthrough/tour.js` near the other wire helpers (after `wireHubTiles`):
+
+```js
+// Promote authored <span class="term" data-term="slug"> markers to interactive
+// buttons that toggle an inline definition pane. GLOSSARY.def is trusted HTML.
+function wireGlossaryTerms(stage) {
+  let counter = 0;
+  for (const span of stage.querySelectorAll('span.term[data-term]')) {
+    const slug = span.dataset.term;
+    const entry = GLOSSARY[slug];
+    if (!entry) {
+      console.warn(`Unknown term: "${slug}" — check data-term against glossary.js`);
+      continue;
+    }
+    const defId = `term-def-${slug}-${++counter}`;
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'term';
+    button.dataset.term = slug;
+    button.setAttribute('aria-expanded', 'false');
+    button.setAttribute('aria-controls', defId);
+    button.textContent = span.textContent;
+    span.replaceWith(button);
+
+    button.addEventListener('click', () => {
+      const isOpen = button.getAttribute('aria-expanded') === 'true';
+      if (isOpen) {
+        const existing = document.getElementById(defId);
+        if (existing) existing.remove();
+        button.setAttribute('aria-expanded', 'false');
+        return;
+      }
+      const def = document.createElement('div');
+      def.className = 'term-def';
+      def.id = defId;
+      def.setAttribute('role', 'region');
+      def.innerHTML = entry.def;
+      button.insertAdjacentElement('afterend', def);
+      button.setAttribute('aria-expanded', 'true');
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Call it from `render()`**
+
+Locate `render(location)` in `tour.js`. After the existing `wireHubTiles(stage);` line, add `wireGlossaryTerms(stage);`:
+
+The final render body should look like:
+
+```js
+function render(location) {
+  const slide = slideAt(location);
+  const stage = document.getElementById('tour-stage');
+  stage.innerHTML = renderSlideHtml(slide, location);
+  wireSnippetToggles(stage);
+  wireHubTiles(stage);
+  wireGlossaryTerms(stage);
+  renderProgress(location);
+  mountDemo(slide);
+}
+```
+
+- [ ] **Step 5: Sanity-check**
+
+Run:
+```bash
+node --check docs/walkthrough/tour.js
+node --test sim/*.test.mjs
+```
+Expected: no syntax errors; 139 tests passing.
+
+Until Task 4 actually marks up terms in slides, the wire helper's `querySelectorAll` returns nothing and this commit has no visible effect — that's fine.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/walkthrough/tour.js docs/walkthrough/tour.css
+git commit -m "Code tour: wire glossary term markup into tour.js + CSS (refs #67)"
+```
+
+---
+
+## Task 4: Mark up terms in slides.js
+
+**Files:**
+- Modify: `docs/walkthrough/slides.js`
+
+- [ ] **Step 1: Apply term markup across slide bodies**
+
+Go through `docs/walkthrough/slides.js` and wrap term occurrences in `<span class="term" data-term="<slug>">display text</span>`. Rules:
+
+- Only wrap **the first** occurrence of each term per slide (avoid every paragraph turning into a click-maze).
+- Only wrap terms where the surrounding prose actually uses them; don't force-insert definitions to show them off.
+- Don't wrap terms inside `<code>` blocks or snippet `code:` strings.
+- Don't wrap terms inside captions or labels that already use `<code>` formatting for code identifiers.
+
+Concrete replacements (exhaustive list — grep for each original phrase and replace once per slide):
+
+1. **loop slide body:**
+   - `<em>no</em> observer pattern, <em>no</em> virtual DOM, <em>no</em> <span class="term" data-term="reactive-framework">reactive framework</span>`
+   - (Wrap only "reactive framework" — "virtual DOM" is a separate term, wrap it too:)
+   - `<em>no</em> <span class="term" data-term="virtual-dom">virtual DOM</span>, <em>no</em> <span class="term" data-term="reactive-framework">reactive framework</span>`
+
+2. **stack slide body:**
+   - `<strong>Vanilla <span class="term" data-term="es-modules">ES modules</span>.</strong>`
+
+3. **state slide body:**
+   - `central export is a <span class="term" data-term="factory-function">factory</span>, <code>createInitialState()</code>`
+
+4. **render slide body:**
+   - `<code>src/render.js</code> is a <span class="term" data-term="pure-function">pure</span> <code>state → DOM</code> projection.`
+   - Also wrap "DOM" elsewhere in the same slide body if it appears outside a `<code>` — check the text; if it only appears inside `<code>` tags, skip.
+
+5. **travel s1 body:**
+   - `The module is (mostly) <span class="term" data-term="pure-function">pure</span>`
+   - `<span class="term" data-term="sol">sol</span>` on first "per-sol" or "sol" usage in prose.
+
+6. **travel s2 body:**
+   - If there's a "NEXT SOL" phrase, don't wrap (that's UI chrome). If prose says "a sol" unqualified, wrap `<span class="term" data-term="sol">sol</span>`.
+
+7. **events s1 body:**
+   - `based on segment, pace, and weighting` — no term here.
+
+8. **multistage s1 body:**
+   - `A <span class="term" data-term="multi-stage-event">multi-stage event</span> is an authored chain`
+
+9. **medical s1 body:**
+   - `first real stress-test of the <code>multiStage.js</code> engine.` — no term.
+
+10. **medical s2 body:**
+    - `<span class="term" data-term="anti-mashing">anti-mashing</span> detection fires exactly as it does in the game`
+
+11. **clickmetrics s1 body:**
+    - `the actual classifier (buckets vs expected read duration)` — wrap `<span class="term" data-term="heuristic">classifier</span>` if the word "heuristic" or "classifier" appears; otherwise add "heuristic" near the description.
+    - Simpler target: `Three signals drive the "you're not reading" flag` or similar — check the current text. If the word "heuristic" is there, wrap it; if not, skip and rely on the anti-mashing term in the medical slide.
+
+12. **awayteam s1 body:**
+    - `an "away team" of 1–3 crew` — consider wrapping `<span class="term" data-term="waypoint">waypoint</span>` if the slide mentions waypoint diverts. Target the first "waypoint" occurrence.
+    - First mention of `<span class="term" data-term="sol">sol</span>` in prose.
+
+13. **smallsys s1 body:**
+    - No obvious terms to wrap.
+
+14. **scoring s1 body:**
+    - `Both modules are <span class="term" data-term="pure-function">pure</span>` — first word.
+
+15. **content-vs-systems slide body:**
+    - No new terms (concepts already covered).
+
+16. **ui slide body:**
+    - `every modal receives the game state and a <span class="term" data-term="dispatch">dispatch</span> function` — wrap "dispatch".
+
+17. **theme slide body:**
+    - `overrides a shared set of <span class="term" data-term="css-variable">CSS variables</span>`
+    - `remembers the last choice in <span class="term" data-term="local-storage">localStorage</span>`
+
+18. **audio slide body:**
+    - No obvious terms unless "localStorage" appears.
+
+19. **tests slide body:**
+    - No obvious terms (the audience for this slide already knows what a unit test is).
+
+20. **workflow slide body:**
+    - No obvious terms.
+
+21. **credits slide body:**
+    - No new terms.
+
+**Also check spine headers and branches for term opportunities** — but keep the "first occurrence per slide" rule.
+
+Terms not yet wrapped after this pass (because no natural prose hosts them): `dom`, `hash-routing`, `single-source-of-truth`, `dynamic-import`, `try-finally`, `eva`, `lmst`. If the current slide prose has them, wrap; if not, leave the entry in the glossary for future use.
+
+**The wrapping rule of thumb:** if reading the slide prose aloud would make an entry-level dev pause and say "wait, what's X?", wrap X. Otherwise don't.
+
+Do not rewrite slide prose just to host a term. If the natural prose doesn't use a glossary term, skip it.
+
+- [ ] **Step 2: Verify parse + tests**
+
+Run:
+```bash
+node --check docs/walkthrough/slides.js
+node --test sim/*.test.mjs
+```
+Expected: clean parse; 139 tests passing.
+
+- [ ] **Step 3: Visually verify term markup (optional — requires local HTTP server)**
+
+If a browser check is possible: start `python3 -m http.server 8765` from the worktree, open `http://localhost:8765/docs/walkthrough/`, and spot-check that each marked term is dotted-underlined, clickable, and toggles a definition. Close definitions, switch themes, confirm repaint. If no browser access, skip — static checks are enough.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/walkthrough/slides.js
+git commit -m "Code tour: mark up glossary terms in slide prose (refs #67)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- `glossary.js` with 20 initial entries — Task 1.
+- `GLOSSARY` keyed by slug with `term` + `def` (trusted HTML) — Task 1.
+- `.term` markup in slide prose — Task 4.
+- `wireGlossaryTerms(stage)` helper, called from `render()` — Task 3.
+- Inline toggle behavior (click opens / click closes, multiple open simultaneously) — Task 3 (via `aria-expanded` check + insertAdjacentElement / removeElement).
+- Unknown-slug warning without crash — Task 3 (`console.warn` + `continue`).
+- Accessibility (real `<button>`, `aria-expanded`, `aria-controls`, free keyboard) — Task 3.
+- `.term` / `.term-def` styled with `currentColor` + `var(--panel-border)` — Task 3.
+- Smoke-test for glossary shape — Task 2.
+
+**Placeholder scan:** No "TBD", "TODO", "Add error handling" text. The Task 4 markup list is exhaustive per slide.
+
+**Type consistency:** `GLOSSARY` keys kebab-case; `data-term` values match slugs; `id="term-def-${slug}-${counter}"` matches `aria-controls`.
+
+**Known soft spots:**
+- Task 4's markup list names concrete occurrences, but since slide prose may have drifted since spec-time, the implementer should search for the quoted substrings and apply edits; if a substring doesn't match exactly, apply the spirit of the instruction rather than skipping.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-code-tour-glossary.md`. Two execution options:
+
+1. **Subagent-Driven** — fresh subagent per task with two-stage review.
+2. **Inline Execution** — execute tasks in this session with checkpoints.
+
+Given this is a 4-task plan, tightly scoped, and immediately follows completed work in the same branch, **inline execution is probably the right fit** — less overhead, and the controller (me) can iterate directly on the handful of edits. But I'll let you pick.
+
+Which approach?

--- a/docs/superpowers/plans/2026-04-21-code-tour-slideshow.md
+++ b/docs/superpowers/plans/2026-04-21-code-tour-slideshow.md
@@ -1,0 +1,1935 @@
+# Code Tour Slideshow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone, interactive, theme-toggleable HTML slideshow at `docs/walkthrough/index.html` that walks programmer-literate readers through the Mars Trail codebase in ~15 minutes.
+
+**Architecture:** Vanilla ES modules (matches game). `index.html` loads the game's existing stylesheets for theming. `tour.js` is the engine (routing, keyboard, chrome); `slides.js` is a plain data module declaring the linear spine + hub branches. Demos live under `demos/` and import real game modules to stay honest. Routing-related logic is written as pure functions so it can be unit-tested with `node --test`.
+
+**Tech Stack:** Vanilla JS (ES modules), vanilla CSS, `node --test` for unit tests. No build step. No server. Open the file directly in a browser.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-code-tour-slideshow-design.md`
+**Issue:** #65
+
+---
+
+## File structure
+
+**New:**
+- `docs/walkthrough/index.html` — entry HTML; loads stylesheets, `tour.js`.
+- `docs/walkthrough/tour.css` — layout primitives only (slide frame, nav bar, hub tiles, code block, progress).
+- `docs/walkthrough/tour.js` — engine: boot, routing, keyboard, chrome, code-block wiring, demo dispatch.
+- `docs/walkthrough/router.js` — **pure** routing helpers: `parseHash`, `hashFor`, `routeToSlide`, `routeForward`, `routeBack`. Unit-testable.
+- `docs/walkthrough/slides.js` — content manifest: `spine` array (16 slides), hub slide `branches` array (8), each branch has `sub` array.
+- `docs/walkthrough/repo.js` — single source of truth for `OWNER`, `REPO`, `BRANCH`, and `githubUrl(path, lineStart, lineEnd)` helper.
+- `docs/walkthrough/demos/loop.js` — game-loop animation (no real-module import; explanatory).
+- `docs/walkthrough/demos/eventPreview.js` — imports `src/content/events.js` + `src/ui/modals.js`; renders a random event card.
+- `docs/walkthrough/demos/mashEmergency.js` — imports `src/systems/medicalEmergency.js` + `src/ui/modals.js`; runs a seeded click-mash rescue.
+- `sim/walkthroughSmoke.test.mjs` — smoke test: imports each demo module under a minimal DOM shim and asserts init functions exist and don't throw.
+- `sim/walkthroughRouter.test.mjs` — unit tests for `router.js` pure helpers.
+
+**Modified:**
+- `README.md` — one-line link to `docs/walkthrough/index.html` near the top.
+
+**Untouched:** everything in `src/`, `styles/`, `assets/`, the game's `index.html`, and `sim/play.mjs`.
+
+---
+
+## Task 1: Scaffold project skeleton
+
+**Files:**
+- Create: `docs/walkthrough/index.html`
+- Create: `docs/walkthrough/tour.css`
+- Create: `docs/walkthrough/tour.js`
+- Create: `docs/walkthrough/slides.js`
+- Create: `docs/walkthrough/repo.js`
+
+- [ ] **Step 1: Create the entry HTML**
+
+Create `docs/walkthrough/index.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mars Trail · Code Tour</title>
+  <link rel="stylesheet" href="../../styles/theme.css">
+  <link rel="stylesheet" href="../../styles/layout.css">
+  <link rel="stylesheet" href="../../styles/components.css">
+  <link rel="stylesheet" href="../../styles/modals.css">
+  <link rel="stylesheet" href="../../styles/theme-lcars.css">
+  <link rel="stylesheet" href="../../styles/theme-voltron.css">
+  <link rel="stylesheet" href="../../styles/theme-starfighter.css">
+  <link rel="stylesheet" href="tour.css">
+</head>
+<body>
+  <div class="scanlines" aria-hidden="true"></div>
+
+  <header class="tour-topbar">
+    <span class="tour-brand">MARS TRAIL · CODE TOUR</span>
+    <span class="tour-topbar-right">
+      <span class="tour-progress" id="tour-progress"></span>
+      <select id="theme-select" class="theme-select" aria-label="Interface theme"></select>
+    </span>
+  </header>
+
+  <main class="tour-stage" id="tour-stage" aria-live="polite"></main>
+
+  <footer class="tour-nav">
+    <button id="tour-prev" type="button" class="btn-secondary">← PREV</button>
+    <button id="tour-next" type="button" class="btn-primary">NEXT →</button>
+  </footer>
+
+  <div id="modal-root"></div>
+
+  <script type="module" src="tour.js"></script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Create minimal tour.css**
+
+Create `docs/walkthrough/tour.css`:
+
+```css
+/* Layout primitives. Colors and decoration come from styles/theme-*.css via CSS vars. */
+
+.tour-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--panel-border, #0a8);
+}
+
+.tour-brand { font-weight: 700; letter-spacing: 0.08em; }
+
+.tour-topbar-right {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.tour-progress { font-size: 0.9em; opacity: 0.85; }
+
+.tour-stage {
+  padding: 24px;
+  max-width: 920px;
+  margin: 0 auto;
+  min-height: calc(100vh - 140px);
+}
+
+.tour-nav {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 24px;
+  border-top: 1px solid var(--panel-border, #0a8);
+}
+
+.tour-slide h1 { margin-top: 0; }
+.tour-slide p { line-height: 1.5; max-width: 70ch; }
+```
+
+- [ ] **Step 3: Create repo constants module**
+
+Create `docs/walkthrough/repo.js`:
+
+```js
+// Single source of truth for GitHub links. package.json has no `repository` field,
+// so bake it here. Update BRANCH if main is ever renamed.
+export const OWNER = 'VanderpoolTeacher';
+export const REPO = 'mars-trail';
+export const BRANCH = 'main';
+
+export function githubUrl(path, lineStart, lineEnd) {
+  const base = `https://github.com/${OWNER}/${REPO}/blob/${BRANCH}/${path}`;
+  if (typeof lineStart !== 'number') return base;
+  if (typeof lineEnd !== 'number' || lineEnd === lineStart) return `${base}#L${lineStart}`;
+  return `${base}#L${lineStart}-L${lineEnd}`;
+}
+```
+
+- [ ] **Step 4: Create slides.js with a single welcome slide**
+
+Create `docs/walkthrough/slides.js`:
+
+```js
+// Slide manifest. Populated across tasks 6, 7, 9, 10, 12, 13.
+export const spine = [
+  {
+    id: 'welcome',
+    title: 'Welcome to the Mars Trail code tour',
+    body: '<p>Press → or click NEXT to begin.</p>',
+  },
+];
+```
+
+- [ ] **Step 5: Create minimal tour.js that renders the first slide**
+
+Create `docs/walkthrough/tour.js`:
+
+```js
+import { spine } from './slides.js';
+
+function renderSlide(slide) {
+  const stage = document.getElementById('tour-stage');
+  stage.innerHTML = `
+    <section class="tour-slide">
+      <h1>${slide.title}</h1>
+      ${slide.body}
+    </section>
+  `;
+}
+
+renderSlide(spine[0]);
+```
+
+- [ ] **Step 6: Manually verify the page loads**
+
+Open `docs/walkthrough/index.html` in a browser.
+Expected: page shows "MARS TRAIL · CODE TOUR" topbar, "Welcome to the Mars Trail code tour" as the heading, "Press → or click NEXT to begin." as body, and PREV/NEXT buttons at the bottom. No console errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/walkthrough/
+git commit -m "Scaffold code tour: entry HTML, stylesheet, empty engine (refs #65)"
+```
+
+---
+
+## Task 2: Pure router helpers + unit tests
+
+**Files:**
+- Create: `docs/walkthrough/router.js`
+- Create: `sim/walkthroughRouter.test.mjs`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `sim/walkthroughRouter.test.mjs`:
+
+```js
+// Unit tests for docs/walkthrough/router.js. Run: node --test sim/walkthroughRouter.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseHash,
+  hashFor,
+  routeForward,
+  routeBack,
+} from '../docs/walkthrough/router.js';
+
+// Minimal slide set used by all tests.
+const slides = {
+  spine: [
+    { id: 'welcome' },
+    { id: 'pitch' },
+    {
+      id: 'hub',
+      branches: [
+        { id: 'travel', sub: [{ id: 's1' }, { id: 's2' }] },
+        { id: 'events', sub: [{ id: 's1' }] },
+      ],
+    },
+    { id: 'credits' },
+  ],
+};
+
+test('parseHash returns spine location for empty / slide hash', () => {
+  assert.deepEqual(parseHash(''),        { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide-0'), { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide-2'), { kind: 'spine', index: 2 });
+});
+
+test('parseHash returns branch location for branch hash', () => {
+  assert.deepEqual(parseHash('#branch-travel-0'), { kind: 'branch', branchId: 'travel', subIndex: 0 });
+  assert.deepEqual(parseHash('#branch-events-0'), { kind: 'branch', branchId: 'events', subIndex: 0 });
+});
+
+test('parseHash clamps invalid input to spine index 0', () => {
+  assert.deepEqual(parseHash('#gibberish'),  { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide-999'),  { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide--1'),   { kind: 'spine', index: 0 });
+});
+
+test('hashFor round-trips a spine location', () => {
+  assert.equal(hashFor({ kind: 'spine', index: 0 }), '#slide-0');
+  assert.equal(hashFor({ kind: 'spine', index: 3 }), '#slide-3');
+});
+
+test('hashFor round-trips a branch location', () => {
+  assert.equal(hashFor({ kind: 'branch', branchId: 'travel', subIndex: 1 }), '#branch-travel-1');
+});
+
+test('routeForward on spine advances to next spine slide', () => {
+  assert.deepEqual(
+    routeForward({ kind: 'spine', index: 0 }, slides),
+    { kind: 'spine', index: 1 }
+  );
+});
+
+test('routeForward on last spine slide is a no-op', () => {
+  assert.deepEqual(
+    routeForward({ kind: 'spine', index: 3 }, slides),
+    { kind: 'spine', index: 3 }
+  );
+});
+
+test('routeForward on last sub-slide of a branch returns to hub', () => {
+  // hub is index 2 in the slides spine above
+  assert.deepEqual(
+    routeForward({ kind: 'branch', branchId: 'travel', subIndex: 1 }, slides),
+    { kind: 'spine', index: 2 }
+  );
+});
+
+test('routeForward inside a multi-sub branch advances sub-index', () => {
+  assert.deepEqual(
+    routeForward({ kind: 'branch', branchId: 'travel', subIndex: 0 }, slides),
+    { kind: 'branch', branchId: 'travel', subIndex: 1 }
+  );
+});
+
+test('routeBack on first spine slide is a no-op', () => {
+  assert.deepEqual(
+    routeBack({ kind: 'spine', index: 0 }, slides),
+    { kind: 'spine', index: 0 }
+  );
+});
+
+test('routeBack on first sub-slide of a branch returns to hub', () => {
+  assert.deepEqual(
+    routeBack({ kind: 'branch', branchId: 'travel', subIndex: 0 }, slides),
+    { kind: 'spine', index: 2 }
+  );
+});
+
+test('routeBack inside a multi-sub branch decrements sub-index', () => {
+  assert.deepEqual(
+    routeBack({ kind: 'branch', branchId: 'travel', subIndex: 1 }, slides),
+    { kind: 'branch', branchId: 'travel', subIndex: 0 }
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test sim/walkthroughRouter.test.mjs`
+Expected: FAIL — module `../docs/walkthrough/router.js` cannot be resolved.
+
+- [ ] **Step 3: Implement router.js to make tests pass**
+
+Create `docs/walkthrough/router.js`:
+
+```js
+// Pure routing helpers for the code tour. No DOM, no side effects.
+//
+// A "location" is one of:
+//   { kind: 'spine',  index: number }              -- position on the spine
+//   { kind: 'branch', branchId: string, subIndex: number } -- inside a hub branch
+
+const SLIDE_HASH = /^#slide-(\d+)$/;
+const BRANCH_HASH = /^#branch-([a-zA-Z0-9_-]+)-(\d+)$/;
+
+export function parseHash(hash) {
+  if (!hash || hash === '#') return { kind: 'spine', index: 0 };
+  const m1 = SLIDE_HASH.exec(hash);
+  if (m1) {
+    const idx = Number(m1[1]);
+    if (idx < 0 || !Number.isFinite(idx)) return { kind: 'spine', index: 0 };
+    return { kind: 'spine', index: idx };
+  }
+  const m2 = BRANCH_HASH.exec(hash);
+  if (m2) return { kind: 'branch', branchId: m2[1], subIndex: Number(m2[2]) };
+  return { kind: 'spine', index: 0 };
+}
+
+export function hashFor(location) {
+  if (location.kind === 'spine') return `#slide-${location.index}`;
+  return `#branch-${location.branchId}-${location.subIndex}`;
+}
+
+function hubIndex(slides) {
+  return slides.spine.findIndex(s => s.id === 'hub');
+}
+
+function findBranch(slides, branchId) {
+  const hub = slides.spine.find(s => s.id === 'hub');
+  if (!hub || !hub.branches) return null;
+  return hub.branches.find(b => b.id === branchId) || null;
+}
+
+export function routeForward(location, slides) {
+  if (location.kind === 'spine') {
+    const next = location.index + 1;
+    if (next >= slides.spine.length) return location;
+    return { kind: 'spine', index: next };
+  }
+  // kind === 'branch'
+  const branch = findBranch(slides, location.branchId);
+  if (!branch) return { kind: 'spine', index: hubIndex(slides) };
+  if (location.subIndex + 1 < branch.sub.length) {
+    return { kind: 'branch', branchId: location.branchId, subIndex: location.subIndex + 1 };
+  }
+  return { kind: 'spine', index: hubIndex(slides) };
+}
+
+export function routeBack(location, slides) {
+  if (location.kind === 'spine') {
+    if (location.index === 0) return location;
+    return { kind: 'spine', index: location.index - 1 };
+  }
+  // kind === 'branch'
+  if (location.subIndex === 0) return { kind: 'spine', index: hubIndex(slides) };
+  return { kind: 'branch', branchId: location.branchId, subIndex: location.subIndex - 1 };
+}
+
+// Validate a parsed hash against a concrete slides manifest.
+// Returns a valid location. Out-of-range hashes fall back to spine 0.
+export function routeToSlide(location, slides) {
+  if (location.kind === 'spine') {
+    if (location.index < 0 || location.index >= slides.spine.length) {
+      return { kind: 'spine', index: 0 };
+    }
+    return location;
+  }
+  const branch = findBranch(slides, location.branchId);
+  if (!branch) return { kind: 'spine', index: 0 };
+  if (location.subIndex < 0 || location.subIndex >= branch.sub.length) {
+    return { kind: 'branch', branchId: location.branchId, subIndex: 0 };
+  }
+  return location;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test sim/walkthroughRouter.test.mjs`
+Expected: PASS — all 11 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/walkthrough/router.js sim/walkthroughRouter.test.mjs
+git commit -m "Code tour: pure router helpers with unit tests (refs #65)"
+```
+
+---
+
+## Task 3: Wire tour.js to the router (spine navigation working end-to-end)
+
+**Files:**
+- Modify: `docs/walkthrough/tour.js`
+- Modify: `docs/walkthrough/slides.js` (add a second spine slide so navigation is observable)
+
+- [ ] **Step 1: Add a second spine slide so forward/back is observable**
+
+Replace the contents of `docs/walkthrough/slides.js`:
+
+```js
+export const spine = [
+  {
+    id: 'welcome',
+    title: 'Welcome to the Mars Trail code tour',
+    body: '<p>Press → or click NEXT to begin.</p>',
+  },
+  {
+    id: 'pitch',
+    title: 'What is Mars Trail?',
+    body: '<p>Placeholder — real content arrives in Task 6.</p>',
+  },
+];
+```
+
+- [ ] **Step 2: Rewrite tour.js with routing wired in**
+
+Replace the contents of `docs/walkthrough/tour.js`:
+
+```js
+import { spine } from './slides.js';
+import { parseHash, hashFor, routeForward, routeBack, routeToSlide } from './router.js';
+
+const slides = { spine };
+let current = routeToSlide(parseHash(window.location.hash), slides);
+
+function slideAt(location) {
+  if (location.kind === 'spine') return slides.spine[location.index];
+  const hub = slides.spine.find(s => s.id === 'hub');
+  const branch = hub.branches.find(b => b.id === location.branchId);
+  return branch.sub[location.subIndex];
+}
+
+function renderProgress(location) {
+  const el = document.getElementById('tour-progress');
+  if (!el) return;
+  if (location.kind === 'spine') {
+    el.textContent = `SPINE ${location.index + 1} / ${slides.spine.length}`;
+  } else {
+    el.textContent = `HUB › ${location.branchId} › ${location.subIndex + 1}`;
+  }
+}
+
+function render(location) {
+  const slide = slideAt(location);
+  document.getElementById('tour-stage').innerHTML = `
+    <section class="tour-slide">
+      <h1>${slide.title}</h1>
+      ${slide.body}
+    </section>
+  `;
+  renderProgress(location);
+}
+
+function go(nextLocation) {
+  current = nextLocation;
+  const hash = hashFor(nextLocation);
+  if (window.location.hash !== hash) {
+    window.history.pushState(null, '', hash);
+  }
+  render(current);
+}
+
+function onKey(e) {
+  if (e.key === 'ArrowRight')      go(routeForward(current, slides));
+  else if (e.key === 'ArrowLeft')  go(routeBack(current, slides));
+  else if (e.key === 'Home')       go({ kind: 'spine', index: 0 });
+  else if (e.key === 'End')        go({ kind: 'spine', index: slides.spine.length - 1 });
+}
+
+document.addEventListener('keydown', onKey);
+document.getElementById('tour-next').addEventListener('click', () => go(routeForward(current, slides)));
+document.getElementById('tour-prev').addEventListener('click', () => go(routeBack(current, slides)));
+window.addEventListener('hashchange', () => {
+  current = routeToSlide(parseHash(window.location.hash), slides);
+  render(current);
+});
+
+render(current);
+```
+
+- [ ] **Step 3: Manually verify navigation works**
+
+Open `docs/walkthrough/index.html` in a browser.
+Expected:
+- Welcome slide loads, progress reads "SPINE 1 / 2".
+- Click NEXT or press → : pitch slide loads, progress reads "SPINE 2 / 2", URL hash becomes `#slide-1`.
+- Click PREV or press ← : welcome slide loads, hash becomes `#slide-0`.
+- Open directly to `…/index.html#slide-1` : pitch slide loads immediately.
+- Browser back button returns to previous slide.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/walkthrough/
+git commit -m "Code tour: spine navigation + hash routing (refs #65)"
+```
+
+---
+
+## Task 4: Theme-toggle dropdown
+
+**Files:**
+- Modify: `docs/walkthrough/tour.js`
+
+- [ ] **Step 1: Add theme wiring to tour.js**
+
+Insert these imports at the top of `docs/walkthrough/tour.js`, just below the existing imports:
+
+```js
+import { THEMES, resolveTheme } from '../../src/theme.js';
+```
+
+Insert this block in `tour.js` anywhere before the final `render(current)` call:
+
+```js
+function initTourTheme() {
+  const select = document.getElementById('theme-select');
+  if (!select) return;
+  select.innerHTML = '';
+  for (const t of THEMES) {
+    const opt = document.createElement('option');
+    opt.value = t.id;
+    opt.textContent = t.label;
+    select.appendChild(opt);
+  }
+  const applyTheme = (raw) => {
+    const theme = resolveTheme(raw);
+    if (theme === 'mc') document.body.removeAttribute('data-theme');
+    else document.body.setAttribute('data-theme', theme);
+    select.value = theme;
+  };
+  applyTheme('mc'); // slideshow always starts in mc; tour does NOT read localStorage
+  select.addEventListener('change', (e) => applyTheme(e.target.value));
+}
+
+initTourTheme();
+```
+
+- [ ] **Step 2: Manually verify theme switching works**
+
+Open `docs/walkthrough/index.html` in a browser.
+Expected:
+- Dropdown in top-right shows four options: Mission Control, LCARS / TNG, Voltron HUD, Last Starfighter.
+- Changing selection repaints the page (colors, borders, fonts change).
+- Refreshing the page always returns to Mission Control (no localStorage persistence for the tour).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/walkthrough/tour.js
+git commit -m "Code tour: theme-toggle dropdown reusing src/theme.js (refs #65)"
+```
+
+---
+
+## Task 5: Code-snippet component
+
+**Files:**
+- Modify: `docs/walkthrough/tour.js`
+- Modify: `docs/walkthrough/tour.css`
+
+- [ ] **Step 1: Add snippet CSS**
+
+Append to `docs/walkthrough/tour.css`:
+
+```css
+.tour-snippets { margin-top: 16px; }
+
+.tour-snippet {
+  border: 1px solid var(--panel-border, #0a8);
+  border-radius: 4px;
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+
+.tour-snippet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  background: var(--panel-header-bg, rgba(0, 170, 136, 0.1));
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.85em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.tour-snippet-header .tour-snippet-label { font-weight: 600; }
+.tour-snippet-header .tour-snippet-links { display: flex; gap: 10px; font-size: 0.9em; }
+
+.tour-snippet-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease;
+}
+
+.tour-snippet.is-open .tour-snippet-body { max-height: 800px; overflow: auto; }
+
+.tour-snippet pre {
+  margin: 0;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  line-height: 1.45;
+  white-space: pre;
+  background: var(--code-bg, #000);
+  color: var(--code-fg, inherit);
+}
+```
+
+- [ ] **Step 2: Add snippet rendering + wiring to tour.js**
+
+Add this import near the top of `docs/walkthrough/tour.js`:
+
+```js
+import { githubUrl } from './repo.js';
+```
+
+Replace the `render` function in `tour.js` with one that emits snippets when the slide declares them:
+
+```js
+function escapeHtml(s) {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function renderSnippet(snippet) {
+  const [a, b] = snippet.lines || [];
+  const label = `${snippet.path}${a ? ` : ${a}${b && b !== a ? `–${b}` : ''}` : ''}`;
+  const url = githubUrl(snippet.path, a, b);
+  return `
+    <div class="tour-snippet" data-snippet>
+      <div class="tour-snippet-header" data-snippet-toggle>
+        <span class="tour-snippet-label">${escapeHtml(label)}${snippet.caption ? ` — ${escapeHtml(snippet.caption)}` : ''}</span>
+        <span class="tour-snippet-links">
+          <a href="${url}" target="_blank" rel="noopener">View on GitHub ↗</a>
+          <span class="tour-snippet-chevron">▾</span>
+        </span>
+      </div>
+      <div class="tour-snippet-body">
+        <pre><code>${escapeHtml(snippet.code)}</code></pre>
+      </div>
+    </div>
+  `;
+}
+
+function render(location) {
+  const slide = slideAt(location);
+  const snippetsHtml = slide.snippets?.length
+    ? `<div class="tour-snippets">${slide.snippets.map(renderSnippet).join('')}</div>`
+    : '';
+  document.getElementById('tour-stage').innerHTML = `
+    <section class="tour-slide">
+      <h1>${slide.title}</h1>
+      ${slide.body}
+      ${snippetsHtml}
+    </section>
+  `;
+  // Wire expand/collapse.
+  for (const header of document.querySelectorAll('[data-snippet-toggle]')) {
+    header.addEventListener('click', () => header.parentElement.classList.toggle('is-open'));
+  }
+  renderProgress(location);
+}
+```
+
+- [ ] **Step 3: Add a snippet to the pitch slide for visual verification**
+
+Replace the `pitch` slide in `docs/walkthrough/slides.js` with:
+
+```js
+  {
+    id: 'pitch',
+    title: 'What is Mars Trail?',
+    body: '<p>Placeholder — real content arrives in Task 6.</p>',
+    snippets: [
+      {
+        path: 'src/main.js',
+        lines: [1, 10],
+        caption: 'Placeholder snippet (replaced in Task 7)',
+        code: '// first lines of main.js will go here\nconsole.log("hello mars");',
+      },
+    ],
+  },
+```
+
+- [ ] **Step 4: Manually verify**
+
+Open `docs/walkthrough/index.html#slide-1` in a browser.
+Expected:
+- A collapsed snippet box appears below the body text, labeled `src/main.js : 1–10 — Placeholder snippet …`.
+- Clicking the header expands it to reveal the code.
+- The "View on GitHub ↗" link opens `https://github.com/VanderpoolTeacher/mars-trail/blob/main/src/main.js#L1-L10` in a new tab.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/walkthrough/tour.js docs/walkthrough/tour.css docs/walkthrough/slides.js
+git commit -m "Code tour: expandable code-snippet component (refs #65)"
+```
+
+---
+
+## Task 6: Spine content — slides 1–4 (pre-code)
+
+**Files:**
+- Modify: `docs/walkthrough/slides.js`
+
+- [ ] **Step 1: Author the first four spine slides**
+
+Replace `docs/walkthrough/slides.js` with:
+
+```js
+export const spine = [
+  {
+    id: 'welcome',
+    title: 'Welcome to the Mars Trail code tour',
+    body: `
+      <p class="subtitle">A ~15-minute guided tour of how this game is organized.</p>
+      <p>Use <strong>← →</strong> to navigate. <strong>Esc</strong> returns from a hub branch. Theme selector in the top-right repaints everything — the tour itself is a live demo of the game's theme system.</p>
+      <p>Press <strong>→</strong> or click <strong>NEXT</strong> to begin.</p>
+    `,
+  },
+  {
+    id: 'pitch',
+    title: 'What is Mars Trail?',
+    body: `
+      <p>An Oregon-Trail-style survival sim set on Mars, built for a game jam. You captain a rover across Acidalia Planitia, rationing power and EVA suits, managing crew, responding to emergencies, and diverting for side missions ("away teams") that chase science points.</p>
+      <p>Runs are short (~10–20 sols of play), most of the difficulty is in the event system, and a run ends when you reach the goal or lose the crew.</p>
+    `,
+  },
+  {
+    id: 'stack',
+    title: 'Tech stack',
+    body: `
+      <p><strong>Vanilla ES modules.</strong> No framework, no bundler, no build step. Open <code>index.html</code> in a browser and you're running the game.</p>
+      <p>This is deliberate: the project is small enough that a build toolchain would be more complexity than feature. It also makes the code unusually easy to read — what you see in the file is what runs.</p>
+      <p>Testing uses Node's built-in <code>node --test</code> runner (see <code>sim/</code>). The simulation harness at <code>sim/play.mjs</code> runs thousands of AI-driven playthroughs to validate balance.</p>
+    `,
+  },
+  {
+    id: 'layout',
+    title: 'Repo layout',
+    body: `
+      <p>The whole project fits in a handful of folders. Each has one job.</p>
+      <pre style="line-height:1.35;font-size:0.9em"><code>Mars Trail/
+├── index.html          — game entry point
+├── src/
+│   ├── main.js         — boots the game, wires UI
+│   ├── state.js        — single source of truth
+│   ├── render.js       — state → DOM
+│   ├── theme.js        — theme switcher
+│   ├── audio.js        — music + mute
+│   ├── systems/        — game logic (pure where possible)
+│   ├── content/        — data: events, emergencies, facts, waypoints
+│   └── ui/             — modals, codex overlay
+├── styles/             — theme.css + per-theme overlays
+├── sim/                — unit tests + playtest harness
+├── assets/             — images, music
+└── docs/superpowers/   — per-feature specs + implementation plans
+</code></pre>
+      <p>The rest of the tour follows the data flow: entry point → state → render → systems (via a hub) → content → UI → themes → audio → tests → workflow.</p>
+    `,
+  },
+  // Slides 5–8 added in Task 7, slide 9 (hub) in Task 9, 10–16 in Task 13.
+];
+```
+
+- [ ] **Step 2: Manually verify**
+
+Open `docs/walkthrough/index.html` in a browser, click through all four slides.
+Expected: readable prose, clean layout, progress counter reads 1/4 through 4/4, no broken markup.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/walkthrough/slides.js
+git commit -m "Code tour: pre-code spine content (welcome, pitch, stack, layout) (refs #65)"
+```
+
+---
+
+## Task 7: Spine content — slides 6–8 (entry point, state, render) with real code snippets
+
+**Files:**
+- Modify: `docs/walkthrough/slides.js`
+
+- [ ] **Step 1: Read the real code that each slide references**
+
+Run: `head -40 src/main.js`; `head -30 src/state.js`; `head -30 src/render.js`
+
+This gives you the lines each snippet will quote verbatim. The `lines` field in each snippet must match the actual line numbers at the time of writing.
+
+- [ ] **Step 2: Append slides 5–8 to the spine**
+
+(Slide 5 — game loop diagram — gets its demo in Task 8; stub its body for now.)
+
+Append to the `spine` array in `docs/walkthrough/slides.js`, between the existing `layout` slide and the trailing comment:
+
+```js
+  {
+    id: 'loop',
+    title: 'The game loop',
+    body: `
+      <p>Every turn (a "sol") follows the same four-phase rhythm:</p>
+      <ol>
+        <li><strong>Input</strong> — player picks pace / rations / actions.</li>
+        <li><strong>Systems</strong> — <code>travel.js</code>, <code>events.js</code>, and friends mutate state.</li>
+        <li><strong>Render</strong> — <code>render.js</code> rebuilds the DOM from state.</li>
+        <li><strong>Log</strong> — mission log entries appear for what just happened.</li>
+      </ol>
+      <p>There is <em>no</em> observer pattern, <em>no</em> virtual DOM, <em>no</em> reactive framework. On every change, <code>render()</code> rebuilds the parts of the DOM it owns from scratch.</p>
+      <div id="demo-loop-mount"></div>
+    `,
+    demo: 'loop',
+  },
+  {
+    id: 'entry',
+    title: 'Entry point',
+    body: `
+      <p><code>index.html</code> loads stylesheets and calls into <code>src/main.js</code>, which boots the game: builds initial state, wires event listeners, paints the first frame.</p>
+      <p>Follow the imports at the top of <code>main.js</code> and you get a one-page map of the whole app.</p>
+    `,
+    snippets: [
+      {
+        path: 'src/main.js',
+        lines: [1, 20],
+        caption: 'Boot imports',
+        code: `// Top of src/main.js — the imports are the table of contents.
+// (Paste the actual current lines 1–20 of src/main.js here.
+//  Update the line range in the lines: [1, 20] above to match.)`,
+      },
+    ],
+  },
+  {
+    id: 'state',
+    title: 'State',
+    body: `
+      <p><code>src/state.js</code> exports a single function, <code>createInitialState()</code>, that returns a plain JS object. That object <em>is</em> the game. Everything else reads it; systems mutate it; <code>render()</code> projects it to DOM.</p>
+      <p>Keeping state in one place is what makes tests easy to write: seed a state, call a system, assert on the resulting state.</p>
+    `,
+    snippets: [
+      {
+        path: 'src/state.js',
+        lines: [1, 30],
+        caption: 'State shape overview',
+        code: `// Top of src/state.js — structural overview of the game object.
+// (Paste actual lines 1–30 of src/state.js here at implementation time,
+//  and update the lines: [1, 30] field to match whatever subset you pasted.)`,
+      },
+    ],
+  },
+  {
+    id: 'render',
+    title: 'Render',
+    body: `
+      <p><code>src/render.js</code> is a pure <code>state → DOM</code> projection. It exports one function — <code>render(state)</code> — that is called after every state change. No partial updates, no diffing; just rebuild the panels it owns.</p>
+      <p>This stays cheap because the DOM is small: a few panels, a crew list, a log. The simplicity is the feature.</p>
+    `,
+    snippets: [
+      {
+        path: 'src/render.js',
+        lines: [1, 30],
+        caption: 'Render entry',
+        code: `// Top of src/render.js — the projection entry point.
+// (Paste actual lines 1–30 of src/render.js here at implementation time,
+//  and update the lines: [1, 30] field to match.)`,
+      },
+    ],
+  },
+```
+
+**IMPORTANT:** Before committing, replace each snippet's `code:` string with the actual current contents of the referenced file range. The placeholder comments above are authoring instructions, not finished content. Update the `lines:` tuple if your chosen range differs.
+
+- [ ] **Step 3: Manually verify**
+
+Open `docs/walkthrough/index.html` in a browser, click to slides 5–8.
+Expected: readable content on each; snippet on entry/state/render slides expands to show real code; "View on GitHub" link opens the correct file and line range.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/walkthrough/slides.js
+git commit -m "Code tour: entry / state / render slides with real code snippets (refs #65)"
+```
+
+---
+
+## Task 8: Game-loop demo (demos/loop.js)
+
+**Files:**
+- Create: `docs/walkthrough/demos/loop.js`
+- Modify: `docs/walkthrough/tour.js` (add demo dispatch)
+
+- [ ] **Step 1: Create the loop demo module**
+
+Create `docs/walkthrough/demos/loop.js`:
+
+```js
+// Explanatory animation of the game loop. No real-module imports —
+// this one is a visualization, not a behavior proof.
+//
+// Exports init(mount) which renders a 4-step cycle: Input → Systems → Render → Log.
+
+const PHASES = ['INPUT', 'SYSTEMS', 'RENDER', 'LOG'];
+
+export function init(mount) {
+  mount.innerHTML = `
+    <div class="loop-demo" style="margin-top:16px;padding:14px;border:1px solid var(--panel-border,#0a8);border-radius:4px">
+      <div style="display:flex;gap:10px;justify-content:center;align-items:center">
+        ${PHASES.map((p, i) => `
+          <div class="loop-phase" data-phase-index="${i}" style="padding:10px 14px;border:1px solid var(--panel-border,#0a8);border-radius:4px;min-width:80px;text-align:center;font-family:ui-monospace,monospace;transition:all 0.2s">${p}</div>
+          ${i < PHASES.length - 1 ? '<span style="opacity:0.6">→</span>' : ''}
+        `).join('')}
+      </div>
+      <div style="text-align:center;margin-top:12px;font-size:0.85em;opacity:0.8" id="loop-caption">Each sol runs through these four phases, in order.</div>
+    </div>
+  `;
+  const phases = mount.querySelectorAll('.loop-phase');
+  let active = 0;
+  const tick = () => {
+    phases.forEach((p, i) => {
+      p.style.background = i === active ? 'var(--panel-header-bg, rgba(0,170,136,0.3))' : 'transparent';
+      p.style.fontWeight = i === active ? '700' : '400';
+    });
+    active = (active + 1) % phases.length;
+  };
+  tick();
+  const id = setInterval(tick, 700);
+  return () => clearInterval(id); // cleanup on teardown
+}
+```
+
+- [ ] **Step 2: Add demo dispatch to tour.js**
+
+Insert near the top of `docs/walkthrough/tour.js`:
+
+```js
+const demoLoaders = {
+  loop:          () => import('./demos/loop.js'),
+  eventPreview:  () => import('./demos/eventPreview.js'),     // wired in Task 11
+  mashEmergency: () => import('./demos/mashEmergency.js'),    // wired in Task 12
+};
+
+let currentDemoCleanup = null;
+
+async function mountDemo(slide) {
+  if (currentDemoCleanup) { currentDemoCleanup(); currentDemoCleanup = null; }
+  if (!slide.demo) return;
+  const loader = demoLoaders[slide.demo];
+  if (!loader) return;
+  const mod = await loader();
+  const mount = document.getElementById(`demo-${slide.demo}-mount`);
+  if (!mount || typeof mod.init !== 'function') return;
+  const cleanup = mod.init(mount);
+  if (typeof cleanup === 'function') currentDemoCleanup = cleanup;
+}
+```
+
+Update `render(location)` to mount the demo after innerHTML is set. Replace the final `renderProgress(location);` line with:
+
+```js
+  renderProgress(location);
+  mountDemo(slide);
+```
+
+- [ ] **Step 3: Manually verify**
+
+Open `docs/walkthrough/index.html#slide-4` in a browser (the "loop" slide).
+Expected: four phase boxes labelled INPUT → SYSTEMS → RENDER → LOG; one highlighted at a time, rotating every 0.7 s. Navigate away and back — animation restarts cleanly (no doubled intervals).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/walkthrough/demos/loop.js docs/walkthrough/tour.js
+git commit -m "Code tour: animated game-loop demo (refs #65)"
+```
+
+---
+
+## Task 9: Hub slide + branch navigation
+
+**Files:**
+- Modify: `docs/walkthrough/slides.js` (add the hub slide with an initial stub for each of the 8 branches)
+- Modify: `docs/walkthrough/tour.js` (hub tile rendering, Esc handler, digit shortcuts)
+- Modify: `docs/walkthrough/tour.css` (hub tile grid)
+
+- [ ] **Step 1: Add hub slide to slides.js with stub branches**
+
+Append to the `spine` array, after the `render` slide:
+
+```js
+  {
+    id: 'hub',
+    title: 'Systems architecture',
+    body: `
+      <p>The game logic lives under <code>src/systems/</code>. Click any tile below to take a short tour of that module and return here. Press <strong>Esc</strong> to come back. Digit keys <strong>1–8</strong> jump to a tile.</p>
+    `,
+    branches: [
+      { id: 'travel',      label: 'travel.js',                         sub: [{ id: 's1', title: 'travel.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
+      { id: 'events',      label: 'events.js + content/events.js',     sub: [{ id: 's1', title: 'events.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
+      { id: 'multistage',  label: 'multiStage.js + multi-stage events', sub: [{ id: 's1', title: 'multiStage.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
+      { id: 'medical',     label: 'medicalEmergency.js',               sub: [{ id: 's1', title: 'medicalEmergency.js — placeholder', body: '<p>Branch content arrives in Task 12.</p>' }] },
+      { id: 'clickmetrics',label: 'clickMetrics.js',                   sub: [{ id: 's1', title: 'clickMetrics.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+      { id: 'awayteam',    label: 'awayTeam.js',                       sub: [{ id: 's1', title: 'awayTeam.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+      { id: 'smallsys',    label: 'crew / corpse / waypoints',         sub: [{ id: 's1', title: 'Small systems — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+      { id: 'scoring',     label: 'career.js + scoring.js',            sub: [{ id: 's1', title: 'Career & scoring — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+    ],
+  },
+```
+
+- [ ] **Step 2: Add hub tile CSS**
+
+Append to `docs/walkthrough/tour.css`:
+
+```css
+.hub-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.hub-tile {
+  padding: 14px;
+  border: 1px solid var(--panel-border, #0a8);
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: ui-monospace, monospace;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  transition: background 0.15s;
+}
+
+.hub-tile:hover, .hub-tile:focus {
+  background: var(--panel-header-bg, rgba(0, 170, 136, 0.15));
+  outline: none;
+}
+
+.hub-tile-key {
+  display: inline-block;
+  font-size: 0.75em;
+  opacity: 0.7;
+  margin-right: 8px;
+}
+
+.tour-breadcrumb {
+  font-size: 0.85em;
+  opacity: 0.75;
+  margin-bottom: 12px;
+  font-family: ui-monospace, monospace;
+}
+```
+
+- [ ] **Step 3: Render hub tiles + breadcrumb in tour.js**
+
+Locate the `render(location)` function in `docs/walkthrough/tour.js`. Replace its body with:
+
+```js
+function render(location) {
+  const slide = slideAt(location);
+  const stage = document.getElementById('tour-stage');
+  const hub = slides.spine.find(s => s.id === 'hub');
+
+  // Breadcrumb for branch slides.
+  const breadcrumb = location.kind === 'branch'
+    ? `<div class="tour-breadcrumb">HUB › ${escapeHtml(location.branchId)} › ${location.subIndex + 1} / ${hub.branches.find(b => b.id === location.branchId).sub.length}</div>`
+    : '';
+
+  // Hub tile grid when we're on the hub slide.
+  const hubTiles = (location.kind === 'spine' && slide.id === 'hub')
+    ? `<div class="hub-tiles" role="navigation" aria-label="Systems">
+         ${slide.branches.map((b, i) => `
+           <button class="hub-tile" data-branch-id="${b.id}" type="button">
+             <span class="hub-tile-key">${i + 1}</span>${escapeHtml(b.label)}
+           </button>
+         `).join('')}
+       </div>`
+    : '';
+
+  const snippetsHtml = slide.snippets?.length
+    ? `<div class="tour-snippets">${slide.snippets.map(renderSnippet).join('')}</div>`
+    : '';
+
+  stage.innerHTML = `
+    <section class="tour-slide">
+      ${breadcrumb}
+      <h1>${slide.title}</h1>
+      ${slide.body}
+      ${hubTiles}
+      ${snippetsHtml}
+    </section>
+  `;
+
+  for (const header of stage.querySelectorAll('[data-snippet-toggle]')) {
+    header.addEventListener('click', () => header.parentElement.classList.toggle('is-open'));
+  }
+  for (const tile of stage.querySelectorAll('.hub-tile')) {
+    tile.addEventListener('click', () => {
+      go({ kind: 'branch', branchId: tile.dataset.branchId, subIndex: 0 });
+    });
+  }
+
+  renderProgress(location);
+  mountDemo(slide);
+}
+```
+
+Replace the `onKey` function with:
+
+```js
+function onKey(e) {
+  if (e.key === 'ArrowRight')      return go(routeForward(current, slides));
+  if (e.key === 'ArrowLeft')       return go(routeBack(current, slides));
+  if (e.key === 'Home')            return go({ kind: 'spine', index: 0 });
+  if (e.key === 'End')             return go({ kind: 'spine', index: slides.spine.length - 1 });
+  if (e.key === 'Escape' && current.kind === 'branch') {
+    const hubIdx = slides.spine.findIndex(s => s.id === 'hub');
+    return go({ kind: 'spine', index: hubIdx });
+  }
+  // Digit 1–8 on hub → open corresponding branch.
+  if (current.kind === 'spine' && slideAt(current).id === 'hub' && /^[1-9]$/.test(e.key)) {
+    const hub = slides.spine.find(s => s.id === 'hub');
+    const idx = Number(e.key) - 1;
+    if (idx < hub.branches.length) {
+      return go({ kind: 'branch', branchId: hub.branches[idx].id, subIndex: 0 });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Manually verify**
+
+Open the tour in a browser and navigate to the hub slide (the one after "render").
+Expected:
+- Eight tiles render in a grid. Each tile shows `1 travel.js`, `2 events.js ...`, etc.
+- Clicking a tile navigates into the branch's first sub-slide; breadcrumb reads "HUB › travel › 1 / 1".
+- Pressing Esc returns to the hub.
+- Pressing `3` from the hub jumps directly to the third branch.
+- Clicking NEXT on a branch sub-slide (with only one sub-slide) returns to the hub.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/walkthrough/
+git commit -m "Code tour: hub slide + branch navigation (refs #65)"
+```
+
+---
+
+## Task 10: Branch content — travel, events, multiStage
+
+**Files:**
+- Modify: `docs/walkthrough/slides.js`
+
+- [ ] **Step 1: Read the current state of the three systems before authoring**
+
+Run: `head -40 src/systems/travel.js`; `head -40 src/systems/events.js`; `head -40 src/systems/multiStage.js`; `head -10 src/content/events.js`
+
+- [ ] **Step 2: Replace the three placeholder branches with real content**
+
+In `docs/walkthrough/slides.js`, replace the `travel`, `events`, and `multistage` branch entries in the hub's `branches` array with:
+
+```js
+      {
+        id: 'travel',
+        label: 'travel.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'travel.js — pace, tick, arrival',
+            body: `
+              <p><code>src/systems/travel.js</code> owns the per-sol resource tick. It advances the rover by pace-dependent km, consumes power, rations, EVA charges, and decides when the rover arrives at the next landmark.</p>
+              <p>The module is (mostly) pure: given a state and a pace, it returns a new state. That purity is what lets <code>sim/playtest1000.mjs</code> run thousands of simulated runs in ~10 seconds.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/travel.js',
+                lines: [1, 30],
+                caption: 'Module overview',
+                code: `// Paste actual src/systems/travel.js lines 1–30 here at implementation time.\n// Update lines: [1, 30] to match the chosen range.`,
+              },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'travel.js — the sol tick',
+            body: `
+              <p>The heart of travel is <code>advanceSol()</code>: one function that runs once per "NEXT SOL" button press. It consumes resources, maybe rolls an event, maybe arrives at a landmark, and writes log lines.</p>
+              <p>If you're looking for where a gameplay decision lives, start here and trace outward.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/travel.js',
+                lines: [80, 140],
+                caption: 'advanceSol body (subset)',
+                code: `// Paste a representative subset of advanceSol (~40-60 lines) here at implementation time.\n// Update lines: to match.`,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'events',
+        label: 'events.js + content/events.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'events.js — rolling an event',
+            body: `
+              <p><code>src/systems/events.js</code> picks which event fires on a given sol, based on segment, pace, and weighting. Event <em>data</em> lives separately in <code>src/content/events.js</code>: each entry has a title, body, and a set of choices with effects.</p>
+              <p>This split (system vs. content) is the dominant pattern in the codebase: logic in <code>src/systems/</code>, data in <code>src/content/</code>. Content can grow without touching logic.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/events.js',
+                lines: [1, 40],
+                caption: 'Event selection',
+                code: `// Paste src/systems/events.js lines 1–40 here at implementation time.`,
+              },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'Live: a random event card',
+            body: `
+              <p>Here is an event card, rendered by the <em>real</em> modal renderer against data from <code>src/content/events.js</code>. Click "Roll another" to re-roll. Choice buttons are real but don't apply effects — this preview is read-only.</p>
+              <div id="demo-eventPreview-mount"></div>
+            `,
+            demo: 'eventPreview',
+          },
+        ],
+      },
+      {
+        id: 'multistage',
+        label: 'multiStage.js + multi-stage events',
+        sub: [
+          {
+            id: 's1',
+            title: 'multiStage.js — authored chains',
+            body: `
+              <p>A multi-stage event is an authored chain: each choice points to the next stage, or to an outcome. <code>src/systems/multiStage.js</code> is a tiny engine that walks that graph. <code>src/content/multiStageEvents.js</code> (and <code>emergencies.js</code>) are the authored data.</p>
+              <p>The medical emergency (hub branch <strong>4</strong>) is the flagship example — a three-stage diagnosis-treatment-disposal chain.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/multiStage.js',
+                lines: [1, 40],
+                caption: 'Engine shape',
+                code: `// Paste src/systems/multiStage.js lines 1–40 here at implementation time.`,
+              },
+            ],
+          },
+        ],
+      },
+```
+
+**IMPORTANT:** Before committing, replace each snippet's `code:` string with the actual current contents of the referenced file range, and update the `lines:` tuple to match what you pasted.
+
+- [ ] **Step 3: Manually verify**
+
+Navigate into each of the three branches (`1`, `2`, `3` from the hub).
+Expected:
+- All sub-slides render readable content and show their snippets.
+- The "Live: a random event card" sub-slide has an empty mount (the demo is wired in Task 11; until then the mount stays empty and a console warning is fine).
+- Breadcrumbs and NEXT/PREV navigation round-trip through the hub.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/walkthrough/slides.js
+git commit -m "Code tour: travel/events/multistage branch content (refs #65)"
+```
+
+---
+
+## Task 11: Event-card preview demo
+
+**Files:**
+- Create: `docs/walkthrough/demos/eventPreview.js`
+
+- [ ] **Step 1: Find the existing modal entry point**
+
+Run: `grep -n "export" src/ui/modals.js | head -20`
+Locate the function that renders an event card (likely `showEventModal` or similar). Note its signature and which DOM element it targets (likely `#modal-root`).
+
+- [ ] **Step 2: Create the demo module**
+
+Create `docs/walkthrough/demos/eventPreview.js`:
+
+```js
+// Real-module demo: imports the game's event content and modal renderer
+// to render a random event card as a read-only preview.
+//
+// NOTE: imports below must stay in sync with src/content/events.js and src/ui/modals.js.
+// If those files move or rename exports, update here and the smoke test will flag the break.
+
+import { events as ALL_EVENTS } from '../../../src/content/events.js';
+import * as Modals from '../../../src/ui/modals.js';
+
+function pickRandom(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+// Adapt this to whatever the real modal entry is named in src/ui/modals.js.
+// Document the expectation so the smoke test can assert it.
+export const REQUIRED_MODAL_EXPORT = 'showEventModal';
+
+export function init(mount) {
+  const showFn = Modals[REQUIRED_MODAL_EXPORT];
+  if (typeof showFn !== 'function') {
+    mount.innerHTML = `<p style="color:#f66">Event preview unavailable: src/ui/modals.js does not export ${REQUIRED_MODAL_EXPORT}.</p>`;
+    return () => {};
+  }
+
+  mount.innerHTML = `
+    <div style="margin-top:12px">
+      <button id="event-preview-roll" class="btn-primary" type="button">Roll another</button>
+    </div>
+    <div id="event-preview-target" style="margin-top:12px"></div>
+  `;
+
+  const roll = () => {
+    const target = document.getElementById('event-preview-target');
+    target.innerHTML = '';
+    const evt = pickRandom(ALL_EVENTS.filter(e => !e.multiStage && !e.stages));
+    // Render via real modal function, but neuter side effects by passing a no-op dispatch
+    // and an explicit preview=true flag. Adapt flags to the real signature at implementation time.
+    try {
+      showFn({
+        event: evt,
+        container: target,
+        preview: true,
+        onChoice: () => {},
+      });
+    } catch (err) {
+      target.innerHTML = `<p style="color:#f66">Could not render event "${evt?.id}": ${err.message}</p>`;
+    }
+  };
+
+  document.getElementById('event-preview-roll').addEventListener('click', roll);
+  roll();
+
+  return () => {}; // no interval/listener to clean up beyond DOM replacement on next render
+}
+```
+
+**IMPORTANT:** The modal signature above is a best-effort guess. At implementation time, open `src/ui/modals.js`, find the real event-modal function, and adapt `init()` to call it correctly. If the real function has no "preview" mode, write a thin wrapper here that renders the event's title, body, and choices as static buttons (not via the real function). Update `REQUIRED_MODAL_EXPORT` and the call shape accordingly.
+
+- [ ] **Step 3: Manually verify**
+
+Navigate to hub → branch 2 (events) → second sub-slide ("Live: a random event card").
+Expected:
+- An event card renders. Title + body + choice buttons visible.
+- Clicking "Roll another" swaps in a different random event.
+- No thrown errors in the console.
+- Switching themes while the demo is visible repaints it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/walkthrough/demos/eventPreview.js
+git commit -m "Code tour: real-module event-card preview demo (refs #65)"
+```
+
+---
+
+## Task 12: Medical emergency branch + mash-emergency demo
+
+**Files:**
+- Create: `docs/walkthrough/demos/mashEmergency.js`
+- Modify: `docs/walkthrough/slides.js` (replace the `medical` placeholder branch)
+
+- [ ] **Step 1: Find the existing mash-emergency UI entry**
+
+Run: `grep -n "export" src/systems/medicalEmergency.js | head -20`; `grep -n "mash\|medical" src/ui/modals.js`
+Identify the modal function that shows the click-mash UI and the state it expects. Note the signature.
+
+- [ ] **Step 2: Create the demo module**
+
+Create `docs/walkthrough/demos/mashEmergency.js`:
+
+```js
+// Real-module demo: imports the medical-emergency system and runs a seeded
+// click-mash rescue in an isolated modal container.
+
+import * as MedicalEmergency from '../../../src/systems/medicalEmergency.js';
+import * as Modals from '../../../src/ui/modals.js';
+
+export const REQUIRED_MEDICAL_EXPORTS = ['startMedicalEmergency'];
+export const REQUIRED_MODAL_EXPORT    = 'showMashEmergencyModal';
+
+function missingExports() {
+  const medMissing = REQUIRED_MEDICAL_EXPORTS.filter(k => typeof MedicalEmergency[k] !== 'function');
+  const modMissing = typeof Modals[REQUIRED_MODAL_EXPORT] !== 'function' ? [REQUIRED_MODAL_EXPORT] : [];
+  return { medMissing, modMissing };
+}
+
+export function init(mount) {
+  const { medMissing, modMissing } = missingExports();
+  if (medMissing.length || modMissing.length) {
+    mount.innerHTML = `<p style="color:#f66">Mash demo unavailable — missing exports: ${[...medMissing, ...modMissing].join(', ')}</p>`;
+    return () => {};
+  }
+
+  mount.innerHTML = `
+    <div style="margin-top:12px">
+      <button id="mash-demo-start" class="btn-primary" type="button">Start emergency</button>
+      <div id="mash-demo-target" style="margin-top:12px"></div>
+    </div>
+  `;
+
+  const start = () => {
+    const target = document.getElementById('mash-demo-target');
+    target.innerHTML = '';
+    // Seed a minimal state the real system will accept. Adapt fields at implementation
+    // time to whatever medicalEmergency.js actually needs.
+    const seededState = {
+      sol: 5,
+      crew: [{ id: 'c1', name: 'Chen', alive: true, damage: 0 }],
+      log: [],
+    };
+    try {
+      Modals[REQUIRED_MODAL_EXPORT]({
+        state: seededState,
+        container: target,
+        preview: true,                  // prevent applying to global state
+        onResolve: () => {},
+      });
+    } catch (err) {
+      target.innerHTML = `<p style="color:#f66">Demo failed: ${err.message}</p>`;
+    }
+  };
+
+  document.getElementById('mash-demo-start').addEventListener('click', start);
+  return () => {};
+}
+```
+
+**IMPORTANT:** At implementation time, open `src/systems/medicalEmergency.js` and `src/ui/modals.js` and adapt `REQUIRED_*_EXPORT*` and the call shape to the real API. If the real modal has no "preview" mode, wrap it with a local function here that does the DOM rendering directly rather than mutating global state. Update the constants so the smoke test can assert the right expectations.
+
+- [ ] **Step 3: Replace the medical placeholder branch**
+
+In `docs/walkthrough/slides.js`, replace the `medical` branch entry in the hub's `branches` array with:
+
+```js
+      {
+        id: 'medical',
+        label: 'medicalEmergency.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'medicalEmergency.js — the three-act chain',
+            body: `
+              <p>The medical emergency is the project's flagship multi-stage event: <strong>Diagnosis → Treatment → Disposal</strong>. Each stage branches on the player's choice and on crew damage. It's the first real stress-test of the <code>multiStage.js</code> engine.</p>
+              <p>Authored data lives in <code>src/content/medicalEmergency.js</code>. The system module wires stage transitions and computes outcomes (including the "leave the body or haul it" disposal beat).</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/medicalEmergency.js',
+                lines: [1, 40],
+                caption: 'Module overview',
+                code: `// Paste src/systems/medicalEmergency.js lines 1–40 here at implementation time.`,
+              },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'Live: the mash-rescue UI',
+            body: `
+              <p>Click <strong>Start emergency</strong> below to run a seeded mash-rescue against the real modal renderer. The anti-mashing detection fires exactly as it does in the game — mash too fast and the outcome turns bad.</p>
+              <p>This demo imports <code>src/systems/medicalEmergency.js</code> and <code>src/ui/modals.js</code> directly; no mock reimplementation.</p>
+              <div id="demo-mashEmergency-mount"></div>
+            `,
+            demo: 'mashEmergency',
+          },
+        ],
+      },
+```
+
+**IMPORTANT:** Update the snippet `code:` to real file contents at implementation time.
+
+- [ ] **Step 4: Manually verify**
+
+Navigate to hub → branch 4 (medical) → second sub-slide ("Live: the mash-rescue UI").
+Expected:
+- "Start emergency" button renders. Clicking it mounts the real mash-rescue modal.
+- Mashing the button fires the anti-mash penalty per the live game behavior.
+- Switching themes repaints the demo.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/walkthrough/demos/mashEmergency.js docs/walkthrough/slides.js
+git commit -m "Code tour: medical branch content + real-module mash demo (refs #65)"
+```
+
+---
+
+## Task 13: Remaining branch content — clickMetrics, awayTeam, small systems, scoring
+
+**Files:**
+- Modify: `docs/walkthrough/slides.js`
+
+- [ ] **Step 1: Read source before authoring**
+
+Run:
+```bash
+head -40 src/systems/clickMetrics.js
+head -40 src/systems/awayTeam.js
+head -20 src/content/awayTeamChains.js
+head -30 src/systems/crew.js
+head -30 src/systems/corpse.js
+head -30 src/systems/waypoints.js
+head -30 src/systems/career.js
+head -30 src/systems/scoring.js
+```
+
+- [ ] **Step 2: Replace the remaining placeholder branches**
+
+Replace the `clickmetrics`, `awayteam`, `smallsys`, and `scoring` entries in the hub `branches` array with:
+
+```js
+      {
+        id: 'clickmetrics',
+        label: 'clickMetrics.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'clickMetrics.js — anti-mash detection',
+            body: `
+              <p>Every click through an event modal is timed and pattern-analyzed. Three signals drive the "you're not reading" flag: response time, always-first-option patterns, and near-zero variance. Above a threshold, the game rolls an anti-mash catastrophic emergency.</p>
+              <p>The module is small and intentionally standalone so its thresholds can be tuned in one place.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/clickMetrics.js', lines: [1, 40], caption: 'Detection helpers',
+                code: `// Paste src/systems/clickMetrics.js lines 1–40 here at implementation time.` },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'awayteam',
+        label: 'awayTeam.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'awayTeam.js — divert and camp',
+            body: `
+              <p>Waypoint diverts dispatch an "away team" of 1–3 crew. The rover camps (does not advance km) while authored chains in <code>src/content/awayTeamChains.js</code> fire stage-per-sol. The reunion modal handles survivors, injuries, and body recovery.</p>
+              <p>Built on the same <code>multiStage.js</code> engine as medical emergencies.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/awayTeam.js', lines: [1, 40], caption: 'Lifecycle entry',
+                code: `// Paste src/systems/awayTeam.js lines 1–40 here at implementation time.` },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'Authored chains',
+            body: `
+              <p>Per-waypoint chains live in <code>src/content/awayTeamChains.js</code>, keyed by waypoint id. Each is a small state machine: stages with choices, some choices mutating <code>returnSolDelta</code> to extend or shorten the camp.</p>
+            `,
+            snippets: [
+              { path: 'src/content/awayTeamChains.js', lines: [1, 40], caption: 'Chain shape',
+                code: `// Paste src/content/awayTeamChains.js lines 1–40 here at implementation time.` },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'smallsys',
+        label: 'crew / corpse / waypoints',
+        sub: [
+          {
+            id: 's1',
+            title: 'Small systems grouped',
+            body: `
+              <p>Three small modules that share state:</p>
+              <ul>
+                <li><code>crew.js</code> — damage, status, death bookkeeping.</li>
+                <li><code>corpse.js</code> — dead-but-present crew; feeds extra weight into cargo.</li>
+                <li><code>waypoints.js</code> — rolling optional diverts along the route.</li>
+              </ul>
+              <p>None of them own much state by themselves; they're coordinators between <code>state.js</code> and the higher-level systems.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/crew.js',      lines: [1, 20], caption: 'crew.js entry',
+                code: `// Paste src/systems/crew.js lines 1–20 here at implementation time.` },
+              { path: 'src/systems/corpse.js',    lines: [1, 20], caption: 'corpse.js entry',
+                code: `// Paste src/systems/corpse.js lines 1–20 here at implementation time.` },
+              { path: 'src/systems/waypoints.js', lines: [1, 20], caption: 'waypoints.js entry',
+                code: `// Paste src/systems/waypoints.js lines 1–20 here at implementation time.` },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'scoring',
+        label: 'career.js + scoring.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'End-of-run scoring',
+            body: `
+              <p>When a run ends, <code>scoring.js</code> computes a score from science collected, sols survived, crew outcome, and modifiers. <code>career.js</code> persists science across runs for the long-term meta-progression.</p>
+              <p>Both modules are pure — they take state in, return numbers out. Easy to unit-test under <code>sim/</code>.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/scoring.js', lines: [1, 30], caption: 'scoring.js entry',
+                code: `// Paste src/systems/scoring.js lines 1–30 here at implementation time.` },
+              { path: 'src/systems/career.js',  lines: [1, 30], caption: 'career.js entry',
+                code: `// Paste src/systems/career.js lines 1–30 here at implementation time.` },
+            ],
+          },
+        ],
+      },
+```
+
+**IMPORTANT:** Replace each snippet's `code:` with the actual file contents and adjust `lines:` to match.
+
+- [ ] **Step 3: Manually verify**
+
+Walk through all four updated branches from the hub.
+Expected: readable content, snippets expand and show real code, breadcrumbs accurate.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/walkthrough/slides.js
+git commit -m "Code tour: clickMetrics/awayTeam/small-systems/scoring branch content (refs #65)"
+```
+
+---
+
+## Task 14: Post-hub spine content — slides 10–16
+
+**Files:**
+- Modify: `docs/walkthrough/slides.js`
+
+- [ ] **Step 1: Append the final seven spine slides**
+
+Append to the end of the `spine` array (after the `hub` entry):
+
+```js
+  {
+    id: 'content-vs-systems',
+    title: 'Content vs. systems',
+    body: `
+      <p>Across the branches you just walked, one pattern repeats: <strong>logic in <code>src/systems/</code>, data in <code>src/content/</code></strong>. A system module knows <em>how</em>; a content module knows <em>what</em>.</p>
+      <p>This split is why adding a new event, emergency, fact, or waypoint is usually a one-file change in <code>content/</code>. The systems stay stable; the world grows.</p>
+    `,
+  },
+  {
+    id: 'ui',
+    title: 'UI layer',
+    body: `
+      <p><code>src/ui/modals.js</code> renders event cards, multi-stage dialogs, mash-rescue, codex pages, and so on. It is DOM-heavy but state-light — every modal receives the game state and a dispatch function, and returns nothing. All flow lives in <code>main.js</code>.</p>
+      <p><code>src/ui/codex.js</code> handles the in-game encyclopedia of Mars facts that players unlock by playing.</p>
+    `,
+    snippets: [
+      { path: 'src/ui/modals.js', lines: [1, 30], caption: 'Modal registry / entry',
+        code: `// Paste src/ui/modals.js lines 1–30 here at implementation time.` },
+    ],
+  },
+  {
+    id: 'theme',
+    title: 'Theme system',
+    body: `
+      <p>Three themes (plus Mission Control default): LCARS, Voltron HUD, Last Starfighter. Each is a stylesheet under <code>styles/theme-*.css</code> that overrides a shared set of CSS variables defined in <code>styles/theme.css</code>. <code>src/theme.js</code> is a 68-line switcher that sets <code>data-theme</code> on <code>&lt;body&gt;</code> and remembers the last choice in localStorage.</p>
+      <p><strong>Live proof:</strong> this slideshow reuses those exact stylesheets. Change the theme dropdown in the top-right right now — every frame, chrome, and demo repaints instantly.</p>
+    `,
+    snippets: [
+      { path: 'src/theme.js', lines: [1, 40], caption: 'Switcher core',
+        code: `// Paste src/theme.js lines 1–40 here at implementation time.` },
+    ],
+  },
+  {
+    id: 'audio',
+    title: 'Audio',
+    body: `
+      <p><code>src/audio.js</code> is a minimal music player: a shuffled playlist, a mute toggle, a manual track dropdown. It never auto-plays — users have to click first, per browser policy. The module exposes four functions and holds one <code>Audio</code> object; that's the entire surface.</p>
+    `,
+    snippets: [
+      { path: 'src/audio.js', lines: [1, 30], caption: 'Player entry',
+        code: `// Paste src/audio.js lines 1–30 here at implementation time.` },
+    ],
+  },
+  {
+    id: 'tests',
+    title: 'Testing',
+    body: `
+      <p>Two kinds of test code:</p>
+      <ul>
+        <li><strong>Unit tests</strong> — <code>sim/*.test.mjs</code>, each uses <code>node --test</code>. Exercise pure functions from <code>src/systems/</code> and <code>src/theme.js</code>. Run one file: <code>node --test sim/theme.test.mjs</code>.</li>
+        <li><strong>Playtest harness</strong> — <code>sim/play.mjs</code> and <code>sim/playtest1000.mjs</code>. Runs thousands of AI-driven playthroughs with various strategies, prints a balance table. This catches difficulty regressions that unit tests can't.</li>
+      </ul>
+      <p>Both paths depend on keeping system modules pure (no DOM imports in <code>src/systems/</code>).</p>
+    `,
+  },
+  {
+    id: 'workflow',
+    title: 'Workflow',
+    body: `
+      <p>Every change follows the same trail:</p>
+      <ol>
+        <li><strong>GitHub issue</strong> — describes problem + acceptance criteria.</li>
+        <li><strong>Spec</strong> — <code>docs/superpowers/specs/YYYY-MM-DD-&lt;topic&gt;-design.md</code>.</li>
+        <li><strong>Plan</strong> — <code>docs/superpowers/plans/YYYY-MM-DD-&lt;topic&gt;.md</code> (this tour is one).</li>
+        <li><strong>Implementation</strong> — small commits, each referencing the issue.</li>
+        <li><strong>Release</strong> — SemVer git tag + GitHub release.</li>
+      </ol>
+      <p>The <code>docs/superpowers/</code> directory is the repository of all past specs and plans, and is a great read in its own right.</p>
+    `,
+  },
+  {
+    id: 'credits',
+    title: 'End of tour',
+    body: `
+      <p>Thanks for walking through. Suggested next steps:</p>
+      <ul>
+        <li>Play a run — <code>index.html</code> in the repo root.</li>
+        <li>Skim the most recent spec in <code>docs/superpowers/specs/</code> to see the current frontier.</li>
+        <li>Pick any system that caught your eye and read its test file under <code>sim/</code>.</li>
+      </ul>
+      <p>Press <strong>Home</strong> to return to the start of the tour, or close the tab.</p>
+    `,
+  },
+```
+
+**IMPORTANT:** Replace each snippet's `code:` with actual file contents and adjust `lines:` to match.
+
+- [ ] **Step 2: Manually verify**
+
+Walk the spine end-to-end.
+Expected:
+- 16 total spine slides. Progress counter reads "SPINE N / 16".
+- All post-hub slides render cleanly.
+- Theme slide's callout still matches live behavior.
+- Home key returns to slide 1; End key jumps to slide 16.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/walkthrough/slides.js
+git commit -m "Code tour: post-hub spine slides — content, UI, theme, audio, tests, workflow, credits (refs #65)"
+```
+
+---
+
+## Task 15: Smoke test + README link
+
+**Files:**
+- Create: `sim/walkthroughSmoke.test.mjs`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write the smoke test**
+
+Create `sim/walkthroughSmoke.test.mjs`:
+
+```js
+// Smoke test for the code-tour demos.
+// Asserts each demo module imports cleanly under Node and exposes the expected surface.
+// Does NOT exercise DOM behavior — only catches import-path drift and top-level export rot.
+//
+// Run: node --test sim/walkthroughSmoke.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Install a minimal DOM shim for modules that touch document at import time.
+// If a demo imports src/ui/modals.js and that file touches document at module top,
+// this prevents a ReferenceError. Adapt the shim if a demo needs more.
+if (typeof globalThis.document === 'undefined') {
+  globalThis.document = {
+    createElement: () => ({ style: {}, appendChild() {}, addEventListener() {}, setAttribute() {}, removeAttribute() {}, querySelectorAll: () => [], classList: { add() {}, remove() {}, toggle() {} } }),
+    getElementById: () => null,
+    addEventListener: () => {},
+    querySelectorAll: () => [],
+    body: { setAttribute() {}, removeAttribute() {}, appendChild() {} },
+  };
+}
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = { location: { hash: '' }, history: { pushState() {} }, addEventListener() {} };
+}
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = { getItem: () => null, setItem() {} };
+}
+
+test('loop demo module imports and exposes init()', async () => {
+  const mod = await import('../docs/walkthrough/demos/loop.js');
+  assert.equal(typeof mod.init, 'function');
+});
+
+test('eventPreview demo module imports, exposes init() and its documented export constant', async () => {
+  const mod = await import('../docs/walkthrough/demos/eventPreview.js');
+  assert.equal(typeof mod.init, 'function');
+  assert.equal(typeof mod.REQUIRED_MODAL_EXPORT, 'string');
+  assert.ok(mod.REQUIRED_MODAL_EXPORT.length > 0);
+});
+
+test('mashEmergency demo module imports, exposes init() and its documented export constants', async () => {
+  const mod = await import('../docs/walkthrough/demos/mashEmergency.js');
+  assert.equal(typeof mod.init, 'function');
+  assert.ok(Array.isArray(mod.REQUIRED_MEDICAL_EXPORTS));
+  assert.ok(mod.REQUIRED_MEDICAL_EXPORTS.every(k => typeof k === 'string' && k.length > 0));
+  assert.equal(typeof mod.REQUIRED_MODAL_EXPORT, 'string');
+});
+
+test('eventPreview declared modal export exists on src/ui/modals.js', async () => {
+  const demo = await import('../docs/walkthrough/demos/eventPreview.js');
+  const modals = await import('../src/ui/modals.js');
+  assert.equal(
+    typeof modals[demo.REQUIRED_MODAL_EXPORT],
+    'function',
+    `src/ui/modals.js must export ${demo.REQUIRED_MODAL_EXPORT}; update either the source or demos/eventPreview.js.`
+  );
+});
+
+test('mashEmergency declared exports exist on their source modules', async () => {
+  const demo = await import('../docs/walkthrough/demos/mashEmergency.js');
+  const med = await import('../src/systems/medicalEmergency.js');
+  for (const k of demo.REQUIRED_MEDICAL_EXPORTS) {
+    assert.equal(typeof med[k], 'function',
+      `src/systems/medicalEmergency.js must export ${k}; update either source or demos/mashEmergency.js.`);
+  }
+  const modals = await import('../src/ui/modals.js');
+  assert.equal(
+    typeof modals[demo.REQUIRED_MODAL_EXPORT],
+    'function',
+    `src/ui/modals.js must export ${demo.REQUIRED_MODAL_EXPORT}.`
+  );
+});
+```
+
+- [ ] **Step 2: Run the smoke test**
+
+Run: `node --test sim/walkthroughSmoke.test.mjs`
+Expected: PASS. If an import fails, adjust the DOM shim or the `REQUIRED_*` constants in the demo files until the test passes. The shim should be kept minimal — don't add methods just to silence an error; understand why the real code needs them first.
+
+- [ ] **Step 3: Add README link**
+
+Open `README.md` and add one line near the top of the project description (below the title / first paragraph):
+
+```markdown
+**New to this repo?** Open [`docs/walkthrough/index.html`](docs/walkthrough/index.html) for an interactive code tour.
+```
+
+Adapt phrasing / placement to the existing README style.
+
+- [ ] **Step 4: Full-spine manual smoke**
+
+Open the tour in a browser. Quickly:
+- Click through the full spine (← → all the way, both directions)
+- Open every hub branch, reach the last sub-slide, confirm NEXT returns to hub
+- Confirm all three real demos load and accept interaction
+- Switch each of the four themes; confirm chrome + demos repaint
+- Deep-link directly to `index.html#slide-8`, `#branch-medical-1` — both should open straight to that spot
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sim/walkthroughSmoke.test.mjs README.md
+git commit -m "Code tour: smoke test for demo imports + README link (closes #65)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Standalone `docs/walkthrough/index.html`, no build step — Task 1.
+- Linear spine of 16 slides — Tasks 6, 7, 14.
+- Hub slide (slide 9) with 8 branches — Tasks 9, 10, 12, 13.
+- Four live demos (three real + always-on theme toggle) — Tasks 4 (theme), 8 (loop), 11 (event preview), 12 (mash).
+- Expandable code snippets with filename+line labels and "View on GitHub" — Task 5.
+- Keyboard nav (← → Esc Home End digits) — Tasks 3, 9.
+- Theme toggle using `src/theme.js` + four themes (mc/lcars/voltron/starfighter) — Task 4.
+- Progress indicator on spine + breadcrumb in branches — Tasks 3, 9.
+- Hash-based deep-linking with browser back/forward — Task 3.
+- Session-only theme (no localStorage read) — Task 4.
+- `sim/walkthroughSmoke.test.mjs` asserting import-path health — Task 15.
+- README link — Task 15.
+
+**Placeholder scan:** Every content-bearing task has `IMPORTANT:` notes where real file contents must be inlined and line ranges updated. That's not a placeholder — it's the acknowledged authoring step for content slides, called out loudly each time. No TBDs, TODOs, or "implement later" left in the plan.
+
+**Type consistency:** `parseHash`, `hashFor`, `routeForward`, `routeBack`, `routeToSlide` are named the same in the test, in `router.js`, and in `tour.js`. The demo registry uses `loop` / `eventPreview` / `mashEmergency` consistently in `tour.js`, in each demo file, in the mount-id convention (`demo-<key>-mount`), and in the smoke test. `REQUIRED_MODAL_EXPORT` / `REQUIRED_MEDICAL_EXPORTS` are constants in the demo files and asserted by the same names in the smoke test.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-code-tour-slideshow.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-21-code-tour-glossary-design.md
+++ b/docs/superpowers/specs/2026-04-21-code-tour-glossary-design.md
@@ -1,0 +1,141 @@
+# Code-Tour Glossary — Design
+
+**Date:** 2026-04-21
+**Status:** Draft — pending user review
+**Related issue:** #67
+**Parent feature:** #65 (code-tour slideshow, PR #66 — not yet merged)
+
+## Problem
+
+The code tour's prose targets programmer-literate readers, but terms like *ES modules*, *pure function*, *single source of truth*, *dispatch*, *factory function*, *CSS variables*, *heuristic*, and *multi-stage event* assume familiarity that entry-level devs don't have. Breaking to Google every third paragraph kills the tour's pacing.
+
+## Goal
+
+Let a reader click any marked term in a slide and see a 1–3-sentence, plain-language definition inline, without navigating away. Multiple definitions can stay open. The feature should feel native to the tour — theme-aware, touch-friendly, keyboard-accessible.
+
+## Scope
+
+**In:**
+
+- New `docs/walkthrough/glossary.js` — trusted in-repo definitions file.
+- ~20 curated term definitions covering the tour's current prose.
+- Markup of terms in existing slide bodies (`<span class="term" data-term="slug">display</span>`).
+- `wireGlossaryTerms(stage)` helper in `tour.js`, invoked from `render()` alongside the existing wire helpers.
+- `.term` / `.term-def` styling in `tour.css` using `currentColor` and existing CSS vars — repaints under all four themes.
+- Accessibility: `.term` is a real `<button>` with `aria-expanded` + `aria-controls`; keyboard Enter/Space toggles.
+- Smoke-test extension asserting `GLOSSARY` imports and entries have non-empty `term` + `def` strings.
+
+**Out:**
+
+- Hover tooltips (click only — touch-friendly).
+- Cross-linking definitions to each other.
+- A standalone glossary index page.
+- Auto-scanning prose to flag undefined terms.
+- Editing tool UI.
+
+## Architecture
+
+**New files:**
+
+- `docs/walkthrough/glossary.js` — exports `const GLOSSARY` object keyed by kebab-case slug:
+  ```js
+  export const GLOSSARY = {
+    'es-modules': {
+      term: 'ES modules',
+      def: '<p>…plain-language definition as trusted HTML…</p>',
+    },
+    // ...
+  };
+  ```
+
+**Modified files:**
+
+- `docs/walkthrough/tour.js` — import `GLOSSARY`; add `wireGlossaryTerms(stage)`; call it from `render()`.
+- `docs/walkthrough/tour.css` — append `.term` / `.term-def` styles.
+- `docs/walkthrough/slides.js` — mark up ~20 term occurrences inline with `<span class="term" data-term="…">…</span>`.
+- `sim/walkthroughSmoke.test.mjs` — add a `glossary` test block asserting each entry has non-empty `term` + `def`.
+
+**Untouched:** game source, other game stylesheets, the slide *structure* (spine / hub / branches).
+
+## Interaction
+
+- Rendered term: `<button type="button" class="term" data-term="<slug>" aria-expanded="false" aria-controls="term-def-<slug>-<n>">display text</button>`. `<n>` is a per-render counter to allow multiple instances.
+- On click:
+  - Look up `GLOSSARY[slug]`. If missing → `console.warn('Unknown term:', slug)` and return.
+  - If a sibling `.term-def` with matching id already exists, remove it, set `aria-expanded="false"`.
+  - Else, insert a `<div class="term-def" id="term-def-<slug>-<n>" role="region">…def HTML…</div>` immediately after the button, set `aria-expanded="true"`.
+- Keyboard: button type gives Enter/Space for free.
+- Render lifecycle: slides re-render on navigation; all term state is tied to DOM, so closed on navigate — that's desired (each slide starts clean).
+
+## Styling
+
+```css
+.term {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: currentColor;
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+.term:hover, .term:focus-visible { opacity: 0.75; outline: none; }
+.term[aria-expanded="true"] { font-weight: 600; }
+
+.term-def {
+  margin: 6px 0 10px 14px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--panel-border, currentColor);
+  opacity: 0.9;
+  font-size: 0.95em;
+}
+.term-def p:first-child { margin-top: 0; }
+.term-def p:last-child  { margin-bottom: 0; }
+```
+
+## Trust boundary
+
+`GLOSSARY[*].def` is trusted HTML, interpolated via `innerHTML` — identical boundary to slide bodies. Document this at the top of `glossary.js` and in the `wireGlossaryTerms` JSDoc.
+
+## Initial term set
+
+Seeded from what appears in the current tour prose. Slugs below; definitions written at implementation time:
+
+| Slug | Term |
+|---|---|
+| `es-modules` | ES modules |
+| `dom` | DOM |
+| `pure-function` | pure function |
+| `single-source-of-truth` | single source of truth |
+| `virtual-dom` | virtual DOM |
+| `reactive-framework` | reactive framework |
+| `css-variable` | CSS variable |
+| `hash-routing` | hash-based routing |
+| `factory-function` | factory function |
+| `dispatch` | dispatch |
+| `local-storage` | localStorage |
+| `dynamic-import` | dynamic import |
+| `try-finally` | try/finally |
+| `heuristic` | heuristic |
+| `multi-stage-event` | multi-stage event |
+| `sol` | sol |
+| `eva` | EVA |
+| `lmst` | LMST |
+| `waypoint` | waypoint |
+| `anti-mashing` | anti-mashing |
+
+Authoring rule: each definition is 1–3 sentences. First sentence is the concept; second (optional) is how this project uses it; third (optional) is an analogy or pointer.
+
+## Testing
+
+- `sim/walkthroughSmoke.test.mjs` — add a test that imports `GLOSSARY` and asserts: (a) non-empty object, (b) every entry has a non-empty `term` string and non-empty `def` string, (c) every slug is kebab-case (lowercase + digits + hyphens).
+- Manual: click terms across slides under each theme, confirm definitions repaint; confirm keyboard Enter/Space; confirm second click closes; confirm multiple open simultaneously; confirm an unknown `data-term` logs a warning without crashing.
+
+## Workflow
+
+Ships as additional commits on `feature/code-tour`, referencing #67 in commit messages. PR #66 accrues the additional scope before merge.
+
+## Open questions
+
+None blocking. If the term list grows beyond ~25, consider splitting `glossary.js` into per-category files — not needed at the initial scope.

--- a/docs/superpowers/specs/2026-04-21-code-tour-slideshow-design.md
+++ b/docs/superpowers/specs/2026-04-21-code-tour-slideshow-design.md
@@ -1,0 +1,204 @@
+# Code Tour Slideshow — Design
+
+**Date:** 2026-04-21
+**Status:** Draft — pending user review
+**Related issue:** #65
+
+## Problem
+
+The Mars Trail codebase is ~5,700 lines of vanilla ES modules across `src/systems/`, `src/content/`, `src/ui/`, plus a `sim/` test harness and a themed UI. The structure is deliberate and well-bounded, but there is no guided entry point: anyone stepping in (including the author after a gap) has to read files cold and reconstruct the architecture by inference. `docs/superpowers/specs/*` capture per-feature intent but don't give a bird's-eye view of how the pieces fit together.
+
+## Goal
+
+Ship a standalone, interactive, theme-toggleable HTML slideshow at `docs/walkthrough/index.html` that walks a programmer-literate reader through how this codebase is set up — from entry point to systems to content to tests to release workflow — in roughly 15 minutes, with the option to drill into any single system, expand code, or run small live demos that exercise the real modules.
+
+Success criteria:
+
+1. A reader with general JS/web knowledge but no prior exposure to Mars Trail can open the file, navigate end-to-end, and correctly answer "where would I look to change X?" for the major subsystems.
+2. The slideshow repaints correctly under all four existing themes (Mission Control / LCARS / Voltron / Starfighter) using the game's own stylesheets, and doubles as a live demo of the theme system.
+3. At least three live demos import and exercise real game modules (no mock reimplementations), proving behavior as documented.
+
+## Scope
+
+**In:**
+
+- Standalone HTML at `docs/walkthrough/index.html` — open directly in a browser, no build step, no server required (ES modules load via relative paths from the doc's location).
+- Linear spine of ~16 slides plus one hub slide with ~8 branch slides.
+- Three live demos (game-loop animation, click-mash medical emergency, event-card preview) plus the always-on theme-toggle demo.
+- Expandable inline code snippets on relevant slides, each with a filename + line range label and a "View on GitHub" link.
+- Keyboard navigation (← → arrows, Esc to exit hub branch, number keys for hub tile shortcuts).
+- Theme dropdown in the slideshow chrome that repaints the page by swapping a `data-theme` attribute, mirroring the game's own approach.
+- Progress indicator (slide N of M on the spine; breadcrumbs inside hub branches).
+- README link pointing readers to the tour.
+
+**Out (deferred):**
+
+- Narration audio / video.
+- Quiz or checkpoint interactions.
+- Search-across-slides.
+- Speaker-notes / presentation mode for projection.
+- Auto-advance / slide timers.
+- Print / PDF export.
+- Any change to the game itself beyond a one-line README link.
+- Hosting on GitHub Pages (the file works locally; pages is a future option, not a requirement).
+
+## Architecture
+
+**New files:**
+
+- `docs/walkthrough/index.html` — entry point. Loads the game's existing stylesheets (`theme.css`, `layout.css`, `components.css`, `modals.css`, `theme-lcars.css`, `theme-voltron.css`, `theme-starfighter.css` — via relative paths into `../../styles/`), a slideshow-specific stylesheet, and the slideshow ES module.
+- `docs/walkthrough/tour.css` — layout and chrome styles (slide container, nav bar, progress, hub tiles, code-block frame). Uses the same CSS variables the game theme files set, so theme-swapping Just Works.
+- `docs/walkthrough/tour.js` — slideshow engine: slide registry, routing (hash-based: `#slide-5`, `#branch-events-1`), keyboard nav, code-snippet expand/collapse.
+- `docs/walkthrough/slides.js` — slide content manifest. An ordered array of slide descriptors (id, title, body HTML, optional code snippets, optional demo id). The hub slide carries a `branches` array; each branch is itself an ordered list of sub-slides.
+- `docs/walkthrough/demos/loop.js` — game-loop animation demo (scrubbable sol counter that pulses through the phases).
+- `docs/walkthrough/demos/mashEmergency.js` — wraps the click-mash medical emergency UI using real `src/ui/modals.js` + `src/systems/medicalEmergency.js` imports.
+- `docs/walkthrough/demos/eventPreview.js` — picks a random event from `src/content/events.js` and renders its card via the real modal renderer.
+
+**Modified files:**
+
+- `README.md` — add a one-line "Code tour: open `docs/walkthrough/index.html` in a browser" link near the top of the project section.
+
+**Untouched:** every file under `src/`, `styles/`, `sim/`, `assets/`, and the game's `index.html`. The slideshow consumes the game code; it does not require any edit to it.
+
+## Visual style & theming
+
+The slideshow reuses the game's existing stylesheets (`styles/theme.css` base + `theme-lcars.css` / `theme-voltron.css` / `theme-starfighter.css` overlays, plus `layout.css`, `components.css`, `modals.css`). A theme selector in the slideshow chrome imports the `THEMES` list and `resolveTheme` helper from `src/theme.js`, setting `data-theme` on `<body>` (or removing the attribute for `mc`), identical to how `src/theme.js` does it.
+
+`tour.css` only defines layout primitives — slide frame, nav bar, code-block wrapper, hub tile grid, progress bar. Colors, borders, typography, and decorative elements all come from the game theme CSS via CSS custom properties. This means:
+
+- Adding a new theme to the game automatically offers it in the slideshow's dropdown (the dropdown enumerates the same `THEMES` list the game uses).
+- The slideshow's visual polish is proportional to the game's.
+
+Default theme on load: `mc` (Mission Control), matching the game's default. The slideshow does **not** read the game's `localStorage` key (`marsTrail.theme`) — tour theme is a session-only choice to avoid surprise state bleed between the game and the tour.
+
+## Slide spine
+
+One linear path, indexed 1–16. Slide 9 is the hub.
+
+| # | Title | Notes |
+|---|---|---|
+| 1 | Welcome | Title, one-paragraph hook, "Press → to begin." |
+| 2 | What is Mars Trail? | Screenshot + one-paragraph pitch. |
+| 3 | Tech stack | "Vanilla ES modules, no build step, no framework — and why." |
+| 4 | Repo layout | Annotated directory tree; top-level folders each get one sentence. |
+| 5 | The game loop | Diagram + **live demo**: animated sol cycle (input → systems → render → log). |
+| 6 | Entry point | `index.html` + `src/main.js` with a code snippet of the boot sequence. |
+| 7 | State | `src/state.js` as the single source of truth; shape overview. |
+| 8 | Render | `src/render.js` as unidirectional `state → DOM`. |
+| 9 | **HUB · Systems architecture** | Tile grid; each tile is a clickable branch. See below. |
+| 10 | Content vs systems | Why data lives in `src/content/`; contrast with logic in `src/systems/`. |
+| 11 | UI layer | `src/ui/modals.js`, `src/ui/codex.js` — how modals and overlays work. |
+| 12 | Theme system | `src/theme.js` + `styles/theme-*.css`; **live demo:** the slideshow itself repaints when you change the dropdown. |
+| 13 | Audio | `src/audio.js` — music shuffle, mute, track select. |
+| 14 | Testing | `sim/*.test.mjs`, `sim/playtest1000.mjs`, how unit tests + playtests differ. |
+| 15 | Workflow | Issue → spec → plan → implement → tag. Reference `docs/superpowers/`. |
+| 16 | Credits / further reading | Links to specs, plans, the repo. "End of tour." |
+
+## Hub branches (slide 9)
+
+Eight tiles, each opens a mini-tour that returns to the hub. Each branch has 1–2 sub-slides unless noted.
+
+1. **travel.js** — pace, tick, arrival (2 slides).
+2. **events.js + content/events.js** — roll, select, apply (2 slides).
+3. **multiStage.js + emergencies / multiStageEvents** — stage chains.
+4. **medicalEmergency.js** — **live demo:** the click-mash rescue UI (2 slides).
+5. **clickMetrics.js** — anti-mash detection.
+6. **awayTeam.js + content/awayTeamChains.js** — waypoint divert flow (2 slides).
+7. **crew.js / corpse.js / waypoints.js** — small systems grouped together.
+8. **career.js / scoring.js** — end-of-run scoring, persistent SCI.
+
+Branch sub-slides get an "Back to hub" button and breadcrumb (`HUB › travel.js › 2 of 2`). Pressing Esc returns to the hub. `→` at the last branch sub-slide also returns to the hub.
+
+## Live demos
+
+Four demos total. Three are opt-in (click a button on the relevant slide); the theme toggle is always on.
+
+1. **Game-loop animation** (slide 5). An SVG/CSS animation of one sol's phases. No real-module import needed; this is explanatory, not a behavior proof. Runs in a loop until you leave the slide.
+2. **Click-mash medical emergency** (hub branch 4). Imports `src/systems/medicalEmergency.js` and `src/ui/modals.js` directly, calls the real "show modal" path with a minimal seeded state, and lets the reader actually mash the button and see the anti-mashing penalty fire. Reusing the modal DOM container the slideshow provides.
+3. **Event-card preview** (hub branch 2). Imports `src/content/events.js` and the modal renderer, picks a random non-multi-stage event, and renders its card. Each click re-rolls.
+4. **Theme toggle** (always-on; slide 12 explicitly highlights it). The dropdown in the slideshow chrome flips `data-theme`; every piece of chrome and every demo repaints.
+
+### Live-demo coupling (decision B1)
+
+Demos import real modules. This is a deliberate trade-off:
+
+- **Benefit:** demos stay honest. If behavior changes, the slideshow shows the new behavior.
+- **Cost:** refactors that change a module's *exports* (rename a function, change a signature) will break the slideshow.
+- **Mitigation:** (a) demos are isolated in `docs/walkthrough/demos/*.js` so breakage is obvious and scoped; (b) each demo file begins with a one-line comment listing the imports it depends on, so a future refactor can grep for dependents; (c) a smoke-test script (`sim/walkthroughSmoke.test.mjs`) loads each demo module under Node with a DOM shim and asserts the imports resolve and top-level exports exist. This won't catch visual breakage, but it catches import-path rot — the most likely failure mode.
+
+## Interactivity / UX
+
+- **Keyboard:** `←` / `→` for prev/next. `Home` / `End` jump to first/last slide on the spine. `Esc` returns to hub when inside a branch; no-op on the spine. Digit keys `1`–`8` on the hub slide open that branch.
+- **Click:** prev / next buttons in the bottom chrome. Hub tiles are clickable. Code blocks have an "Expand" toggle (default collapsed). "View on GitHub" opens `https://github.com/<owner>/<repo>/blob/main/<path>#L<start>-L<end>` in a new tab; `package.json` does not declare a `repository` field, so owner/repo live in a single constant at the top of `tour.js`.
+- **Progress indicator:** bottom-left chrome shows `Spine 7 / 16` on the spine, `Hub › travel.js › 2 / 2` inside a branch.
+- **Deep-linking:** URL hash tracks location (`#slide-5`, `#branch-events-1`). Back/forward browser buttons work.
+- **No persistence:** refreshing loads slide 1 unless a hash is present. No local storage, no cookies.
+
+## Slide data shape
+
+```js
+// docs/walkthrough/slides.js
+export const spine = [
+  {
+    id: 'welcome',
+    title: 'Welcome to the Mars Trail code tour',
+    body: '...HTML string...',
+  },
+  // ...
+  {
+    id: 'loop',
+    title: 'The game loop',
+    body: '...',
+    demo: 'loop',                    // key into demos registry
+  },
+  {
+    id: 'hub',
+    title: 'Systems architecture',
+    branches: [
+      {
+        id: 'travel',
+        label: 'travel.js',
+        sub: [ /* each sub-slide uses the same shape as a spine slide:
+                 id, title, body, and optional snippets / demo */ ],
+      },
+      // ...
+    ],
+  },
+  // ...
+];
+
+// A slide's optional snippets (applies to spine slides and branch sub-slides)
+snippets: [
+  {
+    path: 'src/main.js',
+    lines: [1, 40],
+    caption: 'Boot sequence',
+    code: '...extracted at build time? no — inlined here manually...',
+  },
+]
+```
+
+Code in snippets is **inlined as string literals**, authored by hand when writing each slide. Rationale: no build step, and the curated subset (10–30 lines) beats a raw import dump. Snippets reference exact line numbers so the "View on GitHub" link stays precise; if the code changes, the slide content is updated in the same PR as the code change.
+
+## Testing
+
+- **Unit smoke test:** `sim/walkthroughSmoke.test.mjs` — imports each demo module under a JSDOM shim, asserts top-level exports resolve and demo init functions don't throw. Catches import-path rot.
+- **Manual checklist** (documented in the slideshow spec itself, not automated): open the file under each theme; click through the spine; click each hub tile; run each live demo; confirm deep-linking via hash; confirm keyboard nav works on the spine and in a branch.
+- **No visual-regression suite.** Not worth building for a doc artifact.
+
+## Workflow notes
+
+- A GitHub issue must be opened before implementation begins (per project convention). This spec and its accompanying plan will reference that issue.
+- Ships as a patch release (no game behavior change): likely `v0.9.3` if no other features land first. The tag summary calls out the new tour.
+
+## Open questions
+
+None blocking. Worth noting during implementation:
+
+- **Branch count** — eight hub tiles is the current plan; if any single branch balloons past 3 sub-slides, split the system off into its own hub tile rather than growing the branch.
+
+## Risks
+
+- **Import-path drift (B1 coupling).** Mitigated by the smoke test and by isolating demos in their own folder. Acceptable for the payoff in demo honesty.
+- **Theme CSS coupling.** The slideshow relies on CSS variables defined by the game's theme files. If those variables are renamed, the slideshow's chrome may lose polish. Low-frequency risk; easy to fix when spotted.
+- **Slide rot.** Content slides with specific file/line references will drift as code changes. Mitigation: expectation set in this spec that PRs touching `src/**` check whether a slide's snippet or description needs updating. No tooling enforcement for now; worth a future "link-checker" if this becomes a problem.

--- a/docs/walkthrough/demos/eventPreview.js
+++ b/docs/walkthrough/demos/eventPreview.js
@@ -1,0 +1,96 @@
+// Real-module demo: imports the game's event content and modal renderer
+// to render a random event card as a read-only preview.
+//
+// NOTE: imports below must stay in sync with src/content/events.js and
+// src/ui/modals.js. If those files move or rename exports, update here
+// and the Task 15 smoke test (which asserts on REQUIRED_MODAL_EXPORT)
+// will flag the break.
+//
+// Approach: (b) from the plan. showEventModal targets the document-level
+// #modal-root via getElementById. We temporarily rename the walkthrough
+// page's real #modal-root, give our scoped card container that id, let
+// the real renderer paint into it, then restore. onChoose is wired to a
+// no-op that shows a "read-only preview" note — no state is mutated.
+
+import { EVENTS } from '../../../src/content/events.js';
+import { showEventModal } from '../../../src/ui/modals.js';
+
+// Name of the modals export this demo depends on. The Task 15 smoke test
+// should assert this export still exists in src/ui/modals.js.
+export const REQUIRED_MODAL_EXPORT = 'showEventModal';
+
+// Filter out any multi-stage events. The current events.js has none
+// (multi-stage events live elsewhere and use `stages` instead of `modal`),
+// but keep the guard so future data additions don't surprise us.
+function previewableEvents() {
+  return EVENTS.filter(e => e && e.modal && !e.stages);
+}
+
+function pickRandom(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function renderCard(cardHost, noteEl) {
+  const pool = previewableEvents();
+  if (pool.length === 0) {
+    cardHost.innerHTML = '<p style="opacity:0.8">No previewable events found.</p>';
+    return;
+  }
+  const event = pickRandom(pool);
+
+  // Temporarily rename the page-level #modal-root so the real
+  // showEventModal writes into OUR scoped container instead of the
+  // full-screen overlay.
+  const pageRoot = document.getElementById('modal-root');
+  const restoreId = pageRoot ? pageRoot.id : null;
+  if (pageRoot) pageRoot.id = 'modal-root--stashed-by-eventPreview';
+
+  const prevCardId = cardHost.id;
+  cardHost.id = 'modal-root';
+
+  try {
+    showEventModal(event, () => {
+      if (noteEl) {
+        noteEl.textContent = '(read-only preview — choices are not applied)';
+      }
+    });
+  } catch (err) {
+    console.warn('eventPreview: showEventModal threw', err);
+    cardHost.innerHTML = `<p style="color:var(--text-danger,#f66)">Failed to render event card: ${String(err && err.message || err)}</p>`;
+  } finally {
+    // Restore ids regardless of outcome.
+    cardHost.id = prevCardId;
+    if (pageRoot) pageRoot.id = restoreId;
+  }
+}
+
+export function init(mount) {
+  try {
+    mount.innerHTML = `
+      <div class="event-preview-demo" style="margin-top:12px">
+        <div style="display:flex;gap:10px;align-items:center;margin-bottom:10px">
+          <button type="button" id="event-preview-roll" class="btn-primary">Roll another</button>
+          <span id="event-preview-note" style="opacity:0.8;font-size:0.9em"></span>
+        </div>
+        <div id="event-preview-card"></div>
+      </div>
+    `;
+    const cardHost = mount.querySelector('#event-preview-card');
+    const noteEl   = mount.querySelector('#event-preview-note');
+    const rollBtn  = mount.querySelector('#event-preview-roll');
+
+    const doRoll = () => {
+      if (noteEl) noteEl.textContent = '';
+      renderCard(cardHost, noteEl);
+    };
+
+    rollBtn.addEventListener('click', doRoll);
+    doRoll();
+  } catch (err) {
+    console.warn('eventPreview init failed:', err);
+    try {
+      mount.innerHTML = `<p style="color:var(--text-danger,#f66)">Event preview unavailable: ${String(err && err.message || err)}</p>`;
+    } catch { /* nothing more we can do */ }
+  }
+  return () => {};
+}

--- a/docs/walkthrough/demos/loop.js
+++ b/docs/walkthrough/demos/loop.js
@@ -1,0 +1,32 @@
+// Explanatory animation of the game loop. No real-module imports —
+// this one is a visualization, not a behavior proof.
+//
+// Exports init(mount) which renders a 4-step cycle: Input → Systems → Render → Log.
+
+const PHASES = ['INPUT', 'SYSTEMS', 'RENDER', 'LOG'];
+
+export function init(mount) {
+  mount.innerHTML = `
+    <div class="loop-demo" style="margin-top:16px;padding:14px;border:1px solid var(--panel-border,#0a8);border-radius:4px">
+      <div style="display:flex;gap:10px;justify-content:center;align-items:center">
+        ${PHASES.map((p, i) => `
+          <div class="loop-phase" data-phase-index="${i}" style="padding:10px 14px;border:1px solid var(--panel-border,#0a8);border-radius:4px;min-width:80px;text-align:center;font-family:ui-monospace,monospace;transition:all 0.2s">${p}</div>
+          ${i < PHASES.length - 1 ? '<span style="opacity:0.6">→</span>' : ''}
+        `).join('')}
+      </div>
+      <div style="text-align:center;margin-top:12px;font-size:0.85em;opacity:0.8" id="loop-caption">Each sol runs through these four phases, in order.</div>
+    </div>
+  `;
+  const phases = mount.querySelectorAll('.loop-phase');
+  let active = 0;
+  const tick = () => {
+    phases.forEach((p, i) => {
+      p.style.background = i === active ? 'var(--panel-header-bg, rgba(0,170,136,0.3))' : 'transparent';
+      p.style.fontWeight = i === active ? '700' : '400';
+    });
+    active = (active + 1) % phases.length;
+  };
+  tick();
+  const id = setInterval(tick, 700);
+  return () => clearInterval(id); // cleanup on teardown
+}

--- a/docs/walkthrough/demos/mashEmergency.js
+++ b/docs/walkthrough/demos/mashEmergency.js
@@ -1,0 +1,266 @@
+// Real-module demo: runs the medical-emergency multi-stage chain against
+// the real modal renderer AND exercises the real anti-mash click-metrics
+// heuristic on each choice. Read carefully → score stays low. Mash the
+// buttons → score climbs past the threshold and the demo announces that
+// an emergency WOULD have fired in a real run.
+//
+// NOTE: imports below must stay in sync with src/systems/medicalEmergency.js,
+// src/ui/modals.js, and src/systems/clickMetrics.js. If those files move
+// or rename exports, update here and the Task 15 smoke test (which asserts
+// on REQUIRED_MEDICAL_EXPORTS and REQUIRED_MODAL_EXPORT) will flag the
+// break.
+//
+// Approach: (b) from the plan. showMultiStageModal targets the document
+// #modal-root via getElementById. We temporarily rename the walkthrough
+// page's real #modal-root, give our scoped stage container that id, let
+// the real renderer paint into it, then restore on every stage. The
+// chosen callback:
+//   1. times elapsed ms and calls recordDecision with the real stage text,
+//   2. runs the real resolveMedicalStage to advance the chain,
+//   3. re-renders the next stage (or an "end of chain" note) in the scope.
+// All state is local to this demo — we never write to real game state.
+//
+// Seeded state: a sol-5 rover with five alive crew (mirrors the shape in
+// sim/medicalEmergency.test.mjs). corpses/firedEvents/log/resources are
+// present because resolveMedicalStage reads them during treat/dispose
+// outcomes (applyOutcome → resource deltas, addCorpse on 'keep', etc.).
+// clickMetrics is local: mashScore, emergenciesFired, and a visible last
+// bucket. recordDecision records into THIS state, not the real game's —
+// so there's no cross-demo or cross-page bleed.
+
+import {
+  beginMedicalEmergency,
+  resolveMedicalStage,
+  getMedicalStageView,
+  MEDICAL_EMERGENCY_ID
+} from '../../../src/systems/medicalEmergency.js';
+import { showMultiStageModal } from '../../../src/ui/modals.js';
+import {
+  initialClickMetrics,
+  recordDecision,
+  shouldFireEmergency,
+  CLICK_METRICS_CONFIG
+} from '../../../src/systems/clickMetrics.js';
+
+// Exports consumed by the Task 15 smoke test — these names MUST exist on
+// the real source modules. If someone renames them, the smoke test fails.
+export const REQUIRED_MEDICAL_EXPORTS = [
+  'beginMedicalEmergency',
+  'resolveMedicalStage',
+  'getMedicalStageView',
+  'MEDICAL_EMERGENCY_ID'
+];
+export const REQUIRED_MODAL_EXPORT = 'showMultiStageModal';
+
+// Unique stash id so parallel demos (eventPreview) can't collide on rapid
+// branch-hopping. Suffix differs from eventPreview.js's on purpose.
+const STASH_ID = 'modal-root--stashed-by-mashEmergency';
+
+function seedState() {
+  return {
+    status: 'active',
+    sol: 5,
+    pace: 'steady',
+    resources: { oxygen: 80, water: 80, food: 80, power: 80, panels: 100, mech: 4, eva: 4, cell: 3 },
+    crew: [
+      { id: 'c1', name: 'Alex',  role: 'engineer',  health: 100, status: 'healthy', alive: true },
+      { id: 'c2', name: 'Riya',  role: 'biologist', health: 100, status: 'healthy', alive: true },
+      { id: 'c3', name: 'Tomas', role: 'medic',     health: 100, status: 'healthy', alive: true },
+      { id: 'c4', name: 'Mei',   role: 'pilot',     health: 100, status: 'healthy', alive: true },
+      { id: 'c5', name: 'Sam',   role: 'security',  health: 100, status: 'healthy', alive: true }
+    ],
+    sciencePoints: 0,
+    factsLearned: [],
+    firedEvents: [],
+    corpses: [],
+    deathQueue: [],
+    log: [],
+    activeModal: null,
+    careerBonuses: {}
+  };
+}
+
+function bucketLabel(bucket) {
+  if (!bucket) return '(no clicks yet)';
+  const pretty = {
+    didNotRead: "didn't read",
+    skim:       'skim',
+    hurried:    'hurried',
+    normal:     'normal',
+    thoughtful: 'thoughtful'
+  };
+  return pretty[bucket] || bucket;
+}
+
+function renderHud(hud, metrics) {
+  const threshold = CLICK_METRICS_CONFIG.mashScoreThreshold;
+  const score = metrics.mashScore || 0;
+  const fired = shouldFireEmergency(metrics);
+  const lastBucket = bucketLabel(metrics.lastBucket);
+  const lastElapsed = metrics.lastElapsedMs != null
+    ? `${Math.round(metrics.lastElapsedMs)} ms`
+    : '—';
+  const lastExpected = metrics.lastExpectedMs != null
+    ? `${Math.round(metrics.lastExpectedMs)} ms`
+    : '—';
+  const warn = fired
+    ? `<strong style="color:var(--text-danger,#f66)">MASH DETECTED — in a real run, an anti-mash emergency would fire next.</strong>`
+    : `<span style="opacity:0.8">mash threshold: ${threshold}</span>`;
+  hud.innerHTML = `
+    <div style="font-size:0.9em;line-height:1.5">
+      <div>last click: <strong>${lastBucket}</strong> · elapsed ${lastElapsed} / expected ${lastExpected}</div>
+      <div>mashScore: <strong>${score}</strong> / ${threshold} · ${warn}</div>
+    </div>
+  `;
+}
+
+function renderStage(ctx, stageId) {
+  const { state, host, hud, status } = ctx;
+  const view = getMedicalStageView(state, stageId, ctx.context);
+  if (!view) {
+    status.innerHTML = '<em>End of chain — patient resolved.</em>';
+    return;
+  }
+
+  // Build the synthetic event shape showMultiStageModal expects, same trick
+  // main.js uses at src/main.js:233 for the real medical flow.
+  const stageEvent = {
+    id: MEDICAL_EMERGENCY_ID,
+    severity: 'medical',
+    stages: { [stageId]: view }
+  };
+
+  // Scope-swap #modal-root so the real renderer paints into OUR host.
+  const pageRoot = document.getElementById('modal-root');
+  const restoreId = pageRoot ? pageRoot.id : null;
+  if (pageRoot) pageRoot.id = STASH_ID;
+
+  const prevHostId = host.id;
+  host.id = 'modal-root';
+
+  ctx.stageOpenedAt = performance.now();
+
+  try {
+    showMultiStageModal(stageEvent, stageId, (choiceIdx) => {
+      const elapsed = performance.now() - ctx.stageOpenedAt;
+      // Real click-metrics call — same signature main.js uses at line 257.
+      ctx.metrics = recordDecision(ctx.metrics, elapsed, view.description);
+      renderHud(hud, ctx.metrics);
+
+      // Advance the chain via the real resolver. We mutate a local copy of
+      // state — nothing here escapes the demo.
+      const opened = {
+        ...ctx.state,
+        activeModal: {
+          type: 'multi_stage',
+          payload: {
+            event: { id: MEDICAL_EMERGENCY_ID, stages: { diagnose: {}, treat: {}, dispose: {} } },
+            stageId,
+            source: 'medical',
+            context: ctx.context
+          }
+        }
+      };
+      const resolved = resolveMedicalStage(opened, choiceIdx);
+      ctx.state = { ...resolved, activeModal: null };
+
+      const nextModal = resolved.activeModal;
+      if (nextModal && nextModal.type === 'multi_stage' && nextModal.payload?.source === 'medical') {
+        renderStage(ctx, nextModal.payload.stageId);
+      } else {
+        host.innerHTML = `<p style="padding:10px;opacity:0.85"><em>Chain complete.</em> Click <strong>Start emergency</strong> to run another.</p>`;
+        status.innerHTML = '';
+      }
+    });
+  } catch (err) {
+    console.warn('mashEmergency: showMultiStageModal threw', err);
+    host.innerHTML = `<p style="color:var(--text-danger,#f66)">Failed to render stage: ${String(err && err.message || err)}</p>`;
+  } finally {
+    host.id = prevHostId;
+    if (pageRoot) pageRoot.id = restoreId;
+  }
+}
+
+function startEmergency(ctx) {
+  // Fresh state + fresh metrics on every "Start emergency" click so the
+  // reader can experiment with different mash cadences from a clean slate.
+  ctx.state = seedState();
+  ctx.metrics = initialClickMetrics();
+  renderHud(ctx.hud, ctx.metrics);
+
+  // Use the real pickPatient + pickAilment path inside beginMedicalEmergency,
+  // then pull the context back out for our stage loop.
+  const opened = beginMedicalEmergency(ctx.state);
+  const modal = opened.activeModal;
+  if (!modal || modal.type !== 'multi_stage' || modal.payload?.source !== 'medical') {
+    ctx.status.innerHTML = '<em>Could not begin emergency (no alive crew?).</em>';
+    return;
+  }
+  ctx.state = opened;
+  ctx.context = modal.payload.context;
+  ctx.status.innerHTML = '';
+  renderStage(ctx, modal.payload.stageId);
+}
+
+function missingExports() {
+  const missing = [];
+  if (typeof beginMedicalEmergency !== 'function') missing.push('beginMedicalEmergency');
+  if (typeof resolveMedicalStage   !== 'function') missing.push('resolveMedicalStage');
+  if (typeof getMedicalStageView   !== 'function') missing.push('getMedicalStageView');
+  if (typeof MEDICAL_EMERGENCY_ID  !== 'string')   missing.push('MEDICAL_EMERGENCY_ID');
+  if (typeof showMultiStageModal   !== 'function') missing.push('showMultiStageModal');
+  if (typeof recordDecision        !== 'function') missing.push('recordDecision');
+  if (typeof initialClickMetrics   !== 'function') missing.push('initialClickMetrics');
+  return missing;
+}
+
+export function init(mount) {
+  try {
+    const missing = missingExports();
+    if (missing.length) {
+      console.warn('mashEmergency: missing required exports', missing);
+      mount.innerHTML = `
+        <p style="color:var(--text-danger,#f66)">
+          Demo unavailable — required exports missing: ${missing.map(m => `<code>${m}</code>`).join(', ')}.
+        </p>`;
+      return () => {};
+    }
+
+    mount.innerHTML = `
+      <div class="mash-emergency-demo" style="margin-top:12px">
+        <div style="display:flex;gap:10px;align-items:center;margin-bottom:10px;flex-wrap:wrap">
+          <button type="button" id="mash-start" class="btn-primary">Start emergency</button>
+          <span id="mash-status" style="opacity:0.8;font-size:0.9em"></span>
+        </div>
+        <div id="mash-hud" style="margin-bottom:10px;padding:8px 10px;border:1px solid var(--border,#444);border-radius:4px;background:var(--bg-panel,#1a1a1a)"></div>
+        <div id="mash-host"></div>
+        <p style="margin-top:10px;font-size:0.85em;opacity:0.75">
+          Every click is timed against expected read time (minimum ${CLICK_METRICS_CONFIG.minReadMs} ms).
+          Mash the buttons fast to see <code>mashScore</code> climb past ${CLICK_METRICS_CONFIG.mashScoreThreshold};
+          read carefully to keep it at 0.
+        </p>
+      </div>
+    `;
+
+    const ctx = {
+      state: seedState(),
+      metrics: initialClickMetrics(),
+      context: null,
+      stageOpenedAt: 0,
+      host:   mount.querySelector('#mash-host'),
+      hud:    mount.querySelector('#mash-hud'),
+      status: mount.querySelector('#mash-status')
+    };
+
+    renderHud(ctx.hud, ctx.metrics);
+    ctx.host.innerHTML = '<p style="opacity:0.8;padding:10px"><em>Click <strong>Start emergency</strong> to begin.</em></p>';
+
+    mount.querySelector('#mash-start').addEventListener('click', () => startEmergency(ctx));
+  } catch (err) {
+    console.warn('mashEmergency init failed:', err);
+    try {
+      mount.innerHTML = `<p style="color:var(--text-danger,#f66)">Mash emergency demo unavailable: ${String(err && err.message || err)}</p>`;
+    } catch { /* nothing more we can do */ }
+  }
+  return () => {};
+}

--- a/docs/walkthrough/glossary.js
+++ b/docs/walkthrough/glossary.js
@@ -1,0 +1,87 @@
+// Glossary for the code-tour slideshow.
+// Each entry's `def` is trusted HTML — rendered unescaped when a term is clicked.
+// Definitions authored in-repo for entry-level devs: 1–3 sentences, plain language.
+// Keys are kebab-case; `term` is the display label; `def` is short HTML.
+
+export const GLOSSARY = {
+  'es-modules': {
+    term: 'ES modules',
+    def: `<p>The official JavaScript module system (<code>import</code> / <code>export</code>). Each file is its own scope, and the browser loads imports on demand. No bundler or build step needed.</p>`,
+  },
+  'dom': {
+    term: 'DOM',
+    def: `<p>The "Document Object Model" — the live tree of HTML elements in your browser tab. JavaScript reads and mutates it to change what the user sees.</p>`,
+  },
+  'pure-function': {
+    term: 'pure function',
+    def: `<p>A function whose output depends only on its arguments and that doesn't touch the outside world. Same inputs always give the same outputs, which makes them trivial to unit-test.</p>`,
+  },
+  'single-source-of-truth': {
+    term: 'single source of truth',
+    def: `<p>A pattern where one object (here, <code>state.js</code>'s state tree) is the only place a given piece of data lives. Everything else reads from it and writes through well-defined paths, so there's never a "which copy is right?" question.</p>`,
+  },
+  'virtual-dom': {
+    term: 'virtual DOM',
+    def: `<p>A technique popularized by React where the framework keeps a JS-object copy of the DOM, diffs new versus old on each change, and applies only the minimum updates. Mars Trail deliberately doesn't use one — it just rebuilds from scratch.</p>`,
+  },
+  'reactive-framework': {
+    term: 'reactive framework',
+    def: `<p>A library (React, Vue, Svelte, Solid, …) that automatically re-renders UI when the data it depends on changes. Mars Trail doesn't use one; <code>render(state)</code> is called manually after every state change.</p>`,
+  },
+  'css-variable': {
+    term: 'CSS variable',
+    def: `<p>Also called a "custom property." A value you define once (<code>--panel-border: #0a8;</code>) and reuse with <code>var(--panel-border)</code>. Themes override the variables so every element using them repaints automatically.</p>`,
+  },
+  'hash-routing': {
+    term: 'hash-based routing',
+    def: `<p>Using the part of a URL after <code>#</code> (like <code>#slide-5</code>) as the page's current "location." It never hits the server, works with browser back/forward, and needs no backend — perfect for a single-file app.</p>`,
+  },
+  'factory-function': {
+    term: 'factory function',
+    def: `<p>A plain function that builds and returns a fresh object. <code>createInitialState()</code> is the example here: call it to get a new game state without touching any existing ones.</p>`,
+  },
+  'dispatch': {
+    term: 'dispatch',
+    def: `<p>In this codebase, a callback passed down into UI so it can say "the user chose X." The UI doesn't mutate state directly — it calls <code>dispatch</code> and lets the system decide what to do. Keeps the flow one-directional.</p>`,
+  },
+  'local-storage': {
+    term: 'localStorage',
+    def: `<p>A browser key-value store that persists across tabs and page reloads on the same origin. The game uses it for theme choice and best-run score; the tour intentionally does not.</p>`,
+  },
+  'dynamic-import': {
+    term: 'dynamic import',
+    def: `<p>An <code>import()</code> call inside a function (not at the top of the file). It returns a promise, so the module only loads when that code runs — useful for demos that shouldn't load until the user opens the slide.</p>`,
+  },
+  'try-finally': {
+    term: 'try/finally',
+    def: `<p>A JS block that guarantees the <code>finally</code> branch runs whether the <code>try</code> succeeded or threw. The tour uses it to restore DOM ids even if a real game modal blows up while rendering a demo.</p>`,
+  },
+  'heuristic': {
+    term: 'heuristic',
+    def: `<p>A rule-of-thumb that's usually right but not guaranteed. The anti-mashing detector uses heuristics (response time + bucket patterns) — it might flag a thoughtful-but-fast player, but in aggregate it catches careless clicking.</p>`,
+  },
+  'multi-stage-event': {
+    term: 'multi-stage event',
+    def: `<p>An in-game event with more than one screen: each choice can point to another stage (e.g., diagnose → treat → dispose), rather than resolving immediately. The engine that walks these chains is <code>src/systems/multiStage.js</code>.</p>`,
+  },
+  'sol': {
+    term: 'sol',
+    def: `<p>A Martian day — about 24 hours 39 minutes. The game's turn unit. "Sol 5" = day 5 of the mission.</p>`,
+  },
+  'eva': {
+    term: 'EVA',
+    def: `<p>Extravehicular activity — a crewed trip outside the rover (spacewalk, surface work). The game tracks EVA suit charges as a limited resource.</p>`,
+  },
+  'lmst': {
+    term: 'LMST',
+    def: `<p>Local Mean Solar Time — the clock that keeps the rover's day aligned with the Martian sun, used by NASA mission planners. Shown in the tour's header clock for flavor.</p>`,
+  },
+  'waypoint': {
+    term: 'waypoint',
+    def: `<p>An optional off-route detour along the mission path. Accepting one dispatches an "away team" of 1–3 crew while the rover camps; the chain plays out over a few sols, then the team returns (or doesn't).</p>`,
+  },
+  'anti-mashing': {
+    term: 'anti-mashing',
+    def: `<p>Detection that a player is clicking through event modals too fast or always-first to actually have read them. If the score gets high enough, the game rolls a punitive emergency — the only path you can't button-mash through.</p>`,
+  },
+};

--- a/docs/walkthrough/index.html
+++ b/docs/walkthrough/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mars Trail · Code Tour</title>
+  <link rel="stylesheet" href="../../styles/theme.css">
+  <link rel="stylesheet" href="../../styles/layout.css">
+  <link rel="stylesheet" href="../../styles/components.css">
+  <link rel="stylesheet" href="../../styles/modals.css">
+  <link rel="stylesheet" href="../../styles/theme-lcars.css">
+  <link rel="stylesheet" href="../../styles/theme-voltron.css">
+  <link rel="stylesheet" href="../../styles/theme-starfighter.css">
+  <link rel="stylesheet" href="tour.css">
+</head>
+<body>
+  <div class="scanlines" aria-hidden="true"></div>
+
+  <header class="tour-topbar">
+    <span class="tour-brand">MARS TRAIL · CODE TOUR</span>
+    <span class="tour-topbar-right">
+      <span class="tour-progress" id="tour-progress"></span>
+      <select id="theme-select" class="theme-select" aria-label="Interface theme"></select>
+    </span>
+  </header>
+
+  <main class="tour-stage" id="tour-stage" aria-live="polite"></main>
+
+  <footer class="tour-nav">
+    <button id="tour-prev" type="button" class="btn-secondary">← PREV</button>
+    <button id="tour-next" type="button" class="btn-primary">NEXT →</button>
+  </footer>
+
+  <div id="modal-root"></div>
+
+  <script type="module" src="tour.js"></script>
+</body>
+</html>

--- a/docs/walkthrough/index.html
+++ b/docs/walkthrough/index.html
@@ -20,6 +20,8 @@
     <span class="tour-brand">MARS TRAIL · CODE TOUR</span>
     <span class="tour-topbar-right">
       <span class="tour-progress" id="tour-progress"></span>
+      <button id="tour-home" type="button" class="tour-chrome-btn" title="Return to slide 1">HOME</button>
+      <a id="tour-play-game" class="tour-chrome-btn" href="../../index.html" title="Open the game">PLAY GAME</a>
       <select id="tour-theme-select" class="theme-select" aria-label="Interface theme"></select>
     </span>
   </header>

--- a/docs/walkthrough/index.html
+++ b/docs/walkthrough/index.html
@@ -20,7 +20,7 @@
     <span class="tour-brand">MARS TRAIL · CODE TOUR</span>
     <span class="tour-topbar-right">
       <span class="tour-progress" id="tour-progress"></span>
-      <select id="theme-select" class="theme-select" aria-label="Interface theme"></select>
+      <select id="tour-theme-select" class="theme-select" aria-label="Interface theme"></select>
     </span>
   </header>
 

--- a/docs/walkthrough/index.html
+++ b/docs/walkthrough/index.html
@@ -16,7 +16,7 @@
 <body>
   <div class="scanlines" aria-hidden="true"></div>
 
-  <header class="tour-topbar">
+  <header class="tour-topbar topbar">
     <span class="tour-brand">MARS TRAIL · CODE TOUR</span>
     <span class="tour-topbar-right">
       <span class="tour-progress" id="tour-progress"></span>

--- a/docs/walkthrough/repo.js
+++ b/docs/walkthrough/repo.js
@@ -1,0 +1,12 @@
+// Single source of truth for GitHub links. package.json has no `repository` field,
+// so bake it here. Update BRANCH if main is ever renamed.
+export const OWNER = 'VanderpoolTeacher';
+export const REPO = 'mars-trail';
+export const BRANCH = 'main';
+
+export function githubUrl(path, lineStart, lineEnd) {
+  const base = `https://github.com/${OWNER}/${REPO}/blob/${BRANCH}/${path}`;
+  if (typeof lineStart !== 'number') return base;
+  if (typeof lineEnd !== 'number' || lineEnd === lineStart) return `${base}#L${lineStart}`;
+  return `${base}#L${lineStart}-L${lineEnd}`;
+}

--- a/docs/walkthrough/router.js
+++ b/docs/walkthrough/router.js
@@ -1,0 +1,85 @@
+// Pure routing helpers for the code tour. No DOM, no side effects.
+//
+// A "location" is one of:
+//   { kind: 'spine',  index: number }              -- position on the spine
+//   { kind: 'branch', branchId: string, subIndex: number } -- inside a hub branch
+
+const SLIDE_HASH = /^#slide-(\d+)$/;
+const BRANCH_HASH = /^#branch-([a-zA-Z0-9_-]+)-(\d+)$/;
+
+// Sanity cap for parseHash: any spine index at or above this is treated as
+// invalid and clamped to 0 (protects against garbage / stale deep links like
+// `#slide-999`). The real manifest length is enforced later by routeToSlide.
+const MAX_SPINE_INDEX = 100;
+
+export function parseHash(hash) {
+  if (!hash || hash === '#') return { kind: 'spine', index: 0 };
+  const m1 = SLIDE_HASH.exec(hash);
+  if (m1) {
+    const idx = Number(m1[1]);
+    if (idx < 0 || !Number.isFinite(idx) || idx >= MAX_SPINE_INDEX) {
+      return { kind: 'spine', index: 0 };
+    }
+    return { kind: 'spine', index: idx };
+  }
+  const m2 = BRANCH_HASH.exec(hash);
+  if (m2) return { kind: 'branch', branchId: m2[1], subIndex: Number(m2[2]) };
+  return { kind: 'spine', index: 0 };
+}
+
+export function hashFor(location) {
+  if (location.kind === 'spine') return `#slide-${location.index}`;
+  return `#branch-${location.branchId}-${location.subIndex}`;
+}
+
+function hubIndex(slides) {
+  return slides.spine.findIndex(s => s.id === 'hub');
+}
+
+function findBranch(slides, branchId) {
+  const hub = slides.spine.find(s => s.id === 'hub');
+  if (!hub || !hub.branches) return null;
+  return hub.branches.find(b => b.id === branchId) || null;
+}
+
+export function routeForward(location, slides) {
+  if (location.kind === 'spine') {
+    const next = location.index + 1;
+    if (next >= slides.spine.length) return location;
+    return { kind: 'spine', index: next };
+  }
+  // kind === 'branch'
+  const branch = findBranch(slides, location.branchId);
+  if (!branch) return { kind: 'spine', index: hubIndex(slides) };
+  if (location.subIndex + 1 < branch.sub.length) {
+    return { kind: 'branch', branchId: location.branchId, subIndex: location.subIndex + 1 };
+  }
+  return { kind: 'spine', index: hubIndex(slides) };
+}
+
+export function routeBack(location, slides) {
+  if (location.kind === 'spine') {
+    if (location.index === 0) return location;
+    return { kind: 'spine', index: location.index - 1 };
+  }
+  // kind === 'branch'
+  if (location.subIndex === 0) return { kind: 'spine', index: hubIndex(slides) };
+  return { kind: 'branch', branchId: location.branchId, subIndex: location.subIndex - 1 };
+}
+
+// Validate a parsed hash against a concrete slides manifest.
+// Returns a valid location. Out-of-range hashes fall back to spine 0.
+export function routeToSlide(location, slides) {
+  if (location.kind === 'spine') {
+    if (location.index < 0 || location.index >= slides.spine.length) {
+      return { kind: 'spine', index: 0 };
+    }
+    return location;
+  }
+  const branch = findBranch(slides, location.branchId);
+  if (!branch) return { kind: 'spine', index: 0 };
+  if (location.subIndex < 0 || location.subIndex >= branch.sub.length) {
+    return { kind: 'branch', branchId: location.branchId, subIndex: 0 };
+  }
+  return location;
+}

--- a/docs/walkthrough/router.js
+++ b/docs/walkthrough/router.js
@@ -7,17 +7,12 @@
 const SLIDE_HASH = /^#slide-(\d+)$/;
 const BRANCH_HASH = /^#branch-([a-zA-Z0-9_-]+)-(\d+)$/;
 
-// Sanity cap for parseHash: any spine index at or above this is treated as
-// invalid and clamped to 0 (protects against garbage / stale deep links like
-// `#slide-999`). The real manifest length is enforced later by routeToSlide.
-const MAX_SPINE_INDEX = 100;
-
 export function parseHash(hash) {
   if (!hash || hash === '#') return { kind: 'spine', index: 0 };
   const m1 = SLIDE_HASH.exec(hash);
   if (m1) {
     const idx = Number(m1[1]);
-    if (idx < 0 || !Number.isFinite(idx) || idx >= MAX_SPINE_INDEX) {
+    if (idx < 0 || !Number.isFinite(idx)) {
       return { kind: 'spine', index: 0 };
     }
     return { kind: 'spine', index: idx };

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -453,10 +453,303 @@ export function getMedicalStageView(state, stageId, context) {
           },
         ],
       },
-      { id: 'clickmetrics',label: 'clickMetrics.js',                   sub: [{ id: 's1', title: 'clickMetrics.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
-      { id: 'awayteam',    label: 'awayTeam.js',                       sub: [{ id: 's1', title: 'awayTeam.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
-      { id: 'smallsys',    label: 'crew / corpse / waypoints',         sub: [{ id: 's1', title: 'Small systems — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
-      { id: 'scoring',     label: 'career.js + scoring.js',            sub: [{ id: 's1', title: 'Career & scoring — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+      {
+        id: 'clickmetrics',
+        label: 'clickMetrics.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'clickMetrics.js — anti-mash detection',
+            body: `
+              <p>Every click through an event modal is timed and bucketed against an expected read duration that scales with body length. One "didNotRead" bucket is enough to flag a player; two skims will also trip it. Above <code>mashScoreThreshold</code>, the game rolls an anti-mash catastrophic emergency.</p>
+              <p>The module is small and intentionally standalone so its thresholds can be tuned in one place.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/clickMetrics.js', lines: [6, 19], caption: 'CLICK_METRICS_CONFIG — the tunables',
+                code: `export const CLICK_METRICS_CONFIG = {
+  minReadMs: 1200,              // floor below which any decision is "too fast to read"
+  readMsPerChar: 35,            // ~28 wpm slow-reader rate; scales expected time with body length
+  mashScoreThreshold: 3,        // at or above this score, an emergency fires on the next event
+  maxEmergenciesPerRun: 5,      // cap so a single run can't chain-die from this alone
+  emergencyCooldownDelta: -2,   // mashScore reduction applied when an emergency fires
+  scoreDelta: {
+    didNotRead: 3,   // elapsed < 0.2 * expected — one fast click is enough to flag
+    skim:       2,   // elapsed < 0.5 * expected — two skims trip the heuristic
+    hurried:    1,   // elapsed < 0.75 * expected
+    normal:     0,   // elapsed < expected
+    thoughtful: -1   // elapsed >= expected — slow reads decay the score
+  }
+};` },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'awayteam',
+        label: 'awayTeam.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'awayTeam.js — divert and camp',
+            body: `
+              <p>Waypoint diverts dispatch an "away team" of 1–3 crew. The rover camps (does not advance km) while authored chains in <code>src/content/awayTeamChains.js</code> fire stage-per-sol. Rewards accumulate on <code>state.awayTeam.accumulated</code> and only land on the rover at reunion.</p>
+              <p>Built on the same multi-stage shape as medical emergencies, but with its own resolver because away-team outcomes target the roster (not the full crew) and rewards are deferred.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/awayTeam.js', lines: [36, 69], caption: 'acceptAwayTeam — dispatch the detour',
+                code: `export function acceptAwayTeam(state, waypointId, crewIds) {
+  const aliveCount = state.crew.filter(c => c.alive).length;
+  if (aliveCount < MIN_CREW_FOR_DIVERT) {
+    return {
+      ...state,
+      log: [...state.log, { sol: state.sol, text: 'Too few crew to dispatch an away team. Divert cancelled.' }]
+    };
+  }
+  const waypoint = WAYPOINTS.find(w => w.id === waypointId);
+  const chain = AWAY_TEAM_CHAINS[waypointId];
+  if (!waypoint || !chain) return state;
+
+  const validIds = crewIds.filter(id => state.crew.some(c => c.id === id && c.alive));
+  if (validIds.length === 0) return state;
+  if (validIds.length > aliveCount - 1) return state;   // keep ≥1 on rover
+
+  const returnSol = state.sol + waypoint.detourSols;
+  return {
+    ...state,
+    awayTeam: {
+      waypointId,
+      crewIds:      [...validIds],
+      departSol:    state.sol,
+      returnSol,
+      currentStage: chain.startStage,
+      accumulated:  emptyAccumulated(),
+      deaths:       []
+    },
+    log: [
+      ...state.log,
+      { sol: state.sol, text: \`Away team dispatched to \${waypoint.name}. Due back sol \${returnSol}.\` }
+    ]
+  };
+}` },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'Authored chains',
+            body: `
+              <p>Per-waypoint chains live in <code>src/content/awayTeamChains.js</code>, keyed by waypoint id. Each is a small state machine: stages with choices, some choices mutating <code>returnSolDelta</code> to extend or shorten the camp, others carrying <code>awayTeamDamage</code> that only hits the roster.</p>
+            `,
+            snippets: [
+              { path: 'src/content/awayTeamChains.js', lines: [24, 57], caption: 'olivine_outcrop — a 2-stage geology chain',
+                code: `  olivine_outcrop: {
+    startStage: 'approach',
+    stages: {
+      approach: {
+        title:       'Olivine Outcrop — On Foot',
+        description: 'The cliff face drops fifteen meters to a fresh volcanic scar. Rappel gear is in the kit; ridgeline scan is the safe read.',
+        choices: [
+          { label:          'Rappel to the fresh face (deeper sample)',
+            nextStage:      'deep_sample',
+            returnSolDelta: 1 },
+          { label:          'Scan the face from the ridgeline',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 40 },
+            failOutcome:    { sciencePoints: 15 },
+            nextStage:      null }
+        ]
+      },
+      deep_sample: {
+        title:       'Down the Face',
+        description: 'You are halfway down the scar, rope anchored above. Fresh olivine vein exposed at eye level — drillable if you commit.',
+        choices: [
+          { label:          'Drill the exposed vein',
+            skillCheck:     { role: 'engineer', successP: 0.75 },
+            successOutcome: { sciencePoints: 80 },
+            failOutcome:    { sciencePoints: 30, awayTeamDamage: 20 },
+            nextStage:      null },
+          { label:          'Bag a chip sample and climb out',
+            returnSolDelta: -1,
+            outcome:        { sciencePoints: 35 },
+            nextStage:      null }
+        ]
+      }
+    }
+  },` },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'smallsys',
+        label: 'crew / corpse / waypoints',
+        sub: [
+          {
+            id: 's1',
+            title: 'Small systems grouped',
+            body: `
+              <p>Three small modules that share state:</p>
+              <ul>
+                <li><code>crew.js</code> — damage, status, death bookkeeping (the biggest of the three; owns the medic-reduction rule and the death queue).</li>
+                <li><code>corpse.js</code> — dead-but-present crew; feeds extra weight into the cargo calc.</li>
+                <li><code>waypoints.js</code> — run-start roll of optional diverts along the route; acceptance hands off to <code>awayTeam.js</code>.</li>
+              </ul>
+              <p>Each is a coordinator between <code>state.js</code> and the higher-level systems. <code>corpse.js</code> is essentially a list and a sum; <code>waypoints.js</code> is a roll-and-decline pair.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/crew.js',      lines: [22, 58], caption: 'crew.js — applyDamage with medic reduction',
+                code: `export function applyDamage(state, targetSpec, rawAmount, cause) {
+  const s = {
+    ...state,
+    crew: state.crew.map(c => ({ ...c })),
+    log: [...state.log]
+  };
+
+  const target = pickTarget(s.crew, targetSpec);
+  if (!target) return { state: s, target: null, died: false, dealt: 0 };
+
+  const medicAlive = s.crew.some(c => c.role === 'medic' && c.alive && c.id !== target.id);
+  // Medic doesn't reduce damage to themselves.
+  const reduction = medicAlive ? MEDIC_DAMAGE_REDUCTION : 0;
+  const dealt = Math.max(0, Math.round(rawAmount * (1 - reduction)));
+
+  const wasAlive = target.alive;
+  target.health = Math.max(0, target.health - dealt);
+  target.status = deriveStatus(target.health);
+  if (target.status === 'dead') target.alive = false;
+
+  const died = wasAlive && !target.alive;
+  if (died) {
+    s.log.push({
+      sol: s.sol,
+      text: \`\${target.name} (\${target.role.toUpperCase()}) succumbed to \${cause || 'injuries'}.\`
+    });
+    // Queue a death dialog for the UI dispatcher to surface (issue #33).
+    s.deathQueue = [...(s.deathQueue || []), {
+      crewId: target.id,
+      name:   target.name,
+      role:   target.role,
+      cause:  cause || 'injuries',
+      sol:    s.sol
+    }];
+  }
+  return { state: s, target, died, dealt };
+}` },
+              { path: 'src/systems/corpse.js',    lines: [5, 14], caption: 'corpse.js — the whole module',
+                code: `export const DEFAULT_CORPSE_LBS = 180;
+
+export function addCorpse(state, crewId, weightLbs = DEFAULT_CORPSE_LBS) {
+  if (state.corpses.some(c => c.crewId === crewId)) return state;
+  return { ...state, corpses: [...state.corpses, { crewId, weightLbs }] };
+}
+
+export function corpseWeight(state) {
+  return state.corpses.reduce((n, c) => n + c.weightLbs, 0);
+}` },
+              { path: 'src/systems/waypoints.js', lines: [23, 55], caption: 'waypoints.js — run-start two-pass roll',
+                code: `export function rollWaypoints(state) {
+  const usedIds = new Set();
+  const usedSegments = new Set();
+  const waypoints = [];
+
+  // Pass 1: probabilistic roll per eligible segment.
+  for (let segmentIdx = 1; segmentIdx < state.route.length - 1; segmentIdx++) {
+    if (Math.random() >= WAYPOINT_ROLL_PROB) continue;
+    const candidates = WAYPOINTS.filter(w => !usedIds.has(w.id));
+    if (candidates.length === 0) break;
+    const pick = candidates[Math.floor(Math.random() * candidates.length)];
+    usedIds.add(pick.id);
+    usedSegments.add(segmentIdx);
+    waypoints.push({ waypointId: pick.id, segmentIdx });
+  }
+
+  // Pass 2: top-up until we hit the per-run floor (or run out of room).
+  while (waypoints.length < MIN_WAYPOINTS_PER_RUN) {
+    const empty = [];
+    for (let segmentIdx = 1; segmentIdx < state.route.length - 1; segmentIdx++) {
+      if (!usedSegments.has(segmentIdx)) empty.push(segmentIdx);
+    }
+    const candidates = WAYPOINTS.filter(w => !usedIds.has(w.id));
+    if (empty.length === 0 || candidates.length === 0) break;
+    const segmentIdx = empty[Math.floor(Math.random() * empty.length)];
+    const pick = candidates[Math.floor(Math.random() * candidates.length)];
+    usedIds.add(pick.id);
+    usedSegments.add(segmentIdx);
+    waypoints.push({ waypointId: pick.id, segmentIdx });
+  }
+
+  return { ...state, waypoints };
+}` },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'scoring',
+        label: 'career.js + scoring.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'End-of-run scoring',
+            body: `
+              <p>When a run ends, <code>scoring.js</code> computes a point total and rank from science collected, sols taken, crew outcome, and resources remaining. Rank is gated by a checklist (issue #24): surviving is C, science + learning earn A, and only a full-crew-returned S-run earns the top mark.</p>
+              <p><code>career.js</code> persists science across runs for the long-term meta-progression — tiered bonuses like skill-check boosts and rover km/sol uplift. Both modules keep their compute functions pure; the only impure corners are the localStorage helpers at the bottom of each file.</p>
+            `,
+            snippets: [
+              { path: 'src/systems/scoring.js', lines: [96, 124], caption: 'scoring.js — computeScore breakdown',
+                code: `export function computeScore(state) {
+  const won = state.status === 'won';
+  const breakdown = [];
+
+  const outcomePts = won
+    ? 500
+    : state.totalKmTraveled >= 0.8 * totalRouteKm(state) ? 100 : 0;
+  breakdown.push({ label: 'Mission outcome', value: state.status, points: outcomePts });
+
+  const alive = aliveCrewCount(state);
+  breakdown.push({ label: 'Crew survived', value: \`\${alive}/\${state.crew.length}\`, points: alive * 100 });
+
+  const sciPts = Math.min(state.sciencePoints, 300);
+  breakdown.push({ label: 'Science points', value: state.sciencePoints, points: sciPts });
+
+  const r = state.resources;
+  const rawResPts = Math.round((r.oxygen + r.water + r.food + r.power) / 4);
+  const resPts = Math.min(rawResPts, 100);
+  breakdown.push({ label: 'Resources remaining', value: \`\${rawResPts}%\`, points: resPts });
+
+  const speedPts = won ? Math.max(0, 300 - state.sol * 10) : 0;
+  breakdown.push({ label: 'Speed bonus', value: \`sol \${state.sol}\`, points: speedPts });
+
+  const stops = Math.max(0, state.currentLandmarkIndex);
+  breakdown.push({ label: 'Landmark stops', value: stops, points: stops * 20 });
+
+  const points = breakdown.reduce((sum, b) => sum + b.points, 0);
+  return { points, breakdown, rank: rankFor(state) };
+}` },
+              { path: 'src/systems/career.js',  lines: [7, 26], caption: 'career.js — six persistent meta-tiers',
+                code: `export const CAREER_TIERS = [
+  { minSci:   0, id: 'rookie',          name: 'Rookie',
+    description: 'No bonuses yet.',
+    effect: {} },
+  { minSci:  30, id: 'calibration',     name: 'Calibration Data Analysis',
+    description: 'Waypoint offers show exact reward estimates.',
+    effect: { exactWaypointReward: true } },
+  { minSci: 100, id: 'navigation',      name: 'Navigation Pattern Analysis',
+    description: 'Rover base km/sol +5% at every pace.',
+    effect: { kmMult: 1.05 } },
+  { minSci: 225, id: 'methodology',     name: 'Field Methodology Training',
+    description: 'Skill-check success +10 percentage points across all events.',
+    effect: { skillBonus: 0.10 } },
+  { minSci: 400, id: 'life_support',    name: 'Life-Support Optimization',
+    description: 'O₂ and H₂O consumption −10% at every pace.',
+    effect: { lifeSupportMult: 0.90 } },
+  { minSci: 700, id: 'intel_synthesis', name: 'Mission Intel Synthesis',
+    description: 'One upcoming event previewed on the briefing screen each run.',
+    effect: { eventPreview: true } }
+];` },
+            ],
+          },
+        ],
+      },
     ],
   },
   // Slide 9 (hub) in Task 9, 10–16 in Task 13.

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -870,11 +870,13 @@ export function resolveTheme(raw) {
     body: `
       <p>Thanks for walking through. Suggested next steps:</p>
       <ul>
-        <li>Play a run — <code>index.html</code> in the repo root.</li>
         <li>Skim the most recent spec in <code>docs/superpowers/specs/</code> to see the current frontier.</li>
         <li>Pick any system that caught your eye and read its test file under <code>sim/</code>.</li>
       </ul>
-      <p>Press <strong>Home</strong> to return to the start of the tour, or close the tab.</p>
+      <div class="tour-cta-row">
+        <a class="tour-cta" href="../../index.html">Start Game</a>
+        <button class="tour-cta" type="button" data-action="restart">Restart Mission</button>
+      </div>
     `,
   },
 ];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -6,19 +6,52 @@ export const spine = [
   {
     id: 'welcome',
     title: 'Welcome to the Mars Trail code tour',
-    body: '<p>Press → or click NEXT to begin.</p>',
+    body: `
+      <p class="subtitle">A ~15-minute guided tour of how this game is organized.</p>
+      <p>Use <strong>← →</strong> to navigate. <strong>Esc</strong> returns from a hub branch. Theme selector in the top-right repaints everything — the tour itself is a live demo of the game's theme system.</p>
+      <p>Press <strong>→</strong> or click <strong>NEXT</strong> to begin.</p>
+    `,
   },
   {
     id: 'pitch',
     title: 'What is Mars Trail?',
-    body: '<p>Placeholder — real content arrives in Task 6.</p>',
-    snippets: [
-      {
-        path: 'src/main.js',
-        lines: [1, 10],
-        caption: 'Placeholder snippet (replaced in Task 7)',
-        code: '// first lines of main.js will go here\nconsole.log("hello mars");',
-      },
-    ],
+    body: `
+      <p>An Oregon-Trail-style survival sim set on Mars, built for a game jam. You captain a rover across Acidalia Planitia, rationing power and EVA suits, managing crew, responding to emergencies, and diverting for side missions ("away teams") that chase science points.</p>
+      <p>Runs are short (~10–20 sols of play), most of the difficulty is in the event system, and a run ends when you reach the goal or lose the crew.</p>
+    `,
   },
+  {
+    id: 'stack',
+    title: 'Tech stack',
+    body: `
+      <p><strong>Vanilla ES modules.</strong> No framework, no bundler, no build step. Open <code>index.html</code> in a browser and you're running the game.</p>
+      <p>This is deliberate: the project is small enough that a build toolchain would be more complexity than feature. It also makes the code unusually easy to read — what you see in the file is what runs.</p>
+      <p>Testing uses Node's built-in <code>node --test</code> runner (see <code>sim/</code>). The simulation harness at <code>sim/play.mjs</code> runs thousands of AI-driven playthroughs to validate balance.</p>
+    `,
+  },
+  {
+    id: 'layout',
+    title: 'Repo layout',
+    body: `
+      <p>The whole project fits in a handful of folders. Each has one job.</p>
+      <pre style="line-height:1.35;font-size:0.9em"><code>Mars Trail/
+├── index.html          — game entry point
+├── src/
+│   ├── main.js         — boots the game, wires UI
+│   ├── state.js        — single source of truth
+│   ├── render.js       — state → DOM
+│   ├── theme.js        — theme switcher
+│   ├── audio.js        — music + mute
+│   ├── systems/        — game logic (pure where possible)
+│   ├── content/        — data: events, emergencies, facts, waypoints
+│   └── ui/             — modals, codex overlay
+├── styles/             — theme.css + per-theme overlays
+├── sim/                — unit tests + playtest harness
+├── assets/             — images, music
+└── docs/superpowers/   — per-feature specs + implementation plans
+</code></pre>
+      <p>The rest of the tour follows the data flow: entry point → state → render → systems (via a hub) → content → UI → themes → audio → tests → workflow.</p>
+    `,
+  },
+  // Slides 5–8 added in Task 7, slide 9 (hub) in Task 9, 10–16 in Task 13.
 ];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -16,8 +16,8 @@ export const spine = [
     id: 'pitch',
     title: 'What is Mars Trail?',
     body: `
-      <p>An Oregon-Trail-style survival sim set on Mars, built for a game jam. You captain a rover across Acidalia Planitia, rationing power and EVA suits, managing crew, responding to emergencies, and diverting for side missions ("away teams") that chase science points.</p>
-      <p>Runs are short (~10–20 sols of play), most of the difficulty is in the event system, and a run ends when you reach the goal or lose the crew.</p>
+      <p>An Oregon-Trail-style survival sim set on Mars, built for a game jam. You captain a rover from Jezero Crater to a colony site near Olympus Mons, rationing power and EVA suits, managing crew, responding to emergencies, and diverting for side missions ("away teams") that chase science points.</p>
+      <p>Runs typically take ~15–30 sols (2–3 weeks of in-game time), most of the difficulty is in the event system, and a run ends when you reach the goal or lose the crew.</p>
     `,
   },
   {
@@ -48,7 +48,10 @@ export const spine = [
 ├── styles/             — theme.css + per-theme overlays
 ├── sim/                — unit tests + playtest harness
 ├── assets/             — images, music
-└── docs/superpowers/   — per-feature specs + implementation plans
+└── docs/
+    ├── superpowers/    — per-feature specs + implementation plans
+    ├── walkthrough/    — this interactive tour
+    └── reports/        — session reports
 </code></pre>
       <p>The rest of the tour follows the data flow: entry point → state → render → systems (via a hub) → content → UI → themes → audio → tests → workflow.</p>
     `,

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -56,5 +56,124 @@ export const spine = [
       <p>The rest of the tour follows the data flow: entry point → state → render → systems (via a hub) → content → UI → themes → audio → tests → workflow.</p>
     `,
   },
-  // Slides 5–8 added in Task 7, slide 9 (hub) in Task 9, 10–16 in Task 13.
+  {
+    id: 'loop',
+    title: 'The game loop',
+    body: `
+      <p>Every turn (a "sol") follows the same four-phase rhythm:</p>
+      <ol>
+        <li><strong>Input</strong> — player picks pace / rations / actions.</li>
+        <li><strong>Systems</strong> — <code>travel.js</code>, <code>events.js</code>, and friends mutate state.</li>
+        <li><strong>Render</strong> — <code>render.js</code> rebuilds the DOM from state.</li>
+        <li><strong>Log</strong> — mission log entries appear for what just happened.</li>
+      </ol>
+      <p>There is <em>no</em> observer pattern, <em>no</em> virtual DOM, <em>no</em> reactive framework. On every change, <code>render()</code> rebuilds the parts of the DOM it owns from scratch.</p>
+      <div id="demo-loop-mount"></div>
+    `,
+    demo: 'loop',
+  },
+  {
+    id: 'entry',
+    title: 'Entry point',
+    body: `
+      <p><code>index.html</code> loads stylesheets and calls into <code>src/main.js</code>, which boots the game: builds initial state, wires event listeners, paints the first frame.</p>
+      <p>Follow the imports at the top of <code>main.js</code> and you get a one-page map of the whole app.</p>
+    `,
+    snippets: [
+      {
+        path: 'src/main.js',
+        lines: [1, 17],
+        caption: 'Boot imports',
+        code: `// Mars Trail — entry point
+// Builds initial state, runs first render, wires UI events.
+
+import { createInitialState, CARGO_BUDGET, PART_TYPES } from './state.js';
+import { render } from './render.js';
+import { advanceSol, setPace, setRations, repairBattery, cleanPanels } from './systems/travel.js';
+import { applyEventChoice } from './systems/events.js';
+import { recordDecision } from './systems/clickMetrics.js';
+import { showEventModal, showOutcomeModal, showBriefingModal, showLoadoutModal, showTitleLayer, dimTitleStart, hideTitleLayer, showEndOfRunModal, closeModal, showWaypointOfferModal, showMultiStageModal, showAwayTeamPickerModal, showAwayTeamReunionModal, showDeathDialog } from './ui/modals.js';
+import { declineWaypoint } from './systems/waypoints.js';
+import { applyStageChoice } from './systems/multiStage.js';
+import { acceptAwayTeam, resolveAwayTeamStage, finalizeReunion } from './systems/awayTeam.js';
+import { resolveMedicalStage, getMedicalStageView } from './systems/medicalEmergency.js';
+import { WAYPOINTS } from './content/waypoints.js';
+import { makeLandmarkEncounter } from './content/landmarks.js';
+import './ui/codex.js';   // registers global click handler for codex terms
+import { GAMEPLAY_TRACKS, getSelectedTrackId, isMuted, playTitle, playGameplay, selectTrack, toggleMute, fadeOut, fadeInGameplay, cycleTrack, onTrackChange } from './audio.js';`,
+      },
+    ],
+  },
+  {
+    id: 'state',
+    title: 'State',
+    body: `
+      <p><code>src/state.js</code> exports a single function, <code>createInitialState()</code>, that returns a plain JS object. That object <em>is</em> the game. Everything else reads it; systems mutate it; <code>render()</code> projects it to DOM.</p>
+      <p>Keeping state in one place is what makes tests easy to write: seed a state, call a system, assert on the resulting state.</p>
+    `,
+    snippets: [
+      {
+        path: 'src/state.js',
+        lines: [43, 70],
+        caption: 'State shape (excerpt)',
+        code: `  const baseState = {
+    schemaVersion: 1,
+    runId: uuid(),
+    scenario: 'trek',
+    startedAt: Date.now(),
+    sol: 1,
+    status: 'active',          // 'active' | 'won' | 'lost'
+    lossReason: null,
+
+    // Geography
+    route: TREK_ROUTE.ids,
+    routeKm: TREK_ROUTE.kms,
+    currentLandmarkIndex: 0,
+    kmToNextLandmark: TREK_ROUTE.kms[0],
+    totalKmTraveled: 0,
+
+    // Resources. % values (except panels which is efficiency, and parts which
+    // are discrete). Base levels are lower — supply loadout items bring them up.
+    resources: {
+      oxygen: 76,     // base; +8% per O₂ canister (default 3 = 100%)
+      water:  76,     // base; +8% per H₂O tank (default 3 = 100%)
+      power:  100,
+      food:   76,     // base; +8% per ration pack (default 3 = 100%)
+      panels: 100,
+      mech: 4,
+      eva:  4,
+      cell: 3
+    },`,
+      },
+    ],
+  },
+  {
+    id: 'render',
+    title: 'Render',
+    body: `
+      <p><code>src/render.js</code> is a pure <code>state → DOM</code> projection. It exports one function — <code>render(state)</code> — that is called after every state change. No partial updates, no diffing; just rebuild the panels it owns.</p>
+      <p>This stays cheap because the DOM is small: a few panels, a crew list, a log. The simplicity is the feature.</p>
+    `,
+    snippets: [
+      {
+        path: 'src/render.js',
+        lines: [345, 357],
+        caption: 'Render entry',
+        code: `// ---------- Top-level render ----------
+
+let bound = false;
+export function render(state) {
+  if (!bound) { bindDom(); bound = true; }
+  renderTopbar(state);
+  renderRoute(state);
+  renderTelemetry(state);
+  renderCrew(state);
+  renderControls(state);
+  renderLog(state);
+  renderActionBar(state);
+}`,
+      },
+    ],
+  },
+  // Slide 9 (hub) in Task 9, 10–16 in Task 13.
 ];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -1,8 +1,12 @@
-// Slide manifest. Populated across tasks 6, 7, 9, 10, 12, 13.
 export const spine = [
   {
     id: 'welcome',
     title: 'Welcome to the Mars Trail code tour',
     body: '<p>Press → or click NEXT to begin.</p>',
+  },
+  {
+    id: 'pitch',
+    title: 'What is Mars Trail?',
+    body: '<p>Placeholder — real content arrives in Task 6.</p>',
   },
 ];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -875,7 +875,6 @@ export function resolveTheme(raw) {
       </ul>
       <div class="tour-cta-row">
         <a class="tour-cta" href="../../index.html">Start Game</a>
-        <button class="tour-cta" type="button" data-action="restart">Restart Mission</button>
       </div>
     `,
   },

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -1,0 +1,8 @@
+// Slide manifest. Populated across tasks 6, 7, 9, 10, 12, 13.
+export const spine = [
+  {
+    id: 'welcome',
+    title: 'Welcome to the Mars Trail code tour',
+    body: '<p>Press → or click NEXT to begin.</p>',
+  },
+];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -752,5 +752,129 @@ export function corpseWeight(state) {
       },
     ],
   },
-  // Slide 9 (hub) in Task 9, 10–16 in Task 13.
+  {
+    id: 'content-vs-systems',
+    title: 'Content vs. systems',
+    body: `
+      <p>Across the branches you just walked, one pattern repeats: <strong>logic in <code>src/systems/</code>, data in <code>src/content/</code></strong>. A system module knows <em>how</em>; a content module knows <em>what</em>.</p>
+      <p>This split is why adding a new event, emergency, fact, or waypoint is usually a one-file change in <code>content/</code>. The systems stay stable; the world grows.</p>
+    `,
+  },
+  {
+    id: 'ui',
+    title: 'UI layer',
+    body: `
+      <p><code>src/ui/modals.js</code> renders event cards, multi-stage dialogs, mash-rescue, codex pages, and so on. It is DOM-heavy but state-light — every modal receives the game state and a dispatch function, and returns nothing. All flow lives in <code>main.js</code>.</p>
+      <p><code>src/ui/codex.js</code> handles the in-game encyclopedia of Mars facts that players unlock by playing.</p>
+    `,
+    snippets: [
+      { path: 'src/ui/modals.js', lines: [13, 31], caption: 'showEventModal — render a choice list',
+        code: `export function showEventModal(event, onChoose) {
+  const r = root();
+  if (!r) return;
+
+  const choicesHtml = event.modal.choices.map((c, i) => {
+    const cost = formatCost(c);
+    const check = c.skillCheck
+      ? \`<span class="modal-choice-check">\${c.skillCheck.role.toUpperCase()} CHECK · \${Math.round(c.skillCheck.successP * 100)}%</span>\`
+      : '';
+    const cls = ['modal-choice'];
+    if (c.primary) cls.push('primary');
+    return \`
+      <button class="\${cls.join(' ')}" data-idx="\${i}" type="button">
+        <span class="modal-choice-label">\${escapeHtml(c.label)}</span>
+        \${check}
+        \${cost ? \`<span class="modal-choice-cost">\${cost}</span>\` : ''}
+      </button>
+    \`;
+  }).join('');` },
+    ],
+  },
+  {
+    id: 'theme',
+    title: 'Theme system',
+    body: `
+      <p>Three themes (plus Mission Control default): LCARS, Voltron HUD, Last Starfighter. Each is a stylesheet under <code>styles/theme-*.css</code> that overrides a shared set of CSS variables defined in <code>styles/theme.css</code>. <code>src/theme.js</code> is a 68-line switcher that sets <code>data-theme</code> on <code>&lt;body&gt;</code> and remembers the last choice in localStorage.</p>
+      <p><strong>Live proof:</strong> this slideshow reuses those exact stylesheets. Change the theme dropdown in the top-right right now — every frame, chrome, and demo repaints instantly.</p>
+    `,
+    snippets: [
+      { path: 'src/theme.js', lines: [7, 17], caption: 'THEMES list + resolveTheme',
+        code: `export const THEMES = [
+  { id: 'mc',          label: 'Mission Control' },
+  { id: 'lcars',       label: 'LCARS / TNG' },
+  { id: 'voltron',     label: 'Voltron HUD' },
+  { id: 'starfighter', label: 'Last Starfighter' }
+];
+
+export function resolveTheme(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return 'mc';
+  return THEMES.some(t => t.id === raw) ? raw : 'mc';
+}` },
+    ],
+  },
+  {
+    id: 'audio',
+    title: 'Audio',
+    body: `
+      <p><code>src/audio.js</code> is a minimal music player: a shuffled playlist, a mute toggle, a manual track dropdown. It never auto-plays — users have to click first, per browser policy. The module wraps a single <code>Audio</code> object and exposes small helpers (play, stop, mute, cycle, fade) that <code>main.js</code> wires to the UI.</p>
+    `,
+    snippets: [
+      { path: 'src/audio.js', lines: [74, 88], caption: 'play — load, loop-if-title, respect mute',
+        code: `export function play(trackId) {
+  const track = trackId === 'title'
+    ? TITLE_TRACK
+    : GAMEPLAY_TRACKS.find(t => t.id === trackId);
+  if (!track) return;
+  if (currentTrackId === track.id && !audio.paused) return;
+
+  currentTrackId = track.id;
+  audio.src = track.file;
+  audio.loop = (track.id === 'title'); // title loops; gameplay advances via 'ended'
+  audio.muted = isMuted();
+  audio.play().catch(() => {});
+  unlocked = true;
+  notifyTrackChange(track.id);
+}` },
+    ],
+  },
+  {
+    id: 'tests',
+    title: 'Testing',
+    body: `
+      <p>Two kinds of test code:</p>
+      <ul>
+        <li><strong>Unit tests</strong> — <code>sim/*.test.mjs</code>, each uses <code>node --test</code>. Exercise pure functions from <code>src/systems/</code> and <code>src/theme.js</code>. Run one file: <code>node --test sim/theme.test.mjs</code>.</li>
+        <li><strong>Playtest harness</strong> — <code>sim/play.mjs</code> and <code>sim/playtest1000.mjs</code>. Runs thousands of AI-driven playthroughs with various strategies, prints a balance table. This catches difficulty regressions that unit tests can't.</li>
+      </ul>
+      <p>Both paths depend on keeping system modules pure (no DOM imports in <code>src/systems/</code>).</p>
+    `,
+  },
+  {
+    id: 'workflow',
+    title: 'Workflow',
+    body: `
+      <p>Every change follows the same trail:</p>
+      <ol>
+        <li><strong>GitHub issue</strong> — describes problem + acceptance criteria.</li>
+        <li><strong>Spec</strong> — <code>docs/superpowers/specs/YYYY-MM-DD-&lt;topic&gt;-design.md</code>.</li>
+        <li><strong>Plan</strong> — <code>docs/superpowers/plans/YYYY-MM-DD-&lt;topic&gt;.md</code> (this tour is one).</li>
+        <li><strong>Implementation</strong> — small commits, each referencing the issue.</li>
+        <li><strong>Release</strong> — SemVer git tag + GitHub release.</li>
+      </ol>
+      <p>The <code>docs/superpowers/</code> directory is the repository of all past specs and plans, and is a great read in its own right.</p>
+    `,
+  },
+  {
+    id: 'credits',
+    title: 'End of tour',
+    body: `
+      <p>Thanks for walking through. Suggested next steps:</p>
+      <ul>
+        <li>Play a run — <code>index.html</code> in the repo root.</li>
+        <li>Skim the most recent spec in <code>docs/superpowers/specs/</code> to see the current frontier.</li>
+        <li>Pick any system that caught your eye and read its test file under <code>sim/</code>.</li>
+      </ul>
+      <p>Press <strong>Home</strong> to return to the start of the tour, or close the tab.</p>
+    `,
+  },
 ];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -1,3 +1,7 @@
+// Slide manifest. All HTML in `title`, `body`, and `snippets[].caption` is
+// authored in-repo and trusted — rendered unescaped. Snippet `code` contains
+// literal source text and is escaped at render time. Do not route user input
+// through this file.
 export const spine = [
   {
     id: 'welcome',
@@ -8,5 +12,13 @@ export const spine = [
     id: 'pitch',
     title: 'What is Mars Trail?',
     body: '<p>Placeholder — real content arrives in Task 6.</p>',
+    snippets: [
+      {
+        path: 'src/main.js',
+        lines: [1, 10],
+        caption: 'Placeholder snippet (replaced in Task 7)',
+        code: '// first lines of main.js will go here\nconsole.log("hello mars");',
+      },
+    ],
   },
 ];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -394,7 +394,65 @@ export function applyStageChoice(state, event, stageId, choiceIdx) {
           },
         ],
       },
-      { id: 'medical',     label: 'medicalEmergency.js',               sub: [{ id: 's1', title: 'medicalEmergency.js — placeholder', body: '<p>Branch content arrives in Task 12.</p>' }] },
+      {
+        id: 'medical',
+        label: 'medicalEmergency.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'medicalEmergency.js — the three-act chain',
+            body: `
+              <p>The medical emergency is the project's flagship multi-stage event: <strong>Diagnosis → Treatment → Disposal</strong>. Each stage branches on the player's choice and on crew damage. It's the first real stress-test of the <code>multiStage.js</code> engine.</p>
+              <p>Authored data lives in <code>src/content/medicalEmergency.js</code>. The system module wires stage transitions and computes outcomes (including the "leave the body or haul it" disposal beat). Stage <em>views</em> are built per-run by <code>getMedicalStageView</code> so the diagnose text can weave in the specific patient, the rolled ailment, and whether the medic is themselves the patient.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/medicalEmergency.js',
+                lines: [56, 83],
+                caption: 'getMedicalStageView — Act 1 (diagnose)',
+                code: `// ---- Stage view (title/description/choices, built per-run) ----
+// Returns { title, description, choices } where each choice has
+// { label, key }. The resolver dispatches on key.
+export function getMedicalStageView(state, stageId, context) {
+  const patient = state.crew.find(c => c.id === context.patientId);
+  const ailment = AILMENTS.find(a => a.id === context.ailmentId) || AILMENTS[0];
+  if (!patient) return null;
+
+  const roleCode = (patient.role || '').toUpperCase();
+  const patientTag = \`\${patient.name} (\${roleCode})\`;
+
+  if (stageId === 'diagnose') {
+    const intro = context.selfTreat
+      ? \`\${patientTag} — your medic — is in trouble. \${ailment.symptom} The crew is on their own.\`
+      : \`\${patientTag} is in trouble. \${ailment.symptom} You have to act.\`;
+    const choices = context.selfTreat
+      ? [
+          { label: 'Self-triage (medic impaired)',        key: 'self_triage' },
+          { label: 'Query Earth (comms delay)',           key: 'earth' },
+          { label: 'Dose from med kit and hope',          key: 'hope' }
+        ]
+      : [
+          { label: 'Consult the medic',                    key: 'medic' },
+          { label: 'Query Earth (comms delay)',            key: 'earth' },
+          { label: 'Dose from med kit and hope',           key: 'hope' }
+        ];
+    return { title: \`Medical Emergency — \${ailment.label}\`, description: intro, choices };
+  }`,
+              },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'Live: the mash-rescue UI',
+            body: `
+              <p>Click <strong>Start emergency</strong> below to run a seeded medical chain against the real modal renderer. Every click is timed by <code>clickMetrics.recordDecision</code> — the same anti-mashing heuristic the game uses in a live run. Mash the buttons fast and <code>mashScore</code> climbs past the threshold; read carefully and it stays at 0.</p>
+              <p>This demo imports <code>src/systems/medicalEmergency.js</code>, <code>src/ui/modals.js</code>, and <code>src/systems/clickMetrics.js</code> directly; no mock reimplementation. State is seeded locally and thrown away — nothing leaks into the rest of the tour.</p>
+              <div id="demo-mashEmergency-mount"></div>
+            `,
+            demo: 'mashEmergency',
+          },
+        ],
+      },
       { id: 'clickmetrics',label: 'clickMetrics.js',                   sub: [{ id: 's1', title: 'clickMetrics.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
       { id: 'awayteam',    label: 'awayTeam.js',                       sub: [{ id: 's1', title: 'awayTeam.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
       { id: 'smallsys',    label: 'crew / corpse / waypoints',         sub: [{ id: 's1', title: 'Small systems — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -108,7 +108,7 @@ import { GAMEPLAY_TRACKS, getSelectedTrackId, isMuted, playTitle, playGameplay, 
     id: 'state',
     title: 'State',
     body: `
-      <p><code>src/state.js</code> exports a single function, <code>createInitialState()</code>, that returns a plain JS object. That object <em>is</em> the game. Everything else reads it; systems mutate it; <code>render()</code> projects it to DOM.</p>
+      <p><code>src/state.js</code>'s central export is a factory, <code>createInitialState()</code>, that returns a plain JS object. That object <em>is</em> the game. Everything else reads it; systems mutate it; <code>render()</code> projects it to DOM. (The module also exports a few shared constants and lookup tables — see the file itself.)</p>
       <p>Keeping state in one place is what makes tests easy to write: seed a state, call a system, assert on the resulting state.</p>
     `,
     snippets: [

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -24,7 +24,7 @@ export const spine = [
     id: 'stack',
     title: 'Tech stack',
     body: `
-      <p><strong>Vanilla ES modules.</strong> No framework, no bundler, no build step. Open <code>index.html</code> in a browser and you're running the game.</p>
+      <p><strong>Vanilla <span class="term" data-term="es-modules">ES modules</span>.</strong> No framework, no bundler, no build step. Open <code>index.html</code> in a browser and you're running the game.</p>
       <p>This is deliberate: the project is small enough that a build toolchain would be more complexity than feature. It also makes the code unusually easy to read — what you see in the file is what runs.</p>
       <p>Testing uses Node's built-in <code>node --test</code> runner (see <code>sim/</code>). The simulation harness at <code>sim/play.mjs</code> runs thousands of AI-driven playthroughs to validate balance.</p>
     `,
@@ -67,7 +67,7 @@ export const spine = [
         <li><strong>Render</strong> — <code>render.js</code> rebuilds the DOM from state.</li>
         <li><strong>Log</strong> — mission log entries appear for what just happened.</li>
       </ol>
-      <p>There is <em>no</em> observer pattern, <em>no</em> virtual DOM, <em>no</em> reactive framework. On every change, <code>render()</code> rebuilds the parts of the DOM it owns from scratch.</p>
+      <p>There is <em>no</em> observer pattern, <em>no</em> <span class="term" data-term="virtual-dom">virtual DOM</span>, <em>no</em> <span class="term" data-term="reactive-framework">reactive framework</span>. On every change, <code>render()</code> rebuilds the parts of the <span class="term" data-term="dom">DOM</span> it owns from scratch.</p>
       <div id="demo-loop-mount"></div>
     `,
     demo: 'loop',
@@ -108,8 +108,8 @@ import { GAMEPLAY_TRACKS, getSelectedTrackId, isMuted, playTitle, playGameplay, 
     id: 'state',
     title: 'State',
     body: `
-      <p><code>src/state.js</code>'s central export is a factory, <code>createInitialState()</code>, that returns a plain JS object. That object <em>is</em> the game. Everything else reads it; systems mutate it; <code>render()</code> projects it to DOM. (The module also exports a few shared constants and lookup tables — see the file itself.)</p>
-      <p>Keeping state in one place is what makes tests easy to write: seed a state, call a system, assert on the resulting state.</p>
+      <p><code>src/state.js</code>'s central export is a <span class="term" data-term="factory-function">factory</span>, <code>createInitialState()</code>, that returns a plain JS object. That object <em>is</em> the game. Everything else reads it; systems mutate it; <code>render()</code> projects it to DOM. (The module also exports a few shared constants and lookup tables — see the file itself.)</p>
+      <p>Keeping state in one place — a <span class="term" data-term="single-source-of-truth">single source of truth</span> — is what makes tests easy to write: seed a state, call a system, assert on the resulting state.</p>
     `,
     snippets: [
       {
@@ -190,8 +190,8 @@ export function render(state) {
             id: 's1',
             title: 'travel.js — pace, tick, arrival',
             body: `
-              <p><code>src/systems/travel.js</code> owns the per-sol resource tick. It advances the rover by pace-dependent km, consumes power, rations, EVA charges, and decides when the rover arrives at the next landmark.</p>
-              <p>The module is (mostly) pure: given a state and a pace, it returns a new state. That purity is what lets <code>sim/playtest1000.mjs</code> run thousands of simulated runs in a couple of seconds.</p>
+              <p><code>src/systems/travel.js</code> owns the per-<span class="term" data-term="sol">sol</span> resource tick. It advances the rover by pace-dependent km, consumes power, rations, <span class="term" data-term="eva">EVA</span> charges, and decides when the rover arrives at the next landmark.</p>
+              <p>The module is (mostly) <span class="term" data-term="pure-function">pure</span>: given a state and a pace, it returns a new state. That purity is what lets <code>sim/playtest1000.mjs</code> run thousands of simulated runs in a couple of seconds.</p>
             `,
             snippets: [
               {
@@ -345,7 +345,7 @@ export function rollEvent(state) {
             id: 's1',
             title: 'multiStage.js — authored chains',
             body: `
-              <p>A multi-stage event is an authored chain: each choice points to the next stage, or to an outcome. <code>src/systems/multiStage.js</code> is a tiny engine that walks that graph. <code>src/content/multiStageEvents.js</code> (and <code>emergencies.js</code>) are the authored data.</p>
+              <p>A <span class="term" data-term="multi-stage-event">multi-stage event</span> is an authored chain: each choice points to the next stage, or to an outcome. <code>src/systems/multiStage.js</code> is a tiny engine that walks that graph. <code>src/content/multiStageEvents.js</code> (and <code>emergencies.js</code>) are the authored data.</p>
               <p>The medical emergency (hub branch <strong>4</strong>) is the flagship example — a three-stage diagnosis-treatment-disposal chain.</p>
             `,
             snippets: [
@@ -445,7 +445,7 @@ export function getMedicalStageView(state, stageId, context) {
             id: 's2',
             title: 'Live: the mash-rescue UI',
             body: `
-              <p>Click <strong>Start emergency</strong> below to run a seeded medical chain against the real modal renderer. Every click is timed by <code>clickMetrics.recordDecision</code> — the same anti-mashing heuristic the game uses in a live run. Mash the buttons fast and <code>mashScore</code> climbs past the threshold; read carefully and it stays at 0.</p>
+              <p>Click <strong>Start emergency</strong> below to run a seeded medical chain against the real modal renderer. Every click is timed by <code>clickMetrics.recordDecision</code> — the same <span class="term" data-term="anti-mashing">anti-mashing</span> <span class="term" data-term="heuristic">heuristic</span> the game uses in a live run. Mash the buttons fast and <code>mashScore</code> climbs past the threshold; read carefully and it stays at 0.</p>
               <p>This demo imports <code>src/systems/medicalEmergency.js</code>, <code>src/ui/modals.js</code>, and <code>src/systems/clickMetrics.js</code> directly; no mock reimplementation. State is seeded locally and thrown away — nothing leaks into the rest of the tour.</p>
               <div id="demo-mashEmergency-mount"></div>
             `,
@@ -492,7 +492,7 @@ export function getMedicalStageView(state, stageId, context) {
             id: 's1',
             title: 'awayTeam.js — divert and camp',
             body: `
-              <p>Waypoint diverts dispatch an "away team" of 1–3 crew. The rover camps (does not advance km) while authored chains in <code>src/content/awayTeamChains.js</code> fire stage-per-sol. Rewards accumulate on <code>state.awayTeam.accumulated</code> and only land on the rover at reunion.</p>
+              <p><span class="term" data-term="waypoint">Waypoint</span> diverts dispatch an "away team" of 1–3 crew. The rover camps (does not advance km) while authored chains in <code>src/content/awayTeamChains.js</code> fire stage-per-sol. Rewards accumulate on <code>state.awayTeam.accumulated</code> and only land on the rover at reunion.</p>
               <p>Built on the same multi-stage shape as medical emergencies, but with its own resolver because away-team outcomes target the roster (not the full crew) and rewards are deferred.</p>
             `,
             snippets: [
@@ -692,7 +692,7 @@ export function corpseWeight(state) {
             title: 'End-of-run scoring',
             body: `
               <p>When a run ends, <code>scoring.js</code> computes a point total and rank from science collected, sols taken, crew outcome, and resources remaining. Rank is gated by a checklist (issue #24): surviving is C, science + learning earn A, and only a full-crew-returned S-run earns the top mark.</p>
-              <p><code>career.js</code> persists science across runs for the long-term meta-progression — tiered bonuses like skill-check boosts and rover km/sol uplift. Both modules keep their compute functions pure; the only impure corners are the localStorage helpers at the bottom of each file.</p>
+              <p><code>career.js</code> persists science across runs for the long-term meta-progression — tiered bonuses like skill-check boosts and rover km/sol uplift. Both modules keep their compute functions <span class="term" data-term="pure-function">pure</span>; the only impure corners are the <span class="term" data-term="local-storage">localStorage</span> helpers at the bottom of each file.</p>
             `,
             snippets: [
               { path: 'src/systems/scoring.js', lines: [96, 124], caption: 'scoring.js — computeScore breakdown',
@@ -764,7 +764,7 @@ export function corpseWeight(state) {
     id: 'ui',
     title: 'UI layer',
     body: `
-      <p><code>src/ui/modals.js</code> renders event cards, multi-stage dialogs, mash-rescue, codex pages, and so on. It is DOM-heavy but state-light — every modal receives the game state and a dispatch function, and returns nothing. All flow lives in <code>main.js</code>.</p>
+      <p><code>src/ui/modals.js</code> renders event cards, multi-stage dialogs, mash-rescue, codex pages, and so on. It is DOM-heavy but state-light — every modal receives the game state and a <span class="term" data-term="dispatch">dispatch</span> function, and returns nothing. All flow lives in <code>main.js</code>.</p>
       <p><code>src/ui/codex.js</code> handles the in-game encyclopedia of Mars facts that players unlock by playing.</p>
     `,
     snippets: [
@@ -794,7 +794,7 @@ export function corpseWeight(state) {
     id: 'theme',
     title: 'Theme system',
     body: `
-      <p>Three themes (plus Mission Control default): LCARS, Voltron HUD, Last Starfighter. Each is a stylesheet under <code>styles/theme-*.css</code> that overrides a shared set of CSS variables defined in <code>styles/theme.css</code>. <code>src/theme.js</code> is a 68-line switcher that sets <code>data-theme</code> on <code>&lt;body&gt;</code> and remembers the last choice in localStorage.</p>
+      <p>Three themes (plus Mission Control default): LCARS, Voltron HUD, Last Starfighter. Each is a stylesheet under <code>styles/theme-*.css</code> that overrides a shared set of <span class="term" data-term="css-variable">CSS variables</span> defined in <code>styles/theme.css</code>. <code>src/theme.js</code> is a 68-line switcher that sets <code>data-theme</code> on <code>&lt;body&gt;</code> and remembers the last choice in <span class="term" data-term="local-storage">localStorage</span>.</p>
       <p><strong>Live proof:</strong> this slideshow reuses those exact stylesheets. Change the theme dropdown in the top-right right now — every frame, chrome, and demo repaints instantly.</p>
     `,
     snippets: [

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -182,9 +182,218 @@ export function render(state) {
       <p>The game logic lives under <code>src/systems/</code>. Click any tile below to take a short tour of that module and return here. Press <strong>Esc</strong> to come back. Digit keys <strong>1–8</strong> jump to a tile.</p>
     `,
     branches: [
-      { id: 'travel',      label: 'travel.js',                         sub: [{ id: 's1', title: 'travel.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
-      { id: 'events',      label: 'events.js + content/events.js',     sub: [{ id: 's1', title: 'events.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
-      { id: 'multistage',  label: 'multiStage.js + multi-stage events', sub: [{ id: 's1', title: 'multiStage.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
+      {
+        id: 'travel',
+        label: 'travel.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'travel.js — pace, tick, arrival',
+            body: `
+              <p><code>src/systems/travel.js</code> owns the per-sol resource tick. It advances the rover by pace-dependent km, consumes power, rations, EVA charges, and decides when the rover arrives at the next landmark.</p>
+              <p>The module is (mostly) pure: given a state and a pace, it returns a new state. That purity is what lets <code>sim/playtest1000.mjs</code> run thousands of simulated runs in ~10 seconds.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/travel.js',
+                lines: [26, 54],
+                caption: 'Pace-driven tunables',
+                code: `// Tunable per-sol values. Balanced for a ~17-sol clean trek at steady pace.
+
+const KM_PER_SOL = {
+  cautious: 70,
+  steady:   100,
+  push:     150
+};
+
+// ± variance per sol. Cautious is predictable; push swings wide.
+const KM_VARIANCE = {
+  cautious: 0.10,   // ±10%
+  steady:   0.18,   // ±18%
+  push:     0.30    // ±30% — sometimes great, sometimes you hit a rut
+};
+
+const POWER_PER_SOL = {
+  cautious: 2.5,
+  steady:   4.2,
+  push:     5.8
+};
+
+const FOOD_PER_SOL = {
+  meager:   1.0,
+  standard: 2.2,
+  full:     3.2
+};
+
+const O2_PER_SOL  = 2.2;
+const H2O_PER_SOL = 2.2;`,
+              },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'travel.js — the sol tick',
+            body: `
+              <p>The heart of travel is <code>advanceSol()</code>: one function that runs once per "NEXT SOL" button press. It consumes resources, maybe rolls an event, maybe arrives at a landmark, and writes log lines.</p>
+              <p>This excerpt covers the opening: clone-on-write, camp-mode guard, and the km math for a travel sol. Resource drain, arrival handling, and event rolls live further down in the same function.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/travel.js',
+                lines: [96, 132],
+                caption: 'advanceSol — setup and km math',
+                code: `export function advanceSol(state, mode = 'travel') {
+  if (state.status !== 'active') return state;
+
+  // Camp mode: if an away team is out, the rover stays parked at the
+  // detour turn-off. Resources drain and crew damage accrue as usual,
+  // but km/travel/event-rolling are suppressed — the stage modal IS
+  // the event for that sol.
+  if (state.awayTeam && mode === 'travel') mode = 'camp';
+
+  // Shallow clone the branches we'll mutate.
+  let s = { ...state,
+    resources: { ...state.resources },
+    crew: state.crew.map(c => ({ ...c })),
+    log: [...state.log],
+    crewDialogue: null   // clear yesterday's speech bubble
+  };
+
+  s.sol = state.sol + 1;
+  const powerDead = s.resources.power === 0;
+
+  // ---- Travel (skipped on repair/clean/camp sols and when batteries are dead) ----
+  let usableKm = 0;
+  if (mode === 'travel' && !powerDead) {
+    const pilotAlive = s.crew.some(c => c.role === 'pilot' && c.alive);
+    const baseKm     = KM_PER_SOL[s.pace];
+    const variance   = KM_VARIANCE[s.pace] * (pilotAlive ? 1 : NO_PILOT_VARIANCE_MULT);
+    const jitter     = (Math.random() * 2 - 1) * variance;
+    const pilotMult  = pilotAlive ? 1 + PILOT_KM_BONUS : 1;
+    const lbs        = cargoPounds(s);
+    const weightMult = Math.max(0.5, 1 - lbs * CARGO_WEIGHT_SPEED);
+    const kmMult     = state.careerBonuses?.kmMult || 1;
+    const km         = Math.max(0, baseKm * pilotMult * weightMult * kmMult * (1 + jitter));
+    usableKm         = Math.min(km, s.kmToNextLandmark);
+
+    s.totalKmTraveled += usableKm;
+    s.kmToNextLandmark -= usableKm;
+  }`,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'events',
+        label: 'events.js + content/events.js',
+        sub: [
+          {
+            id: 's1',
+            title: 'events.js — rolling an event',
+            body: `
+              <p><code>src/systems/events.js</code> picks which event fires on a given sol, based on pace and per-event weighting. Event <em>data</em> lives separately in <code>src/content/events.js</code>: each entry has a title, body, and a set of choices with effects.</p>
+              <p>This split (system vs. content) is the dominant pattern in the codebase: logic in <code>src/systems/</code>, data in <code>src/content/</code>. Content can grow without touching logic.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/events.js',
+                lines: [23, 45],
+                caption: 'Event selection',
+                code: `// P(event per sol) by pace. Careful driving = fewer incidents.
+const EVENT_BASE_RATE_BY_PACE = {
+  cautious: 0.20,
+  steady:   0.25,
+  push:     0.78
+};
+
+// Pick a random event using weighted selection. One-shot events that have
+// already fired this run are filtered out. Returns an event object or null.
+export function rollEvent(state) {
+  const rate = EVENT_BASE_RATE_BY_PACE[state.pace];
+  if (Math.random() > rate) return null;
+  const fired = state.firedEvents || [];
+  const eligible = EVENTS.filter(e => !(e.oneShot && fired.includes(e.id)));
+  if (eligible.length === 0) return null;
+  const totalWeight = eligible.reduce((sum, e) => sum + e.weight, 0);
+  let r = Math.random() * totalWeight;
+  for (const e of eligible) {
+    r -= e.weight;
+    if (r <= 0) return e;
+  }
+  return eligible[eligible.length - 1];
+}`,
+              },
+            ],
+          },
+          {
+            id: 's2',
+            title: 'Live: a random event card',
+            body: `
+              <p>Here is an event card, rendered by the <em>real</em> modal renderer against data from <code>src/content/events.js</code>. Click "Roll another" to re-roll. Choice buttons are real but don't apply effects — this preview is read-only.</p>
+              <div id="demo-eventPreview-mount"></div>
+            `,
+            demo: 'eventPreview',
+          },
+        ],
+      },
+      {
+        id: 'multistage',
+        label: 'multiStage.js + multi-stage events',
+        sub: [
+          {
+            id: 's1',
+            title: 'multiStage.js — authored chains',
+            body: `
+              <p>A multi-stage event is an authored chain: each choice points to the next stage, or to an outcome. <code>src/systems/multiStage.js</code> is a tiny engine that walks that graph. <code>src/content/multiStageEvents.js</code> (and <code>emergencies.js</code>) are the authored data.</p>
+              <p>The medical emergency (hub branch <strong>4</strong>) is the flagship example — a three-stage diagnosis-treatment-disposal chain.</p>
+            `,
+            snippets: [
+              {
+                path: 'src/systems/multiStage.js',
+                lines: [10, 45],
+                caption: 'Engine shape — resolving a stage choice',
+                code: `// ---- Resolve a chosen option on a given stage ----
+//
+// Returns { state, nextStage, skillResult, damageTarget, applied, returnSolDelta }.
+// state:          new state after outcome application.
+// nextStage:      key of the next stage, or null to end the chain.
+// skillResult:    present when the choice had a skillCheck.
+// returnSolDelta: number to shift an away-team return sol by; 0 for non-away contexts.
+export function applyStageChoice(state, event, stageId, choiceIdx) {
+  const stage  = event.stages[stageId];
+  const choice = stage?.choices[choiceIdx];
+  if (!choice) return { state, nextStage: null, skillResult: null, damageTarget: null, applied: {}, returnSolDelta: 0 };
+
+  let outcome = choice.outcome;
+  let skillResult = null;
+
+  if (choice.skillCheck) {
+    const { role, successP } = choice.skillCheck;
+    const specialistAlive = state.crew.some(c => c.role === role && c.alive);
+    const baseP = specialistAlive ? successP : Math.max(0.2, successP - 0.4);
+    const bonus = state.careerBonuses?.skillBonus || 0;
+    const effectiveP = Math.min(0.95, baseP + bonus);
+    const success = Math.random() < effectiveP;
+    outcome = success ? choice.successOutcome : choice.failOutcome;
+    skillResult = { role, success, specialistAlive };
+  }
+
+  const { state: s, damageTarget, applied } = applyOutcome(state, outcome);
+  return {
+    state: s,
+    nextStage: choice.nextStage ?? null,
+    skillResult,
+    damageTarget,
+    applied,
+    returnSolDelta: choice.returnSolDelta ?? 0
+  };
+}`,
+              },
+            ],
+          },
+        ],
+      },
       { id: 'medical',     label: 'medicalEmergency.js',               sub: [{ id: 's1', title: 'medicalEmergency.js — placeholder', body: '<p>Branch content arrives in Task 12.</p>' }] },
       { id: 'clickmetrics',label: 'clickMetrics.js',                   sub: [{ id: 's1', title: 'clickMetrics.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
       { id: 'awayteam',    label: 'awayTeam.js',                       sub: [{ id: 's1', title: 'awayTeam.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -175,5 +175,22 @@ export function render(state) {
       },
     ],
   },
+  {
+    id: 'hub',
+    title: 'Systems architecture',
+    body: `
+      <p>The game logic lives under <code>src/systems/</code>. Click any tile below to take a short tour of that module and return here. Press <strong>Esc</strong> to come back. Digit keys <strong>1–8</strong> jump to a tile.</p>
+    `,
+    branches: [
+      { id: 'travel',      label: 'travel.js',                         sub: [{ id: 's1', title: 'travel.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
+      { id: 'events',      label: 'events.js + content/events.js',     sub: [{ id: 's1', title: 'events.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
+      { id: 'multistage',  label: 'multiStage.js + multi-stage events', sub: [{ id: 's1', title: 'multiStage.js — placeholder', body: '<p>Branch content arrives in Task 10.</p>' }] },
+      { id: 'medical',     label: 'medicalEmergency.js',               sub: [{ id: 's1', title: 'medicalEmergency.js — placeholder', body: '<p>Branch content arrives in Task 12.</p>' }] },
+      { id: 'clickmetrics',label: 'clickMetrics.js',                   sub: [{ id: 's1', title: 'clickMetrics.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+      { id: 'awayteam',    label: 'awayTeam.js',                       sub: [{ id: 's1', title: 'awayTeam.js — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+      { id: 'smallsys',    label: 'crew / corpse / waypoints',         sub: [{ id: 's1', title: 'Small systems — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+      { id: 'scoring',     label: 'career.js + scoring.js',            sub: [{ id: 's1', title: 'Career & scoring — placeholder', body: '<p>Branch content arrives in Task 13.</p>' }] },
+    ],
+  },
   // Slide 9 (hub) in Task 9, 10–16 in Task 13.
 ];

--- a/docs/walkthrough/slides.js
+++ b/docs/walkthrough/slides.js
@@ -191,7 +191,7 @@ export function render(state) {
             title: 'travel.js — pace, tick, arrival',
             body: `
               <p><code>src/systems/travel.js</code> owns the per-sol resource tick. It advances the rover by pace-dependent km, consumes power, rations, EVA charges, and decides when the rover arrives at the next landmark.</p>
-              <p>The module is (mostly) pure: given a state and a pace, it returns a new state. That purity is what lets <code>sim/playtest1000.mjs</code> run thousands of simulated runs in ~10 seconds.</p>
+              <p>The module is (mostly) pure: given a state and a pace, it returns a new state. That purity is what lets <code>sim/playtest1000.mjs</code> run thousands of simulated runs in a couple of seconds.</p>
             `,
             snippets: [
               {

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -65,7 +65,11 @@
   transition: max-height 0.2s ease;
 }
 
-.tour-snippet.is-open .tour-snippet-body { max-height: 800px; overflow: auto; }
+.tour-snippet.is-open .tour-snippet-body {
+  max-height: 800px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
 
 .tour-snippet pre {
   margin: 0;
@@ -73,9 +77,20 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.85em;
   line-height: 1.45;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
   background: var(--code-bg, #000);
   color: var(--code-fg, inherit);
+}
+
+/* Inline <pre> blocks inside slide prose (e.g. the repo-layout tree) — also wrap. */
+.tour-stage pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .hub-tiles {

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -115,3 +115,17 @@
   margin-bottom: 12px;
   font-family: ui-monospace, monospace;
 }
+
+/* Links inherit the surrounding themed text color instead of browser blue. */
+.tour-stage a,
+.tour-stage a:visited {
+  color: currentColor;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.tour-stage a:hover,
+.tour-stage a:focus {
+  opacity: 0.75;
+  outline: none;
+}

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -29,8 +29,8 @@ body {
 
 .tour-stage {
   flex: 1 1 auto;
-  min-height: 0;        /* required for flex child to actually clip/scroll */
-  overflow-y: auto;
+  min-height: 0;
+  overflow: hidden;       /* stage itself does not scroll; only code blocks do */
   width: 100%;
   max-width: 920px;
   margin: 0 auto;
@@ -79,7 +79,7 @@ body {
 }
 
 .tour-snippet.is-open .tour-snippet-body {
-  max-height: 800px;
+  max-height: min(60vh, 500px);
   overflow-x: hidden;
   overflow-y: auto;
 }

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -30,12 +30,21 @@ body {
 .tour-stage {
   flex: 1 1 auto;
   min-height: 0;
-  overflow: hidden;       /* stage itself does not scroll; only code blocks do */
+  overflow: hidden;
   width: 100%;
   max-width: 920px;
   margin: 0 auto;
   padding: 24px;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.tour-slide {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .tour-nav {
@@ -48,13 +57,27 @@ body {
 .tour-slide h1 { margin-top: 0; }
 .tour-slide p { line-height: 1.5; max-width: 70ch; }
 
-.tour-snippets { margin-top: 16px; }
+.tour-snippets {
+  margin-top: 16px;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
 
 .tour-snippet {
   border: 1px solid var(--panel-border, #0a8);
   border-radius: 4px;
-  margin-bottom: 10px;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 auto;
+  min-height: 0;
+}
+
+.tour-snippet.is-open {
+  flex: 1 1 auto;
 }
 
 .tour-snippet-header {
@@ -79,7 +102,9 @@ body {
 }
 
 .tour-snippet.is-open .tour-snippet-body {
-  max-height: min(60vh, 500px);
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
   overflow-x: hidden;
   overflow-y: auto;
   scrollbar-width: none;        /* Firefox */
@@ -103,23 +128,15 @@ body {
   color: var(--code-fg, inherit);
 }
 
-/* Inline <pre> blocks inside slide prose (e.g. the repo-layout tree) — wrap,
-   and if they'd otherwise exceed the available stage, cap and scroll. */
+/* Inline <pre> blocks in slide prose (e.g. the repo-layout tree). Snippet pre
+   scroll is handled by the surrounding .tour-snippet-body (flex-filled), so
+   this rule just ensures inline pre blocks wrap and never horizontal-scroll. */
 .tour-stage pre {
   white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;
   max-width: 100%;
-  max-height: min(55vh, 460px);
   overflow-x: hidden;
-  overflow-y: auto;
-  padding-bottom: 16px;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-.tour-stage pre::-webkit-scrollbar {
-  display: none;
 }
 
 .hub-tiles {

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -194,8 +194,8 @@
   font: inherit;
   color: currentColor;
   cursor: pointer;
-  text-decoration: underline dotted;
-  text-underline-offset: 3px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .term:hover,
@@ -204,16 +204,11 @@
   outline: none;
 }
 
-.term[aria-expanded="true"] {
-  font-weight: 600;
-}
-
 .term-def {
-  margin: 6px 0 10px 14px;
-  padding: 8px 12px;
-  border-left: 3px solid var(--panel-border, currentColor);
-  opacity: 0.9;
+  margin: 6px 0 10px 0;
+  opacity: 0.85;
   font-size: 0.95em;
+  font-style: italic;
 }
 
 .term-def p:first-child { margin-top: 0; }

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -92,7 +92,7 @@ body {
 
 .tour-snippet pre {
   margin: 0;
-  padding: 10px 12px;
+  padding: 10px 12px 24px;            /* extra bottom padding so last line breathes */
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.85em;
   line-height: 1.45;
@@ -103,13 +103,23 @@ body {
   color: var(--code-fg, inherit);
 }
 
-/* Inline <pre> blocks inside slide prose (e.g. the repo-layout tree) — also wrap. */
+/* Inline <pre> blocks inside slide prose (e.g. the repo-layout tree) — wrap,
+   and if they'd otherwise exceed the available stage, cap and scroll. */
 .tour-stage pre {
   white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;
   max-width: 100%;
+  max-height: min(55vh, 460px);
   overflow-x: hidden;
+  overflow-y: auto;
+  padding-bottom: 16px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.tour-stage pre::-webkit-scrollbar {
+  display: none;
 }
 
 .hub-tiles {

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -34,3 +34,46 @@
 
 .tour-slide h1 { margin-top: 0; }
 .tour-slide p { line-height: 1.5; max-width: 70ch; }
+
+.tour-snippets { margin-top: 16px; }
+
+.tour-snippet {
+  border: 1px solid var(--panel-border, #0a8);
+  border-radius: 4px;
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+
+.tour-snippet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  background: var(--panel-header-bg, rgba(0, 170, 136, 0.1));
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.85em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.tour-snippet-header .tour-snippet-label { font-weight: 600; }
+.tour-snippet-header .tour-snippet-links { display: flex; gap: 10px; font-size: 0.9em; }
+
+.tour-snippet-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease;
+}
+
+.tour-snippet.is-open .tour-snippet-body { max-height: 800px; overflow: auto; }
+
+.tour-snippet pre {
+  margin: 0;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  line-height: 1.45;
+  white-space: pre;
+  background: var(--code-bg, #000);
+  color: var(--code-fg, inherit);
+}

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -185,31 +185,41 @@
   outline: none;
 }
 
-/* Glossary term buttons. Inherit the themed text color. */
-.term {
+/* Glossary term buttons. Beat every theme's generic button styling by using a
+ * specificity high enough to win against `body[data-theme="..."] button {...}`. */
+.tour-stage .term,
+.tour-stage .term:hover,
+.tour-stage .term:focus,
+.tour-stage .term:focus-visible {
   background: none;
+  background-color: transparent;
   border: 0;
+  border-radius: 0;
   padding: 0;
   margin: 0;
   font: inherit;
+  letter-spacing: inherit;
+  text-transform: none;
+  text-shadow: none;
+  box-shadow: none;
   color: currentColor;
   cursor: pointer;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.term:hover,
-.term:focus-visible {
+.tour-stage .term:hover,
+.tour-stage .term:focus-visible {
   opacity: 0.75;
   outline: none;
 }
 
-.term-def {
+.tour-stage .term-def {
   margin: 6px 0 10px 0;
   opacity: 0.85;
   font-size: 0.95em;
   font-style: italic;
 }
 
-.term-def p:first-child { margin-top: 0; }
-.term-def p:last-child  { margin-bottom: 0; }
+.tour-stage .term-def p:first-child { margin-top: 0; }
+.tour-stage .term-def p:last-child  { margin-bottom: 0; }

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -1,0 +1,36 @@
+/* Layout primitives. Colors and decoration come from styles/theme-*.css via CSS vars. */
+
+.tour-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--panel-border, #0a8);
+}
+
+.tour-brand { font-weight: 700; letter-spacing: 0.08em; }
+
+.tour-topbar-right {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.tour-progress { font-size: 0.9em; opacity: 0.85; }
+
+.tour-stage {
+  padding: 24px;
+  max-width: 920px;
+  margin: 0 auto;
+  min-height: calc(100vh - 140px);
+}
+
+.tour-nav {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 24px;
+  border-top: 1px solid var(--panel-border, #0a8);
+}
+
+.tour-slide h1 { margin-top: 0; }
+.tour-slide p { line-height: 1.5; max-width: 70ch; }

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -77,3 +77,41 @@
   background: var(--code-bg, #000);
   color: var(--code-fg, inherit);
 }
+
+.hub-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.hub-tile {
+  padding: 14px;
+  border: 1px solid var(--panel-border, #0a8);
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: ui-monospace, monospace;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  transition: background 0.15s;
+}
+
+.hub-tile:hover, .hub-tile:focus {
+  background: var(--panel-header-bg, rgba(0, 170, 136, 0.15));
+  outline: none;
+}
+
+.hub-tile-key {
+  display: inline-block;
+  font-size: 0.75em;
+  opacity: 0.7;
+  margin-right: 8px;
+}
+
+.tour-breadcrumb {
+  font-size: 0.85em;
+  opacity: 0.75;
+  margin-bottom: 12px;
+  font-family: ui-monospace, monospace;
+}

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -164,42 +164,23 @@
 
 .tour-cta {
   display: inline-block;
-  padding: 14px 28px;
+  padding: 12px 24px;
   font-family: ui-monospace, monospace;
-  font-size: 1.1em;
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  font-size: 1em;
+  font-weight: 600;
+  letter-spacing: 0.1em;
   color: currentColor;
   background: transparent;
-  border: 2px solid currentColor;
+  border: 1px solid currentColor;
   border-radius: 4px;
   text-decoration: none;
   cursor: pointer;
-  animation: tour-cta-pulse 1.8s ease-in-out infinite;
-  transition: transform 0.15s;
+  transition: background 0.15s, transform 0.15s;
 }
 
 .tour-cta:hover,
 .tour-cta:focus-visible {
-  transform: scale(1.03);
+  background: var(--panel-header-bg, rgba(255, 255, 255, 0.08));
+  transform: scale(1.02);
   outline: none;
-  animation-play-state: paused;
-}
-
-@keyframes tour-cta-pulse {
-  0%, 100% {
-    box-shadow: 0 0 4px currentColor, 0 0 8px currentColor;
-    opacity: 1;
-  }
-  50% {
-    box-shadow: 0 0 16px currentColor, 0 0 28px currentColor;
-    opacity: 0.92;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tour-cta {
-    animation: none;
-    box-shadow: 0 0 8px currentColor;
-  }
 }

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -82,6 +82,12 @@ body {
   max-height: min(60vh, 500px);
   overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-width: none;        /* Firefox */
+  -ms-overflow-style: none;     /* legacy Edge / IE */
+}
+
+.tour-snippet-body::-webkit-scrollbar {
+  display: none;                /* WebKit: Safari, Chrome */
 }
 
 .tour-snippet pre {

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -1,5 +1,14 @@
 /* Layout primitives. Colors and decoration come from styles/theme-*.css via CSS vars. */
 
+/* The game's layout.css pins html/body to 100dvh with overflow:hidden on desktop so
+   the dashboard fits the viewport exactly. The tour is a document-flow page and
+   needs normal page scrolling — override that here (tour.css loads last). */
+html, body {
+  overflow: auto;
+  height: auto;
+  min-height: 100dvh;
+}
+
 .tour-topbar {
   display: flex;
   justify-content: space-between;

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -184,3 +184,37 @@
   transform: scale(1.02);
   outline: none;
 }
+
+/* Glossary term buttons. Inherit the themed text color. */
+.term {
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: currentColor;
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+
+.term:hover,
+.term:focus-visible {
+  opacity: 0.75;
+  outline: none;
+}
+
+.term[aria-expanded="true"] {
+  font-weight: 600;
+}
+
+.term-def {
+  margin: 6px 0 10px 14px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--panel-border, currentColor);
+  opacity: 0.9;
+  font-size: 0.95em;
+}
+
+.term-def p:first-child { margin-top: 0; }
+.term-def p:last-child  { margin-bottom: 0; }

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -1,12 +1,12 @@
 /* Layout primitives. Colors and decoration come from styles/theme-*.css via CSS vars. */
 
-/* The game's layout.css pins html/body to 100dvh with overflow:hidden on desktop so
-   the dashboard fits the viewport exactly. The tour is a document-flow page and
-   needs normal page scrolling — override that here (tour.css loads last). */
-html, body {
-  overflow: auto;
-  height: auto;
-  min-height: 100dvh;
+/* Keep the page pinned to the viewport (topbar + footer always visible) and put
+   the scroll inside the main stage. Layout.css already sets html/body to 100dvh
+   with overflow:hidden on desktop; we make body a flex column so the stage can
+   flex:1 and own the overflow. */
+body {
+  display: flex;
+  flex-direction: column;
 }
 
 .tour-topbar {
@@ -28,10 +28,14 @@ html, body {
 .tour-progress { font-size: 0.9em; opacity: 0.85; }
 
 .tour-stage {
-  padding: 24px;
+  flex: 1 1 auto;
+  min-height: 0;        /* required for flex child to actually clip/scroll */
+  overflow-y: auto;
+  width: 100%;
   max-width: 920px;
   margin: 0 auto;
-  min-height: calc(100vh - 140px);
+  padding: 24px;
+  box-sizing: border-box;
 }
 
 .tour-nav {

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -216,9 +216,13 @@
 
 .tour-stage .term-def {
   margin: 6px 0 10px 0;
-  opacity: 0.85;
+  color: #f0ece4;
   font-size: 0.95em;
   font-style: italic;
+}
+
+.tour-stage .term-def code {
+  color: inherit;
 }
 
 .tour-stage .term-def p:first-child { margin-top: 0; }

--- a/docs/walkthrough/tour.css
+++ b/docs/walkthrough/tour.css
@@ -129,3 +129,77 @@
   opacity: 0.75;
   outline: none;
 }
+
+/* Persistent chrome buttons in the topbar (HOME / PLAY GAME). */
+.tour-chrome-btn {
+  display: inline-block;
+  padding: 4px 10px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.85em;
+  letter-spacing: 0.08em;
+  color: currentColor;
+  background: transparent;
+  border: 1px solid var(--panel-border, currentColor);
+  border-radius: 3px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.tour-chrome-btn:hover,
+.tour-chrome-btn:focus-visible {
+  background: var(--panel-header-bg, rgba(255, 255, 255, 0.08));
+  outline: none;
+  opacity: 1;
+}
+
+/* End-slide CTAs — prominent, themed, glow + pulse. */
+.tour-cta-row {
+  display: flex;
+  gap: 18px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 30px 0 10px;
+}
+
+.tour-cta {
+  display: inline-block;
+  padding: 14px 28px;
+  font-family: ui-monospace, monospace;
+  font-size: 1.1em;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: currentColor;
+  background: transparent;
+  border: 2px solid currentColor;
+  border-radius: 4px;
+  text-decoration: none;
+  cursor: pointer;
+  animation: tour-cta-pulse 1.8s ease-in-out infinite;
+  transition: transform 0.15s;
+}
+
+.tour-cta:hover,
+.tour-cta:focus-visible {
+  transform: scale(1.03);
+  outline: none;
+  animation-play-state: paused;
+}
+
+@keyframes tour-cta-pulse {
+  0%, 100% {
+    box-shadow: 0 0 4px currentColor, 0 0 8px currentColor;
+    opacity: 1;
+  }
+  50% {
+    box-shadow: 0 0 16px currentColor, 0 0 28px currentColor;
+    opacity: 0.92;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tour-cta {
+    animation: none;
+    box-shadow: 0 0 8px currentColor;
+  }
+}

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -87,6 +87,25 @@ function renderSnippet(snippet) {
   `;
 }
 
+function renderSlideHtml(slide) {
+  const snippetsHtml = slide.snippets?.length
+    ? `<div class="tour-snippets">${slide.snippets.map(renderSnippet).join('')}</div>`
+    : '';
+  return `
+    <section class="tour-slide">
+      <h1>${slide.title}</h1>
+      ${slide.body}
+      ${snippetsHtml}
+    </section>
+  `;
+}
+
+function wireSnippetToggles(stage) {
+  for (const header of stage.querySelectorAll('[data-snippet-toggle]')) {
+    header.addEventListener('click', () => header.parentElement.classList.toggle('is-open'));
+  }
+}
+
 // Renders a slide into #tour-stage.
 // TRUST BOUNDARY: slide.title, slide.body, slide.snippets[i].path, and
 // slide.snippets[i].caption are interpolated as HTML. The slide manifest
@@ -95,20 +114,9 @@ function renderSnippet(snippet) {
 // Do not route any user-supplied content through this function.
 function render(location) {
   const slide = slideAt(location);
-  const snippetsHtml = slide.snippets?.length
-    ? `<div class="tour-snippets">${slide.snippets.map(renderSnippet).join('')}</div>`
-    : '';
-  document.getElementById('tour-stage').innerHTML = `
-    <section class="tour-slide">
-      <h1>${slide.title}</h1>
-      ${slide.body}
-      ${snippetsHtml}
-    </section>
-  `;
-  // Wire expand/collapse.
-  for (const header of document.querySelectorAll('[data-snippet-toggle]')) {
-    header.addEventListener('click', () => header.parentElement.classList.toggle('is-open'));
-  }
+  const stage = document.getElementById('tour-stage');
+  stage.innerHTML = renderSlideHtml(slide);
+  wireSnippetToggles(stage);
   renderProgress(location);
   mountDemo(slide);
 }

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -10,12 +10,14 @@ const demoLoaders = {
 };
 
 let currentDemoCleanup = null;
+let demoMountEpoch = 0;
 
 async function mountDemo(slide) {
   if (currentDemoCleanup) { currentDemoCleanup(); currentDemoCleanup = null; }
   if (!slide.demo) return;
   const loader = demoLoaders[slide.demo];
   if (!loader) return;
+  const myEpoch = ++demoMountEpoch;
   let mod;
   try {
     mod = await loader();
@@ -23,9 +25,16 @@ async function mountDemo(slide) {
     console.warn(`Demo "${slide.demo}" failed to load:`, err);
     return;
   }
+  if (myEpoch !== demoMountEpoch) return;
   const mount = document.getElementById(`demo-${slide.demo}-mount`);
   if (!mount || typeof mod.init !== 'function') return;
-  const cleanup = mod.init(mount);
+  let cleanup;
+  try {
+    cleanup = mod.init(mount);
+  } catch (err) {
+    console.warn(`Demo "${slide.demo}" init failed:`, err);
+    return;
+  }
   if (typeof cleanup === 'function') currentDemoCleanup = cleanup;
 }
 

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -1,6 +1,7 @@
 import { spine } from './slides.js';
 import { parseHash, hashFor, routeForward, routeBack, routeToSlide } from './router.js';
 import { THEMES, resolveTheme } from '../../src/theme.js';
+import { githubUrl } from './repo.js';
 
 const slides = { spine };
 let current = routeToSlide(parseHash(window.location.hash), slides);
@@ -22,14 +23,57 @@ function renderProgress(location) {
   }
 }
 
+function escapeHtml(s) {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function renderSnippet(snippet) {
+  const [a, b] = snippet.lines || [];
+  const label = `${snippet.path}${a ? ` : ${a}${b && b !== a ? `–${b}` : ''}` : ''}`;
+  const url = githubUrl(snippet.path, a, b);
+  return `
+    <div class="tour-snippet" data-snippet>
+      <div class="tour-snippet-header" data-snippet-toggle>
+        <span class="tour-snippet-label">${escapeHtml(label)}${snippet.caption ? ` — ${escapeHtml(snippet.caption)}` : ''}</span>
+        <span class="tour-snippet-links">
+          <a href="${url}" target="_blank" rel="noopener">View on GitHub ↗</a>
+          <span class="tour-snippet-chevron">▾</span>
+        </span>
+      </div>
+      <div class="tour-snippet-body">
+        <pre><code>${escapeHtml(snippet.code)}</code></pre>
+      </div>
+    </div>
+  `;
+}
+
+// Renders a slide into #tour-stage.
+// TRUST BOUNDARY: slide.title, slide.body, slide.snippets[i].path, and
+// slide.snippets[i].caption are interpolated as HTML. The slide manifest
+// (slides.js, authored in-repo) is trusted. Snippet code is escaped via
+// escapeHtml because it contains literal source with '<', '&', etc.
+// Do not route any user-supplied content through this function.
 function render(location) {
   const slide = slideAt(location);
+  const snippetsHtml = slide.snippets?.length
+    ? `<div class="tour-snippets">${slide.snippets.map(renderSnippet).join('')}</div>`
+    : '';
   document.getElementById('tour-stage').innerHTML = `
     <section class="tour-slide">
       <h1>${slide.title}</h1>
       ${slide.body}
+      ${snippetsHtml}
     </section>
   `;
+  // Wire expand/collapse.
+  for (const header of document.querySelectorAll('[data-snippet-toggle]')) {
+    header.addEventListener('click', () => header.parentElement.classList.toggle('is-open'));
+  }
   renderProgress(location);
 }
 

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -54,7 +54,11 @@ function renderProgress(location) {
   if (location.kind === 'spine') {
     el.textContent = `SPINE ${location.index + 1} / ${slides.spine.length}`;
   } else {
-    el.textContent = `HUB › ${location.branchId} › ${location.subIndex + 1}`;
+    const hub = slides.spine.find(s => s.id === 'hub');
+    const branch = hub?.branches.find(b => b.id === location.branchId);
+    const label = branch?.label ?? location.branchId;
+    const total = branch?.sub.length ?? 1;
+    el.textContent = `HUB › ${label} › ${location.subIndex + 1} / ${total}`;
   }
 }
 
@@ -102,9 +106,9 @@ function renderHubTiles(branches) {
 function renderBreadcrumb(location) {
   if (location.kind !== 'branch') return '';
   const hub = slides.spine.find(s => s.id === 'hub');
-  const branch = hub.branches.find(b => b.id === location.branchId);
-  const total = branch ? branch.sub.length : 1;
-  return `<div class="tour-breadcrumb">HUB › ${escapeHtml(location.branchId)} › ${location.subIndex + 1} / ${total}</div>`;
+  const branch = hub?.branches.find(b => b.id === location.branchId);
+  if (!branch) return '';
+  return `<div class="tour-breadcrumb">HUB › ${escapeHtml(branch.label)} › ${location.subIndex + 1} / ${branch.sub.length}</div>`;
 }
 
 function renderSlideHtml(slide, location) {

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -144,6 +144,12 @@ function wireHubTiles(stage) {
   }
 }
 
+function wireCtas(stage) {
+  for (const btn of stage.querySelectorAll('[data-action="restart"]')) {
+    btn.addEventListener('click', () => go({ kind: 'spine', index: 0 }));
+  }
+}
+
 // Renders a slide into #tour-stage.
 // TRUST BOUNDARY: slide.title, slide.body, slide.snippets[i].path, and
 // slide.snippets[i].caption are interpolated as HTML. The slide manifest
@@ -156,6 +162,7 @@ function render(location) {
   stage.innerHTML = renderSlideHtml(slide, location);
   wireSnippetToggles(stage);
   wireHubTiles(stage);
+  wireCtas(stage);
   renderProgress(location);
   mountDemo(slide);
 }
@@ -191,6 +198,7 @@ function onKey(e) {
 document.addEventListener('keydown', onKey);
 document.getElementById('tour-next').addEventListener('click', () => go(routeForward(current, slides)));
 document.getElementById('tour-prev').addEventListener('click', () => go(routeBack(current, slides)));
+document.getElementById('tour-home')?.addEventListener('click', () => go({ kind: 'spine', index: 0 }));
 window.addEventListener('hashchange', () => {
   current = routeToSlide(parseHash(window.location.hash), slides);
   render(current);

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -99,7 +99,7 @@ function renderHubTiles(branches) {
   `;
 }
 
-function renderBreadcrumb(location, slides) {
+function renderBreadcrumb(location) {
   if (location.kind !== 'branch') return '';
   const hub = slides.spine.find(s => s.id === 'hub');
   const branch = hub.branches.find(b => b.id === location.branchId);
@@ -114,7 +114,7 @@ function renderSlideHtml(slide, location) {
   const hubTilesHtml = (location.kind === 'spine' && slide.id === 'hub')
     ? renderHubTiles(slide.branches)
     : '';
-  const breadcrumbHtml = renderBreadcrumb(location, slides);
+  const breadcrumbHtml = renderBreadcrumb(location);
   return `
     <section class="tour-slide">
       ${breadcrumbHtml}

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -1,0 +1,13 @@
+import { spine } from './slides.js';
+
+function renderSlide(slide) {
+  const stage = document.getElementById('tour-stage');
+  stage.innerHTML = `
+    <section class="tour-slide">
+      <h1>${slide.title}</h1>
+      ${slide.body}
+    </section>
+  `;
+}
+
+renderSlide(spine[0]);

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -87,14 +87,40 @@ function renderSnippet(snippet) {
   `;
 }
 
-function renderSlideHtml(slide) {
+function renderHubTiles(branches) {
+  return `
+    <div class="hub-tiles" role="navigation" aria-label="Systems">
+      ${branches.map((b, i) => `
+        <button class="hub-tile" data-branch-id="${escapeHtml(b.id)}" type="button">
+          <span class="hub-tile-key">${i + 1}</span>${escapeHtml(b.label)}
+        </button>
+      `).join('')}
+    </div>
+  `;
+}
+
+function renderBreadcrumb(location, slides) {
+  if (location.kind !== 'branch') return '';
+  const hub = slides.spine.find(s => s.id === 'hub');
+  const branch = hub.branches.find(b => b.id === location.branchId);
+  const total = branch ? branch.sub.length : 1;
+  return `<div class="tour-breadcrumb">HUB › ${escapeHtml(location.branchId)} › ${location.subIndex + 1} / ${total}</div>`;
+}
+
+function renderSlideHtml(slide, location) {
   const snippetsHtml = slide.snippets?.length
     ? `<div class="tour-snippets">${slide.snippets.map(renderSnippet).join('')}</div>`
     : '';
+  const hubTilesHtml = (location.kind === 'spine' && slide.id === 'hub')
+    ? renderHubTiles(slide.branches)
+    : '';
+  const breadcrumbHtml = renderBreadcrumb(location, slides);
   return `
     <section class="tour-slide">
+      ${breadcrumbHtml}
       <h1>${slide.title}</h1>
       ${slide.body}
+      ${hubTilesHtml}
       ${snippetsHtml}
     </section>
   `;
@@ -103,6 +129,14 @@ function renderSlideHtml(slide) {
 function wireSnippetToggles(stage) {
   for (const header of stage.querySelectorAll('[data-snippet-toggle]')) {
     header.addEventListener('click', () => header.parentElement.classList.toggle('is-open'));
+  }
+}
+
+function wireHubTiles(stage) {
+  for (const tile of stage.querySelectorAll('.hub-tile')) {
+    tile.addEventListener('click', () => {
+      go({ kind: 'branch', branchId: tile.dataset.branchId, subIndex: 0 });
+    });
   }
 }
 
@@ -115,8 +149,9 @@ function wireSnippetToggles(stage) {
 function render(location) {
   const slide = slideAt(location);
   const stage = document.getElementById('tour-stage');
-  stage.innerHTML = renderSlideHtml(slide);
+  stage.innerHTML = renderSlideHtml(slide, location);
   wireSnippetToggles(stage);
+  wireHubTiles(stage);
   renderProgress(location);
   mountDemo(slide);
 }
@@ -131,10 +166,22 @@ function go(nextLocation) {
 }
 
 function onKey(e) {
-  if (e.key === 'ArrowRight')      go(routeForward(current, slides));
-  else if (e.key === 'ArrowLeft')  go(routeBack(current, slides));
-  else if (e.key === 'Home')       go({ kind: 'spine', index: 0 });
-  else if (e.key === 'End')        go({ kind: 'spine', index: slides.spine.length - 1 });
+  if (e.key === 'ArrowRight')      return go(routeForward(current, slides));
+  if (e.key === 'ArrowLeft')       return go(routeBack(current, slides));
+  if (e.key === 'Home')            return go({ kind: 'spine', index: 0 });
+  if (e.key === 'End')             return go({ kind: 'spine', index: slides.spine.length - 1 });
+  if (e.key === 'Escape' && current.kind === 'branch') {
+    const hubIdx = slides.spine.findIndex(s => s.id === 'hub');
+    return go({ kind: 'spine', index: hubIdx });
+  }
+  // Digit 1–9 on hub → open corresponding branch.
+  if (current.kind === 'spine' && slideAt(current).id === 'hub' && /^[1-9]$/.test(e.key)) {
+    const hub = slides.spine.find(s => s.id === 'hub');
+    const idx = Number(e.key) - 1;
+    if (idx < hub.branches.length) {
+      return go({ kind: 'branch', branchId: hub.branches[idx].id, subIndex: 0 });
+    }
+  }
 }
 
 document.addEventListener('keydown', onKey);

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -1,13 +1,59 @@
 import { spine } from './slides.js';
+import { parseHash, hashFor, routeForward, routeBack, routeToSlide } from './router.js';
 
-function renderSlide(slide) {
-  const stage = document.getElementById('tour-stage');
-  stage.innerHTML = `
+const slides = { spine };
+let current = routeToSlide(parseHash(window.location.hash), slides);
+
+function slideAt(location) {
+  if (location.kind === 'spine') return slides.spine[location.index];
+  const hub = slides.spine.find(s => s.id === 'hub');
+  const branch = hub.branches.find(b => b.id === location.branchId);
+  return branch.sub[location.subIndex];
+}
+
+function renderProgress(location) {
+  const el = document.getElementById('tour-progress');
+  if (!el) return;
+  if (location.kind === 'spine') {
+    el.textContent = `SPINE ${location.index + 1} / ${slides.spine.length}`;
+  } else {
+    el.textContent = `HUB › ${location.branchId} › ${location.subIndex + 1}`;
+  }
+}
+
+function render(location) {
+  const slide = slideAt(location);
+  document.getElementById('tour-stage').innerHTML = `
     <section class="tour-slide">
       <h1>${slide.title}</h1>
       ${slide.body}
     </section>
   `;
+  renderProgress(location);
 }
 
-renderSlide(spine[0]);
+function go(nextLocation) {
+  current = nextLocation;
+  const hash = hashFor(nextLocation);
+  if (window.location.hash !== hash) {
+    window.history.pushState(null, '', hash);
+  }
+  render(current);
+}
+
+function onKey(e) {
+  if (e.key === 'ArrowRight')      go(routeForward(current, slides));
+  else if (e.key === 'ArrowLeft')  go(routeBack(current, slides));
+  else if (e.key === 'Home')       go({ kind: 'spine', index: 0 });
+  else if (e.key === 'End')        go({ kind: 'spine', index: slides.spine.length - 1 });
+}
+
+document.addEventListener('keydown', onKey);
+document.getElementById('tour-next').addEventListener('click', () => go(routeForward(current, slides)));
+document.getElementById('tour-prev').addEventListener('click', () => go(routeBack(current, slides)));
+window.addEventListener('hashchange', () => {
+  current = routeToSlide(parseHash(window.location.hash), slides);
+  render(current);
+});
+
+render(current);

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -58,7 +58,10 @@ window.addEventListener('hashchange', () => {
 });
 
 function initTourTheme() {
-  const select = document.getElementById('theme-select');
+  // Uses a distinct id ('tour-theme-select') so src/theme.js's module-top initTheme()
+  // — which getElementById('theme-select')s and binds a localStorage-writing change
+  // listener — doesn't attach to the tour dropdown. Tour theme is session-only.
+  const select = document.getElementById('tour-theme-select');
   if (!select) return;
   select.innerHTML = '';
   for (const t of THEMES) {

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -1,5 +1,6 @@
 import { spine } from './slides.js';
 import { parseHash, hashFor, routeForward, routeBack, routeToSlide } from './router.js';
+import { THEMES, resolveTheme } from '../../src/theme.js';
 
 const slides = { spine };
 let current = routeToSlide(parseHash(window.location.hash), slides);
@@ -55,5 +56,27 @@ window.addEventListener('hashchange', () => {
   current = routeToSlide(parseHash(window.location.hash), slides);
   render(current);
 });
+
+function initTourTheme() {
+  const select = document.getElementById('theme-select');
+  if (!select) return;
+  select.innerHTML = '';
+  for (const t of THEMES) {
+    const opt = document.createElement('option');
+    opt.value = t.id;
+    opt.textContent = t.label;
+    select.appendChild(opt);
+  }
+  const applyTheme = (raw) => {
+    const theme = resolveTheme(raw);
+    if (theme === 'mc') document.body.removeAttribute('data-theme');
+    else document.body.setAttribute('data-theme', theme);
+    select.value = theme;
+  };
+  applyTheme('mc'); // slideshow always starts in mc; tour does NOT read localStorage
+  select.addEventListener('change', (e) => applyTheme(e.target.value));
+}
+
+initTourTheme();
 
 render(current);

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -145,12 +145,6 @@ function wireHubTiles(stage) {
   }
 }
 
-function wireCtas(stage) {
-  for (const btn of stage.querySelectorAll('[data-action="restart"]')) {
-    btn.addEventListener('click', () => go({ kind: 'spine', index: 0 }));
-  }
-}
-
 // Promote authored <span class="term" data-term="slug"> markers to interactive
 // buttons that toggle an inline definition pane. GLOSSARY.def is trusted HTML.
 function wireGlossaryTerms(stage) {
@@ -203,7 +197,6 @@ function render(location) {
   stage.innerHTML = renderSlideHtml(slide, location);
   wireSnippetToggles(stage);
   wireHubTiles(stage);
-  wireCtas(stage);
   wireGlossaryTerms(stage);
   renderProgress(location);
   mountDemo(slide);

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -2,6 +2,7 @@ import { spine } from './slides.js';
 import { parseHash, hashFor, routeForward, routeBack, routeToSlide } from './router.js';
 import { THEMES, resolveTheme } from '../../src/theme.js';
 import { githubUrl } from './repo.js';
+import { GLOSSARY } from './glossary.js';
 
 const demoLoaders = {
   loop:          () => import('./demos/loop.js'),
@@ -150,6 +151,46 @@ function wireCtas(stage) {
   }
 }
 
+// Promote authored <span class="term" data-term="slug"> markers to interactive
+// buttons that toggle an inline definition pane. GLOSSARY.def is trusted HTML.
+function wireGlossaryTerms(stage) {
+  let counter = 0;
+  for (const span of stage.querySelectorAll('span.term[data-term]')) {
+    const slug = span.dataset.term;
+    const entry = GLOSSARY[slug];
+    if (!entry) {
+      console.warn(`Unknown term: "${slug}" — check data-term against glossary.js`);
+      continue;
+    }
+    const defId = `term-def-${slug}-${++counter}`;
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'term';
+    button.dataset.term = slug;
+    button.setAttribute('aria-expanded', 'false');
+    button.setAttribute('aria-controls', defId);
+    button.textContent = span.textContent;
+    span.replaceWith(button);
+
+    button.addEventListener('click', () => {
+      const isOpen = button.getAttribute('aria-expanded') === 'true';
+      if (isOpen) {
+        const existing = document.getElementById(defId);
+        if (existing) existing.remove();
+        button.setAttribute('aria-expanded', 'false');
+        return;
+      }
+      const def = document.createElement('div');
+      def.className = 'term-def';
+      def.id = defId;
+      def.setAttribute('role', 'region');
+      def.innerHTML = entry.def;
+      button.insertAdjacentElement('afterend', def);
+      button.setAttribute('aria-expanded', 'true');
+    });
+  }
+}
+
 // Renders a slide into #tour-stage.
 // TRUST BOUNDARY: slide.title, slide.body, slide.snippets[i].path, and
 // slide.snippets[i].caption are interpolated as HTML. The slide manifest
@@ -163,6 +204,7 @@ function render(location) {
   wireSnippetToggles(stage);
   wireHubTiles(stage);
   wireCtas(stage);
+  wireGlossaryTerms(stage);
   renderProgress(location);
   mountDemo(slide);
 }

--- a/docs/walkthrough/tour.js
+++ b/docs/walkthrough/tour.js
@@ -3,6 +3,32 @@ import { parseHash, hashFor, routeForward, routeBack, routeToSlide } from './rou
 import { THEMES, resolveTheme } from '../../src/theme.js';
 import { githubUrl } from './repo.js';
 
+const demoLoaders = {
+  loop:          () => import('./demos/loop.js'),
+  eventPreview:  () => import('./demos/eventPreview.js'),     // wired in Task 11
+  mashEmergency: () => import('./demos/mashEmergency.js'),    // wired in Task 12
+};
+
+let currentDemoCleanup = null;
+
+async function mountDemo(slide) {
+  if (currentDemoCleanup) { currentDemoCleanup(); currentDemoCleanup = null; }
+  if (!slide.demo) return;
+  const loader = demoLoaders[slide.demo];
+  if (!loader) return;
+  let mod;
+  try {
+    mod = await loader();
+  } catch (err) {
+    console.warn(`Demo "${slide.demo}" failed to load:`, err);
+    return;
+  }
+  const mount = document.getElementById(`demo-${slide.demo}-mount`);
+  if (!mount || typeof mod.init !== 'function') return;
+  const cleanup = mod.init(mount);
+  if (typeof cleanup === 'function') currentDemoCleanup = cleanup;
+}
+
 const slides = { spine };
 let current = routeToSlide(parseHash(window.location.hash), slides);
 
@@ -75,6 +101,7 @@ function render(location) {
     header.addEventListener('click', () => header.parentElement.classList.toggle('is-open'));
   }
   renderProgress(location);
+  mountDemo(slide);
 }
 
 function go(nextLocation) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "type": "module",
   "private": true,
-  "version": "0.9.2"
+  "version": "0.10.0"
 }

--- a/sim/walkthroughRouter.test.mjs
+++ b/sim/walkthroughRouter.test.mjs
@@ -6,6 +6,7 @@ import {
   hashFor,
   routeForward,
   routeBack,
+  routeToSlide,
 } from '../docs/walkthrough/router.js';
 
 // Minimal slide set used by all tests.
@@ -37,8 +38,32 @@ test('parseHash returns branch location for branch hash', () => {
 
 test('parseHash clamps invalid input to spine index 0', () => {
   assert.deepEqual(parseHash('#gibberish'),  { kind: 'spine', index: 0 });
-  assert.deepEqual(parseHash('#slide-999'),  { kind: 'spine', index: 0 });
   assert.deepEqual(parseHash('#slide--1'),   { kind: 'spine', index: 0 });
+});
+
+test('routeToSlide clamps out-of-range spine index to 0', () => {
+  assert.deepEqual(
+    routeToSlide({ kind: 'spine', index: 999 }, slides),
+    { kind: 'spine', index: 0 }
+  );
+  assert.deepEqual(
+    routeToSlide({ kind: 'spine', index: -1 }, slides),
+    { kind: 'spine', index: 0 }
+  );
+});
+
+test('routeToSlide falls back to spine 0 when branchId is unknown', () => {
+  assert.deepEqual(
+    routeToSlide({ kind: 'branch', branchId: 'missing', subIndex: 0 }, slides),
+    { kind: 'spine', index: 0 }
+  );
+});
+
+test('routeToSlide clamps out-of-range subIndex to 0 inside its branch', () => {
+  assert.deepEqual(
+    routeToSlide({ kind: 'branch', branchId: 'travel', subIndex: 99 }, slides),
+    { kind: 'branch', branchId: 'travel', subIndex: 0 }
+  );
 });
 
 test('hashFor round-trips a spine location', () => {

--- a/sim/walkthroughRouter.test.mjs
+++ b/sim/walkthroughRouter.test.mjs
@@ -1,0 +1,101 @@
+// Unit tests for docs/walkthrough/router.js. Run: node --test sim/walkthroughRouter.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseHash,
+  hashFor,
+  routeForward,
+  routeBack,
+} from '../docs/walkthrough/router.js';
+
+// Minimal slide set used by all tests.
+const slides = {
+  spine: [
+    { id: 'welcome' },
+    { id: 'pitch' },
+    {
+      id: 'hub',
+      branches: [
+        { id: 'travel', sub: [{ id: 's1' }, { id: 's2' }] },
+        { id: 'events', sub: [{ id: 's1' }] },
+      ],
+    },
+    { id: 'credits' },
+  ],
+};
+
+test('parseHash returns spine location for empty / slide hash', () => {
+  assert.deepEqual(parseHash(''),        { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide-0'), { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide-2'), { kind: 'spine', index: 2 });
+});
+
+test('parseHash returns branch location for branch hash', () => {
+  assert.deepEqual(parseHash('#branch-travel-0'), { kind: 'branch', branchId: 'travel', subIndex: 0 });
+  assert.deepEqual(parseHash('#branch-events-0'), { kind: 'branch', branchId: 'events', subIndex: 0 });
+});
+
+test('parseHash clamps invalid input to spine index 0', () => {
+  assert.deepEqual(parseHash('#gibberish'),  { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide-999'),  { kind: 'spine', index: 0 });
+  assert.deepEqual(parseHash('#slide--1'),   { kind: 'spine', index: 0 });
+});
+
+test('hashFor round-trips a spine location', () => {
+  assert.equal(hashFor({ kind: 'spine', index: 0 }), '#slide-0');
+  assert.equal(hashFor({ kind: 'spine', index: 3 }), '#slide-3');
+});
+
+test('hashFor round-trips a branch location', () => {
+  assert.equal(hashFor({ kind: 'branch', branchId: 'travel', subIndex: 1 }), '#branch-travel-1');
+});
+
+test('routeForward on spine advances to next spine slide', () => {
+  assert.deepEqual(
+    routeForward({ kind: 'spine', index: 0 }, slides),
+    { kind: 'spine', index: 1 }
+  );
+});
+
+test('routeForward on last spine slide is a no-op', () => {
+  assert.deepEqual(
+    routeForward({ kind: 'spine', index: 3 }, slides),
+    { kind: 'spine', index: 3 }
+  );
+});
+
+test('routeForward on last sub-slide of a branch returns to hub', () => {
+  // hub is index 2 in the slides spine above
+  assert.deepEqual(
+    routeForward({ kind: 'branch', branchId: 'travel', subIndex: 1 }, slides),
+    { kind: 'spine', index: 2 }
+  );
+});
+
+test('routeForward inside a multi-sub branch advances sub-index', () => {
+  assert.deepEqual(
+    routeForward({ kind: 'branch', branchId: 'travel', subIndex: 0 }, slides),
+    { kind: 'branch', branchId: 'travel', subIndex: 1 }
+  );
+});
+
+test('routeBack on first spine slide is a no-op', () => {
+  assert.deepEqual(
+    routeBack({ kind: 'spine', index: 0 }, slides),
+    { kind: 'spine', index: 0 }
+  );
+});
+
+test('routeBack on first sub-slide of a branch returns to hub', () => {
+  assert.deepEqual(
+    routeBack({ kind: 'branch', branchId: 'travel', subIndex: 0 }, slides),
+    { kind: 'spine', index: 2 }
+  );
+});
+
+test('routeBack inside a multi-sub branch decrements sub-index', () => {
+  assert.deepEqual(
+    routeBack({ kind: 'branch', branchId: 'travel', subIndex: 1 }, slides),
+    { kind: 'branch', branchId: 'travel', subIndex: 0 }
+  );
+});

--- a/sim/walkthroughSmoke.test.mjs
+++ b/sim/walkthroughSmoke.test.mjs
@@ -1,0 +1,78 @@
+// Smoke test for the code-tour demos.
+// Asserts each demo module imports cleanly under Node and exposes the expected surface.
+// Does NOT exercise DOM behavior — only catches import-path drift and top-level export rot.
+//
+// Run: node --test sim/walkthroughSmoke.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Install a minimal DOM shim for modules that touch document at import time.
+if (typeof globalThis.document === 'undefined') {
+  globalThis.document = {
+    createElement: () => ({ style: {}, appendChild() {}, addEventListener() {}, setAttribute() {}, removeAttribute() {}, querySelectorAll: () => [], classList: { add() {}, remove() {}, toggle() {} } }),
+    getElementById: () => null,
+    addEventListener: () => {},
+    querySelectorAll: () => [],
+    body: { setAttribute() {}, removeAttribute() {}, appendChild() {} },
+  };
+}
+if (typeof globalThis.window === 'undefined') {
+  globalThis.window = { location: { hash: '' }, history: { pushState() {} }, addEventListener() {} };
+}
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = { getItem: () => null, setItem() {} };
+}
+
+test('loop demo module imports and exposes init()', async () => {
+  const mod = await import('../docs/walkthrough/demos/loop.js');
+  assert.equal(typeof mod.init, 'function');
+});
+
+test('eventPreview demo module imports, exposes init() and its documented export constant', async () => {
+  const mod = await import('../docs/walkthrough/demos/eventPreview.js');
+  assert.equal(typeof mod.init, 'function');
+  assert.equal(typeof mod.REQUIRED_MODAL_EXPORT, 'string');
+  assert.ok(mod.REQUIRED_MODAL_EXPORT.length > 0);
+});
+
+test('mashEmergency demo module imports, exposes init() and its documented export constants', async () => {
+  const mod = await import('../docs/walkthrough/demos/mashEmergency.js');
+  assert.equal(typeof mod.init, 'function');
+  assert.ok(Array.isArray(mod.REQUIRED_MEDICAL_EXPORTS));
+  assert.ok(mod.REQUIRED_MEDICAL_EXPORTS.every(k => typeof k === 'string' && k.length > 0));
+  assert.equal(typeof mod.REQUIRED_MODAL_EXPORT, 'string');
+});
+
+test('eventPreview declared modal export exists on src/ui/modals.js', async () => {
+  const demo = await import('../docs/walkthrough/demos/eventPreview.js');
+  const modals = await import('../src/ui/modals.js');
+  assert.equal(
+    typeof modals[demo.REQUIRED_MODAL_EXPORT],
+    'function',
+    `src/ui/modals.js must export ${demo.REQUIRED_MODAL_EXPORT}; update either the source or demos/eventPreview.js.`
+  );
+});
+
+test('mashEmergency declared exports exist on their source modules', async () => {
+  const demo = await import('../docs/walkthrough/demos/mashEmergency.js');
+  const med = await import('../src/systems/medicalEmergency.js');
+  for (const k of demo.REQUIRED_MEDICAL_EXPORTS) {
+    // REQUIRED_MEDICAL_EXPORTS mixes functions (beginMedicalEmergency,
+    // resolveMedicalStage, getMedicalStageView) with a string constant
+    // (MEDICAL_EMERGENCY_ID). Asserting `!== 'undefined'` catches
+    // import-path rot — which is all this smoke test needs to do —
+    // without forcing the test to know each name's kind.
+    assert.notEqual(
+      typeof med[k],
+      'undefined',
+      `src/systems/medicalEmergency.js must export ${k} (function or value); update either source or demos/mashEmergency.js.`
+    );
+  }
+  const modals = await import('../src/ui/modals.js');
+  assert.equal(
+    typeof modals[demo.REQUIRED_MODAL_EXPORT],
+    'function',
+    `src/ui/modals.js must export ${demo.REQUIRED_MODAL_EXPORT}.`
+  );
+});

--- a/sim/walkthroughSmoke.test.mjs
+++ b/sim/walkthroughSmoke.test.mjs
@@ -76,3 +76,29 @@ test('mashEmergency declared exports exist on their source modules', async () =>
     `src/ui/modals.js must export ${demo.REQUIRED_MODAL_EXPORT}.`
   );
 });
+
+test('glossary module imports and exposes a non-empty GLOSSARY object', async () => {
+  const mod = await import('../docs/walkthrough/glossary.js');
+  assert.equal(typeof mod.GLOSSARY, 'object');
+  assert.ok(mod.GLOSSARY !== null);
+  const keys = Object.keys(mod.GLOSSARY);
+  assert.ok(keys.length > 0, 'GLOSSARY must have at least one entry');
+});
+
+test('every glossary entry has non-empty term + def strings', async () => {
+  const { GLOSSARY } = await import('../docs/walkthrough/glossary.js');
+  for (const [slug, entry] of Object.entries(GLOSSARY)) {
+    assert.equal(typeof entry.term, 'string', `${slug}: term must be a string`);
+    assert.ok(entry.term.length > 0, `${slug}: term must be non-empty`);
+    assert.equal(typeof entry.def, 'string', `${slug}: def must be a string`);
+    assert.ok(entry.def.length > 0, `${slug}: def must be non-empty`);
+  }
+});
+
+test('every glossary slug is kebab-case (lowercase letters, digits, hyphens)', async () => {
+  const { GLOSSARY } = await import('../docs/walkthrough/glossary.js');
+  const kebab = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+  for (const slug of Object.keys(GLOSSARY)) {
+    assert.match(slug, kebab, `${slug} is not kebab-case`);
+  }
+});

--- a/styles/components.css
+++ b/styles/components.css
@@ -979,4 +979,17 @@ body[data-theme="lcars"] .eor-col-facts {
   display: block;
   width: 100%;
   margin: 0.75rem 0 1rem;
+  animation: mission-cta-pulse 1.8s ease-in-out infinite;
+}
+
+.eor-new-rank:hover,
+.eor-new-rank:focus-visible {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eor-new-rank {
+    animation: none;
+    box-shadow: 0 0 10px currentColor;
+  }
 }

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -282,12 +282,30 @@ body[data-theme="lcars"] .modal-severity.severity-away-team {
   box-shadow: var(--glow);
   cursor: pointer;
   margin-bottom: 48px;
-  transition: background 120ms, box-shadow 120ms;
+  transition: background 120ms, box-shadow 120ms, transform 120ms;
+  animation: mission-cta-pulse 1.8s ease-in-out infinite;
 }
 
 .title-start:hover {
   background: rgba(0, 255, 100, 0.18);
   box-shadow: var(--glow-strong);
+  animation-play-state: paused;
+}
+
+@keyframes mission-cta-pulse {
+  0%, 100% {
+    box-shadow: 0 0 6px currentColor, 0 0 10px currentColor;
+  }
+  50% {
+    box-shadow: 0 0 18px currentColor, 0 0 32px currentColor;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .title-start {
+    animation: none;
+    box-shadow: 0 0 10px currentColor;
+  }
 }
 
 .title-credits {


### PR DESCRIPTION
## Summary
- Standalone theme-toggleable HTML slideshow at `docs/walkthrough/index.html` walks programmer-literate readers through the Mars Trail codebase in ~15 minutes.
- 16-slide linear spine + hub slide with 8 clickable branches (travel, events, multistage, medical, clickmetrics, awayteam, smallsys, scoring).
- Three live demos import real game modules: animated game-loop diagram, read-only event-card preview (`src/content/events.js` + `src/ui/modals.js`), and mash-rescue UI (`src/systems/medicalEmergency.js` + `src/ui/modals.js` + `src/systems/clickMetrics.js`).
- Reuses the game's own `theme.css`, `layout.css`, `components.css`, `modals.css`, and per-theme stylesheets — the tour doubles as a live demo of the theme system.
- Pure router helpers unit-tested (`sim/walkthroughRouter.test.mjs`, 15 tests) and a demo-import smoke test (`sim/walkthroughSmoke.test.mjs`, 5 tests) guard against import-path rot.
- Full sim suite: 116 baseline + 20 new = 136 passing.
- No game source files touched — only additions under `docs/walkthrough/`, `sim/`, and a new root `README.md` linking to the tour.

Spec: `docs/superpowers/specs/2026-04-21-code-tour-slideshow-design.md`
Plan: `docs/superpowers/plans/2026-04-21-code-tour-slideshow.md`

## Test Plan
- [ ] `node --test sim/*.test.mjs` — expect 136 passing, 0 failing
- [ ] Open `docs/walkthrough/index.html` in a browser
- [ ] Click through the 16-slide spine end-to-end with NEXT / ← → keys
- [ ] Open each of the 8 hub branches; confirm Esc returns to hub and branch sub-slides advance to hub on last-slide NEXT
- [ ] Trigger each live demo: game-loop animation (slide 5), random event card (hub branch 2 → sub 2, "Roll another"), mash rescue (hub branch 4 → sub 2, "Start emergency")
- [ ] Switch each of the 4 themes via the top-right dropdown; confirm chrome and demos repaint
- [ ] Deep-link: open `.../index.html#slide-7` and `.../index.html#branch-medical-1` — both route correctly on load
- [ ] After tour theme changes, confirm the game's `marsTrail.theme` in localStorage is NOT overwritten (reload the game at `index.html` — it should still be in whatever theme was last saved there)

Closes #65