### PR TITLE
v0.11.0: The Lounge — themed soundtrack jukebox

### DIFF
--- a/docs/superpowers/plans/2026-04-25-lounge.md
+++ b/docs/superpowers/plans/2026-04-25-lounge.md
@@ -1,0 +1,992 @@
+# The Lounge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add "The Lounge" — a themed soundtrack jukebox screen reachable from the title screen, with a track list (theme-flavored), now-playing card, seekable progress bar, and play/pause/prev/next/mute controls. Resolves issue #70.
+
+**Architecture:** Vanilla ES modules, no build step. Extend `src/audio.js` with a small seek/progress API. Add `src/content/trackFlavor.js` (3 themes × 8 tracks of flavor text). Create `src/ui/lounge.js` that renders into a new `#lounge-layer` div in `index.html`. Wire open/close from `src/main.js` (entry from title screen LOUNGE button, plus topbar music control becomes a LOUNGE link). Per-theme skin in `theme-lcars.css` / `theme-starfighter.css` / `theme-voltron.css`; layout/structure in `components.css`.
+
+**Tech Stack:** Vanilla JS (ES modules), HTML, CSS, HTMLAudioElement, localStorage.
+
+**Verification approach:** No automated test framework in this repo. Each task ends with **manual browser verification steps** (open `index.html` via the existing static server / file://, click through the described scenario, confirm). Commit after each task passes verification.
+
+---
+
+## File map
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `src/audio.js` | Modify | Add seek/progress API + play/pause exports while keeping shuffle behavior |
+| `src/content/trackFlavor.js` | Create | Flavor text per track per theme (8 tracks × 3 themes) |
+| `src/ui/lounge.js` | Create | Render Lounge layer, wire all controls + live updates |
+| `src/ui/modals.js` | Modify | Add LOUNGE button to title screen, wire its callback |
+| `index.html` | Modify | Add `#lounge-layer` div; replace topbar `<select>` with a "🎵 LOUNGE" button |
+| `src/main.js` | Modify | Open Lounge from topbar link; pass Lounge open callback to title layer; remove now-redundant `<select>` wiring |
+| `styles/components.css` | Modify | Base Lounge layout (grid, list, card, controls) |
+| `styles/theme-lcars.css` | Modify | LCARS skin for Lounge |
+| `styles/theme-starfighter.css` | Modify | Starfighter skin for Lounge |
+| `styles/theme-voltron.css` | Modify | Voltron skin for Lounge |
+| `package.json` | Modify | Bump version to 0.11.0 |
+
+---
+
+## Task 0: Branch + dev server
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout -b feature/lounge
+```
+
+- [ ] **Step 2: Start a static dev server in the project root for manual verification**
+
+```bash
+python3 -m http.server 8765
+```
+
+Leave running in a background shell. Verification URL: `http://localhost:8765/`.
+
+- [ ] **Step 3: Sanity check** — open the URL in a browser, confirm the title screen renders with the existing START MISSION button and music begins on first click.
+
+---
+
+## Task 1: Extend `src/audio.js` with seek/progress + play/pause API
+
+**Files:**
+- Modify: `src/audio.js` (append new exports; do not change existing behavior)
+
+- [ ] **Step 1: Add the new exports at the bottom of `src/audio.js` (just above `isUnlocked`)**
+
+```js
+// ---- Seek / progress / play-pause API (used by the Lounge) ----
+
+const timeUpdateListeners = [];
+export function onTimeUpdate(cb) { timeUpdateListeners.push(cb); }
+audio.addEventListener('timeupdate', () => {
+  timeUpdateListeners.forEach(cb => { try { cb(audio.currentTime, audio.duration || 0); } catch {} });
+});
+
+export function getCurrentTime() { return audio.currentTime || 0; }
+export function getDuration()    { return audio.duration   || 0; }
+export function getProgress()    {
+  const d = audio.duration;
+  return (d && isFinite(d)) ? (audio.currentTime / d) : 0;
+}
+export function seekTo(fraction) {
+  const d = audio.duration;
+  if (!d || !isFinite(d)) return;
+  audio.currentTime = Math.max(0, Math.min(1, fraction)) * d;
+}
+export function isPlaying() { return !audio.paused; }
+export function getCurrentTrackId() { return currentTrackId; }
+
+export function pauseAudio() { audio.pause(); }
+export function resumeAudio() {
+  if (currentTrackId) audio.play().catch(() => {});
+}
+export function togglePlayPause() {
+  if (audio.paused) resumeAudio(); else pauseAudio();
+  return !audio.paused;
+}
+```
+
+- [ ] **Step 2: Manual verification in browser DevTools console**
+
+Open the dashboard (start a mission so gameplay music plays), then in the console:
+
+```js
+const a = await import('/src/audio.js');
+a.getDuration();             // > 0
+a.getCurrentTime();          // > 0 after a few seconds
+a.getProgress();             // a fraction 0..1
+a.seekTo(0.5);               // jumps mid-track
+a.isPlaying();               // true
+a.togglePlayPause();         // pauses → returns false
+a.togglePlayPause();         // resumes → returns true
+a.onTimeUpdate((t, d) => console.log('tick', t.toFixed(1), '/', d.toFixed(1)));
+// Wait a couple seconds → see ticks logged.
+```
+
+Expected: each call returns the documented value; ticks log every ~250ms.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/audio.js
+git commit -m "audio: add seek/progress/play-pause API for the Lounge (#70)"
+```
+
+---
+
+## Task 2: Create `src/content/trackFlavor.js`
+
+**Files:**
+- Create: `src/content/trackFlavor.js`
+
+- [ ] **Step 1: Write the file with three flavor variants per track**
+
+```js
+// Mars Trail — per-theme flavor copy for the Lounge.
+// Keys are the audio.js track ids ('title' + GAMEPLAY_TRACKS ids).
+// Themes match the keys in src/theme.js: 'lcars', 'starfighter', 'voltron'.
+
+export const TRACK_FLAVOR = {
+  title: {
+    lcars:       "Stardate 4127.1 — opening signature, transmitted on first contact with Tractus Martis.",
+    starfighter: "Pre-launch hum on the runway. Helmets on. Throttles up.",
+    voltron:     "The summoning hymn. Five lions, one sky."
+  },
+  vacuum: {
+    lcars:       "Stardate 4131.7 — ambient harmonic recorded in the Tharsis radio shadow.",
+    starfighter: "Track 4 on the long burn. Saved my sanity past Phobos.",
+    voltron:     "A lullaby the Blue Lion sings to the deep oceans of Naxzela."
+  },
+  choir: {
+    lcars:       "Stardate 4139.2 — chorus reconstructed from EVA helmet recordings.",
+    starfighter: "What you hear when the squadron flies tight enough to touch wings.",
+    voltron:     "The voices of the Castle of Lions, raised in unison at dawn."
+  },
+  violin: {
+    lcars:       "Stardate 4144.0 — solo violin intercepted on a derelict relay.",
+    starfighter: "Cassette my wingmate left in the cockpit. Played it every sortie.",
+    voltron:     "Allura's lament, played the night Altea fell."
+  },
+  void: {
+    lcars:       "Stardate 4150.6 — algorithmic composition; mathematics of empty space.",
+    starfighter: "The math song. I hum it in the long dark between jumps.",
+    voltron:     "The Black Lion's meditation — patterns older than the Paladins."
+  },
+  star: {
+    lcars:       "Stardate 4157.4 — recording from the salt flats of Meridiani Planum.",
+    starfighter: "What the radio sounds like when there's no one out there to answer.",
+    voltron:     "The silence between roars. Sacred to the Red Lion."
+  },
+  crater: {
+    lcars:       "Stardate 4162.9 — geophonic capture from inside Gale Crater rim.",
+    starfighter: "Bass that rumbles through the canopy. Felt it in my teeth.",
+    voltron:     "The Yellow Lion stomps and the earth answers."
+  },
+  voidbread: {
+    lcars:       "Stardate 4170.3 — galley hymn, sung over recycled rations.",
+    starfighter: "The mess hall song. Sung loud, sung off-key, sung together.",
+    voltron:     "A blessing for the food, taught to the Paladins by the Olkari."
+  }
+};
+
+// Resolve a flavor line, with a safe fallback if a theme is missing copy.
+export function getFlavor(trackId, themeId) {
+  const entry = TRACK_FLAVOR[trackId];
+  if (!entry) return '';
+  return entry[themeId] || entry.lcars || '';
+}
+```
+
+- [ ] **Step 2: Manual verification in browser DevTools console**
+
+```js
+const f = await import('/src/content/trackFlavor.js');
+f.getFlavor('vacuum', 'lcars');         // Stardate string
+f.getFlavor('vacuum', 'starfighter');   // mixtape line
+f.getFlavor('vacuum', 'voltron');       // lullaby line
+f.getFlavor('unknown', 'lcars');        // ''
+f.getFlavor('vacuum', 'unknown');       // falls back to lcars line
+```
+
+Expected: each returns the matching string (or '' for unknown trackId).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/trackFlavor.js
+git commit -m "content: per-theme flavor copy for Lounge tracks (#70)"
+```
+
+---
+
+## Task 3: Create `src/ui/lounge.js`
+
+**Files:**
+- Create: `src/ui/lounge.js`
+
+- [ ] **Step 1: Write the Lounge module**
+
+```js
+// Mars Trail — The Lounge: a themed soundtrack jukebox screen.
+// Renders into #lounge-layer. Selecting a row calls audio.selectTrack
+// so playback continues seamlessly when the player closes the Lounge.
+
+import {
+  TITLE_TRACK,
+  GAMEPLAY_TRACKS,
+  selectTrack,
+  play,
+  togglePlayPause,
+  isPlaying,
+  isMuted,
+  toggleMute,
+  cycleTrack,
+  onTrackChange,
+  onTimeUpdate,
+  seekTo,
+  getCurrentTrackId,
+  getDuration,
+  getCurrentTime
+} from '../audio.js';
+import { getFlavor } from '../content/trackFlavor.js';
+import { getActiveTheme } from '../theme.js';
+
+const ALL_TRACKS = [TITLE_TRACK, ...GAMEPLAY_TRACKS];
+
+let opened = false;
+let unsubTrack = null;
+let unsubTime  = null;
+let onCloseCb  = null;
+
+function fmtTime(sec) {
+  if (!isFinite(sec) || sec < 0) sec = 0;
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function render() {
+  const layer = document.getElementById('lounge-layer');
+  if (!layer) return;
+  const theme = getActiveTheme();
+
+  const rows = ALL_TRACKS.map(t => `
+    <li class="lounge-row" data-track="${t.id}">
+      <div class="lounge-row-main">
+        <span class="lounge-row-name">${t.name}</span>
+        <span class="lounge-row-flavor">${escapeHtml(getFlavor(t.id, theme))}</span>
+      </div>
+      <span class="lounge-row-indicator" aria-hidden="true">▶</span>
+    </li>
+  `).join('');
+
+  layer.innerHTML = `
+    <div class="lounge-screen">
+      <header class="lounge-header">
+        <h1 class="lounge-title">THE LOUNGE</h1>
+        <button class="lounge-close" id="lounge-close" type="button" aria-label="Close the Lounge">CLOSE ✕</button>
+      </header>
+
+      <section class="lounge-now-playing" id="lounge-now-playing" aria-live="polite">
+        <div class="lounge-np-label">NOW PLAYING</div>
+        <div class="lounge-np-name"  id="lounge-np-name">—</div>
+        <div class="lounge-np-flavor" id="lounge-np-flavor"></div>
+        <div class="lounge-progress-row">
+          <span class="lounge-time" id="lounge-time-current">0:00</span>
+          <div class="lounge-progress" id="lounge-progress" role="slider"
+               aria-label="Seek" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+            <div class="lounge-progress-fill" id="lounge-progress-fill"></div>
+          </div>
+          <span class="lounge-time" id="lounge-time-total">0:00</span>
+        </div>
+        <div class="lounge-controls">
+          <button class="lounge-ctrl" id="lounge-prev"  type="button" aria-label="Previous track">⏮</button>
+          <button class="lounge-ctrl lounge-ctrl-play" id="lounge-playpause" type="button" aria-label="Play/Pause">⏸</button>
+          <button class="lounge-ctrl" id="lounge-next"  type="button" aria-label="Next track">⏭</button>
+          <button class="lounge-ctrl" id="lounge-mute"  type="button" aria-label="Mute/Unmute">🔊</button>
+        </div>
+      </section>
+
+      <section class="lounge-list-section">
+        <h2 class="lounge-list-header">SOUNDTRACK</h2>
+        <ul class="lounge-list" id="lounge-list">${rows}</ul>
+      </section>
+    </div>
+  `;
+
+  wire();
+  refreshNowPlaying();
+  refreshPlayPause();
+  refreshMute();
+}
+
+function wire() {
+  const layer = document.getElementById('lounge-layer');
+
+  layer.querySelector('#lounge-close').addEventListener('click', close);
+
+  layer.querySelector('#lounge-list').addEventListener('click', (e) => {
+    const row = e.target.closest('.lounge-row');
+    if (!row) return;
+    const id = row.dataset.track;
+    if (id === 'title') {
+      play('title');
+    } else {
+      selectTrack(id);
+    }
+  });
+
+  layer.querySelector('#lounge-prev').addEventListener('click', () => {
+    cycleTrack(-1);
+  });
+  layer.querySelector('#lounge-next').addEventListener('click', () => {
+    cycleTrack(1);
+  });
+  layer.querySelector('#lounge-playpause').addEventListener('click', () => {
+    togglePlayPause();
+    refreshPlayPause();
+  });
+  layer.querySelector('#lounge-mute').addEventListener('click', () => {
+    toggleMute();
+    refreshMute();
+  });
+
+  // Seek by clicking anywhere on the progress bar.
+  const bar = layer.querySelector('#lounge-progress');
+  const seekFromEvent = (e) => {
+    const rect = bar.getBoundingClientRect();
+    const x = (e.clientX ?? (e.touches?.[0]?.clientX ?? 0)) - rect.left;
+    seekTo(Math.max(0, Math.min(1, x / rect.width)));
+  };
+  bar.addEventListener('click', seekFromEvent);
+
+  // Drag-to-scrub.
+  let dragging = false;
+  bar.addEventListener('mousedown', (e) => { dragging = true; seekFromEvent(e); });
+  window.addEventListener('mousemove', (e) => { if (dragging) seekFromEvent(e); });
+  window.addEventListener('mouseup',   () => { dragging = false; });
+
+  // ESC closes.
+  document.addEventListener('keydown', escClose);
+}
+
+function escClose(e) {
+  if (e.key === 'Escape' && opened) {
+    close();
+  }
+}
+
+function refreshNowPlaying() {
+  const id = getCurrentTrackId();
+  const track = ALL_TRACKS.find(t => t.id === id);
+  const layer = document.getElementById('lounge-layer');
+  if (!layer) return;
+
+  layer.querySelector('#lounge-np-name').textContent = track ? track.name : '—';
+  layer.querySelector('#lounge-np-flavor').textContent = track ? getFlavor(track.id, getActiveTheme()) : '';
+
+  layer.querySelectorAll('.lounge-row').forEach(row => {
+    row.classList.toggle('playing', row.dataset.track === id);
+  });
+}
+
+function refreshProgress(current, duration) {
+  const layer = document.getElementById('lounge-layer');
+  if (!layer) return;
+  const fill  = layer.querySelector('#lounge-progress-fill');
+  const bar   = layer.querySelector('#lounge-progress');
+  const tcur  = layer.querySelector('#lounge-time-current');
+  const ttot  = layer.querySelector('#lounge-time-total');
+  if (!fill) return;
+
+  const cur = current ?? getCurrentTime();
+  const dur = duration ?? getDuration();
+  const pct = (dur > 0) ? Math.min(100, (cur / dur) * 100) : 0;
+
+  fill.style.width = `${pct}%`;
+  bar.setAttribute('aria-valuenow', pct.toFixed(0));
+  tcur.textContent = fmtTime(cur);
+  ttot.textContent = fmtTime(dur);
+}
+
+function refreshPlayPause() {
+  const layer = document.getElementById('lounge-layer');
+  if (!layer) return;
+  layer.querySelector('#lounge-playpause').textContent = isPlaying() ? '⏸' : '▶';
+}
+
+function refreshMute() {
+  const layer = document.getElementById('lounge-layer');
+  if (!layer) return;
+  layer.querySelector('#lounge-mute').textContent = isMuted() ? '🔇' : '🔊';
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => (
+    { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[c]
+  ));
+}
+
+export function openLounge(onClose) {
+  if (opened) return;
+  opened = true;
+  onCloseCb = onClose || null;
+
+  const layer = document.getElementById('lounge-layer');
+  layer.classList.add('active');
+  render();
+
+  unsubTrack = onTrackChange(() => { refreshNowPlaying(); refreshPlayPause(); });
+  unsubTime  = onTimeUpdate((c, d) => refreshProgress(c, d));
+
+  // Initial paint of progress.
+  refreshProgress();
+}
+
+export function close() {
+  if (!opened) return;
+  opened = false;
+  const layer = document.getElementById('lounge-layer');
+  layer.classList.remove('active');
+  layer.innerHTML = '';
+  document.removeEventListener('keydown', escClose);
+  // onTrackChange / onTimeUpdate listeners stay registered; their callbacks
+  // are no-ops once the layer is empty (DOM lookups return null). This is
+  // fine for a single-player game; not worth the bookkeeping to deregister.
+  if (onCloseCb) onCloseCb();
+}
+
+export function isLoungeOpen() { return opened; }
+```
+
+- [ ] **Step 2: Confirm `src/theme.js` exposes `getActiveTheme`. If not, add it.**
+
+Open `src/theme.js` and check for an export named `getActiveTheme` returning the current theme id (one of `'lcars'`, `'starfighter'`, `'voltron'`). If absent, add at the bottom:
+
+```js
+export function getActiveTheme() {
+  return localStorage.getItem('marsTrail.theme') || 'lcars';
+}
+```
+
+(Use whatever localStorage key `theme.js` already uses — open the file and match it.)
+
+- [ ] **Step 3: Manual verification — defer until Task 5 wires the open path. No test runs in this task.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/lounge.js src/theme.js
+git commit -m "ui: add Lounge screen module (#70)"
+```
+
+---
+
+## Task 4: Add `#lounge-layer` and topbar LOUNGE button to `index.html`
+
+**Files:**
+- Modify: `index.html`
+
+- [ ] **Step 1: Replace the topbar music controls block**
+
+Find the existing block (lines 22–25):
+
+```html
+      <span class="music-controls">
+        <select id="music-select" title="Select track"></select>
+        <button id="music-mute" type="button" title="Mute/unmute music">🔊</button>
+      </span>
+```
+
+Replace with:
+
+```html
+      <span class="music-controls">
+        <button id="lounge-open" type="button" title="Open The Lounge (soundtrack)">🎵 LOUNGE</button>
+        <button id="music-mute" type="button" title="Mute/unmute music">🔊</button>
+      </span>
+```
+
+- [ ] **Step 2: Add the Lounge layer near the title-layer / modal-root**
+
+Find the line `<div id="title-layer" class="title-layer"></div>` and add directly below it:
+
+```html
+  <div id="lounge-layer" class="lounge-layer"></div>
+```
+
+- [ ] **Step 3: Manual verification**
+
+Reload `http://localhost:8765/`. Confirm:
+- Topbar shows a `🎵 LOUNGE` button instead of a dropdown.
+- Mute button still present and still works (existing wiring still attached in main.js — it'll error on the missing `#music-select`; that's fixed in Task 5).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add index.html
+git commit -m "html: add #lounge-layer and topbar LOUNGE button (#70)"
+```
+
+---
+
+## Task 5: Wire Lounge open/close in `src/main.js` and the title screen
+
+**Files:**
+- Modify: `src/main.js`
+- Modify: `src/ui/modals.js`
+
+- [ ] **Step 1: Update the topbar music-controls wiring in `src/main.js`**
+
+Find this block (around lines 304–326):
+
+```js
+// ---- Music controls ----
+const musicSelect = document.getElementById('music-select');
+const musicMute   = document.getElementById('music-mute');
+
+// Populate track selector.
+GAMEPLAY_TRACKS.forEach(t => {
+  const opt = document.createElement('option');
+  opt.value = t.id;
+  opt.textContent = t.name;
+  musicSelect.appendChild(opt);
+});
+musicSelect.value = getSelectedTrackId();
+musicMute.textContent = isMuted() ? '🔇' : '🔊';
+musicMute.classList.toggle('muted', isMuted());
+
+musicSelect.addEventListener('change', () => {
+  selectTrack(musicSelect.value);
+});
+
+// Keep dropdown in sync with shuffle-driven track changes.
+onTrackChange((id) => {
+  if (id !== 'title') musicSelect.value = id;
+});
+```
+
+Replace with:
+
+```js
+// ---- Music controls ----
+const loungeOpenBtn = document.getElementById('lounge-open');
+const musicMute     = document.getElementById('music-mute');
+
+musicMute.textContent = isMuted() ? '🔇' : '🔊';
+musicMute.classList.toggle('muted', isMuted());
+
+loungeOpenBtn.addEventListener('click', () => openLounge());
+```
+
+- [ ] **Step 2: Add `openLounge` import at the top of `src/main.js`**
+
+In the import block, add:
+
+```js
+import { openLounge } from './ui/lounge.js';
+```
+
+And remove `getSelectedTrackId` from the `./audio.js` import line if it's no longer used. (It is no longer used after this change.)
+
+- [ ] **Step 3: Update the keyboard handler so ArrowUp/ArrowDown still work**
+
+Find this block (around lines 335–350):
+
+```js
+document.addEventListener('keydown', (e) => {
+  // Don't hijack keys when a select/input is focused.
+  if (document.activeElement && (document.activeElement.tagName === 'SELECT' || document.activeElement.tagName === 'INPUT')) return;
+
+  if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+    e.preventDefault();
+    const dir = e.key === 'ArrowUp' ? -1 : 1;
+    const newId = cycleTrack(dir);
+    musicSelect.value = newId;
+  } else if (e.key === 'm' || e.key === 'M') {
+```
+
+Replace the inner `cycleTrack` block (the `if (e.key === 'ArrowUp' ...)` branch) with:
+
+```js
+  if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+    e.preventDefault();
+    const dir = e.key === 'ArrowUp' ? -1 : 1;
+    cycleTrack(dir);
+  } else if (e.key === 'm' || e.key === 'M') {
+```
+
+(The `musicSelect.value = newId;` line is removed because `musicSelect` no longer exists.)
+
+- [ ] **Step 4: Add a LOUNGE button to the title screen in `src/ui/modals.js`**
+
+In `showTitleLayer`, find the existing markup (around line 165):
+
+```html
+      <button class="title-start" id="title-start" type="button">START MISSION</button>
+```
+
+Replace with:
+
+```html
+      <div class="title-actions">
+        <button class="title-start" id="title-start" type="button">START MISSION</button>
+        <button class="title-lounge" id="title-lounge" type="button">🎵 THE LOUNGE</button>
+      </div>
+```
+
+Then below the existing `layer.querySelector('#title-start').addEventListener('click', onStart);` add:
+
+```js
+  layer.querySelector('#title-lounge').addEventListener('click', () => {
+    import('./lounge.js').then(m => m.openLounge());
+  });
+```
+
+(Dynamic import keeps the title screen module's existing import surface unchanged.)
+
+- [ ] **Step 5: Manual verification — full open/close path**
+
+Reload the page.
+
+1. On the title screen, click `🎵 THE LOUNGE` → Lounge opens, title music keeps playing, current track highlighted in the list.
+2. Click a different gameplay track row → it begins playing immediately, highlight updates.
+3. Click ⏯ → music pauses; click again → resumes.
+4. Click ⏮ / ⏭ → cycles tracks; row highlight follows.
+5. Click 🔊 → toggles to 🔇 and audio mutes; click again → unmutes.
+6. Click somewhere on the progress bar → playback jumps to that point. Drag to scrub also works.
+7. Press `Esc` → Lounge closes; music keeps playing seamlessly.
+8. Click topbar `🎵 LOUNGE` → opens again. Click `CLOSE ✕` → closes.
+9. Reload page → previously selected track ID still chosen (localStorage persistence).
+10. Mute persists across reload.
+11. Start a mission and verify in-game gameplay shuffle still works after using the Lounge.
+
+Do not proceed to Task 6 until all 11 checks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.js src/ui/modals.js
+git commit -m "ui: open the Lounge from title screen and topbar (#70)"
+```
+
+---
+
+## Task 6: Base Lounge layout in `styles/components.css`
+
+**Files:**
+- Modify: `styles/components.css`
+
+- [ ] **Step 1: Append the following block to the bottom of `styles/components.css`**
+
+```css
+/* ----- The Lounge ----- */
+
+.lounge-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 90;             /* above dashboard, below transition overlay (which is 100+) */
+  display: none;
+  background: var(--bg);
+  overflow: auto;
+}
+.lounge-layer.active { display: block; }
+
+.lounge-screen {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 24px 20px 48px;
+  display: grid;
+  gap: 20px;
+}
+
+.lounge-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--fg-faint);
+  padding-bottom: 8px;
+}
+.lounge-title {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: 0.15em;
+  color: var(--fg);
+  text-shadow: var(--glow);
+}
+.lounge-close {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 6px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+}
+.lounge-close:hover { border-color: var(--fg); box-shadow: var(--glow); }
+
+.lounge-now-playing {
+  border: 1px solid var(--fg-faint);
+  padding: 14px 16px;
+  background: var(--bg-panel);
+}
+.lounge-np-label {
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--fg-dim);
+}
+.lounge-np-name {
+  font-size: 18px;
+  margin: 4px 0 4px;
+  color: var(--fg);
+  text-shadow: var(--glow);
+}
+.lounge-np-flavor {
+  font-size: 12px;
+  color: var(--fg-dim);
+  font-style: italic;
+  min-height: 1.4em;
+}
+
+.lounge-progress-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+}
+.lounge-time {
+  font-size: 11px;
+  color: var(--fg-dim);
+  min-width: 3.2em;
+  text-align: center;
+}
+.lounge-progress {
+  position: relative;
+  height: 6px;
+  background: var(--fg-faint);
+  cursor: pointer;
+  user-select: none;
+}
+.lounge-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  background: var(--fg);
+  box-shadow: var(--glow);
+  transition: width 120ms linear;
+}
+
+.lounge-controls {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  justify-content: center;
+}
+.lounge-ctrl {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 6px 12px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  cursor: pointer;
+  min-width: 44px;
+}
+.lounge-ctrl:hover { border-color: var(--fg); box-shadow: var(--glow); }
+.lounge-ctrl-play  { min-width: 56px; }
+
+.lounge-list-section { display: grid; gap: 8px; }
+.lounge-list-header {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--fg-dim);
+  border-bottom: 1px dashed var(--fg-faint);
+  padding-bottom: 4px;
+}
+
+.lounge-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+}
+.lounge-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.lounge-row:hover {
+  border-color: var(--fg-faint);
+  background: var(--bg-panel);
+}
+.lounge-row.playing {
+  border-color: var(--fg);
+  background: var(--bg-panel);
+  box-shadow: var(--glow);
+}
+.lounge-row-main { display: grid; gap: 2px; }
+.lounge-row-name {
+  font-size: 14px;
+  color: var(--fg);
+}
+.lounge-row-flavor {
+  font-size: 11px;
+  color: var(--fg-dim);
+  font-style: italic;
+}
+.lounge-row-indicator {
+  color: var(--fg-faint);
+  font-size: 12px;
+  visibility: hidden;
+}
+.lounge-row.playing .lounge-row-indicator { visibility: visible; color: var(--fg); }
+
+/* Title screen — give the LOUNGE button a sibling layout */
+.title-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  margin-top: 6px;
+}
+.title-lounge {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 8px 18px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.15em;
+  cursor: pointer;
+}
+.title-lounge:hover { border-color: var(--fg); box-shadow: var(--glow); }
+```
+
+- [ ] **Step 2: Manual verification**
+
+Reload, open the Lounge. Confirm:
+- Layout is centered, dark background, phosphor green text.
+- Track list is readable; current track is highlighted with glow.
+- Progress bar visible; fill animates while playing.
+- Controls render in a centered row.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add styles/components.css
+git commit -m "css: base Lounge layout in components.css (#70)"
+```
+
+---
+
+## Task 7: Per-theme Lounge skins
+
+**Files:**
+- Modify: `styles/theme-lcars.css`
+- Modify: `styles/theme-starfighter.css`
+- Modify: `styles/theme-voltron.css`
+
+The base styling already pulls from theme tokens (`--fg`, `--bg-panel`, `--glow`), so theme skins inherit much of the look automatically. These additions polish per-theme accents.
+
+- [ ] **Step 1: Append to `styles/theme-lcars.css`**
+
+```css
+.theme-lcars .lounge-title { font-family: var(--lcars-font, inherit); letter-spacing: 0.18em; }
+.theme-lcars .lounge-now-playing,
+.theme-lcars .lounge-row { border-radius: 0 12px 0 12px; }
+.theme-lcars .lounge-row.playing { background: var(--lcars-accent, var(--bg-panel)); color: var(--bg); }
+.theme-lcars .lounge-row.playing .lounge-row-name,
+.theme-lcars .lounge-row.playing .lounge-row-flavor { color: var(--bg); }
+.theme-lcars .lounge-progress { border-radius: 999px; }
+.theme-lcars .lounge-progress-fill { border-radius: 999px; }
+```
+
+- [ ] **Step 2: Append to `styles/theme-starfighter.css`**
+
+```css
+.theme-starfighter .lounge-screen { padding-top: 32px; }
+.theme-starfighter .lounge-title { letter-spacing: 0.25em; }
+.theme-starfighter .lounge-now-playing,
+.theme-starfighter .lounge-row { border-style: dashed; }
+.theme-starfighter .lounge-row.playing { border-style: solid; }
+.theme-starfighter .lounge-progress { height: 4px; }
+```
+
+- [ ] **Step 3: Append to `styles/theme-voltron.css`**
+
+```css
+.theme-voltron .lounge-title { text-transform: uppercase; }
+.theme-voltron .lounge-now-playing,
+.theme-voltron .lounge-row { border-width: 2px; }
+.theme-voltron .lounge-row.playing { border-color: var(--voltron-red, var(--fg)); }
+.theme-voltron .lounge-progress-fill { background: var(--voltron-red, var(--fg)); box-shadow: 0 0 6px var(--voltron-red, var(--fg)); }
+```
+
+(If a theme file uses different custom property names, substitute the right ones — open the theme file and pick the existing accent color token.)
+
+- [ ] **Step 4: Manual verification — switch themes**
+
+Reload. Use the topbar theme dropdown to cycle through `LCARS → Starfighter → Voltron`. For each theme:
+- Open the Lounge.
+- Confirm all rows show the theme-appropriate flavor text (e.g. "Stardate ..." in LCARS, "Track 4 on the long burn..." in Starfighter, "A lullaby the Blue Lion sings..." in Voltron).
+- Confirm overall look matches the active theme (no weird unstyled artifacts, no broken backgrounds).
+- Click around to verify functionality is identical across themes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add styles/theme-lcars.css styles/theme-starfighter.css styles/theme-voltron.css
+git commit -m "css: per-theme Lounge skins for lcars/starfighter/voltron (#70)"
+```
+
+---
+
+## Task 8: Final acceptance pass + version bump
+
+- [ ] **Step 1: Run through every issue acceptance criterion in the browser**
+
+Open the page fresh and verify each checkbox in issue #70:
+
+- [ ] Main menu (title screen) has a Lounge entry point.
+- [ ] Lounge renders correctly in all three themes.
+- [ ] All 8 tracks appear with theme-appropriate flavor text per active theme.
+- [ ] Clicking a row plays that track and persists the selection (reload, confirm same track).
+- [ ] Now-playing card shows live elapsed time and a working seek bar.
+- [ ] Play/pause, prev, next, mute all work and reflect current state.
+- [ ] Leaving the Lounge does not interrupt playback.
+- [ ] Selection + mute persist across reload.
+- [ ] No regressions: title-music loop, gameplay shuffle, fade in/out into a mission still work.
+
+If any check fails, open a fix in a new commit before moving on.
+
+- [ ] **Step 2: Bump version**
+
+In `package.json`:
+
+```json
+{
+  "type": "module",
+  "private": true,
+  "version": "0.11.0"
+}
+```
+
+- [ ] **Step 3: Commit version bump**
+
+```bash
+git add package.json
+git commit -m "v0.11.0: The Lounge — themed soundtrack jukebox"
+```
+
+- [ ] **Step 4: Stop the dev server**
+
+In the background shell running `python3 -m http.server 8765`, send Ctrl-C / kill it.
+
+- [ ] **Step 5: Push the branch and open a PR**
+
+```bash
+git push -u origin feature/lounge
+gh pr create --title "v0.11.0: The Lounge — themed soundtrack jukebox" --body "Closes #70."
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Each acceptance criterion from issue #70 maps to verification in Task 5 step 5 and Task 8 step 1.
+- **No automated tests:** Documented up front. Each task uses concrete manual verification scripts.
+- **Type consistency:** `openLounge()` is exported from `src/ui/lounge.js` and imported by `src/main.js` and (dynamically) by `src/ui/modals.js`. Audio API additions are referenced consistently throughout.
+- **YAGNI honored:** No visualizer, no playlists, no volume slider — all explicitly out of scope per the spec.
+- **DRY:** Track flavor copy lives in one module (`trackFlavor.js`); both row-render and now-playing-card read from `getFlavor()`.

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <span class="topbar-right">
       <span class="sci-counter" id="sci-counter" title="Science points collected">SCI 0</span>
       <span class="music-controls">
-        <select id="music-select" title="Select track"></select>
+        <button id="lounge-open" type="button" title="Open The Lounge (soundtrack)">🎵 LOUNGE</button>
         <button id="music-mute" type="button" title="Mute/unmute music">🔊</button>
       </span>
       <span class="clock" id="clock">SOL 1 · 00:00 LMST</span>
@@ -97,6 +97,7 @@
   </main>
 
   <div id="title-layer" class="title-layer"></div>
+  <div id="lounge-layer" class="lounge-layer"></div>
   <div id="modal-root"></div>
   <div id="transition-overlay" class="transition-overlay"></div>
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
     <span class="topbar-right">
       <span class="sci-counter" id="sci-counter" title="Science points collected">SCI 0</span>
       <span class="music-controls">
-        <button id="lounge-open" type="button" title="Open The Lounge (soundtrack)">🎵 LOUNGE</button>
         <button id="music-mute" type="button" title="Mute/unmute music">🔊</button>
       </span>
       <span class="clock" id="clock">SOL 1 · 00:00 LMST</span>
@@ -98,6 +97,7 @@
 
   <div id="title-layer" class="title-layer"></div>
   <div id="lounge-layer" class="lounge-layer"></div>
+  <button id="lounge-open" class="lounge-vinyl lounge-vinyl-md lounge-vinyl-corner" type="button" title="Open The Lounge (soundtrack)" aria-label="Open The Lounge"><span class="lounge-vinyl-center"></span></button>
   <div id="modal-root"></div>
   <div id="transition-overlay" class="transition-overlay"></div>
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "type": "module",
   "private": true,
-  "version": "0.10.0"
+  "version": "0.11.0"
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -106,9 +106,7 @@ export function toggleMute() {
 
 export function selectTrack(trackId) {
   localStorage.setItem(STORAGE_KEY_TRACK, trackId);
-  if (currentTrackId !== 'title') {
-    play(trackId);
-  }
+  play(trackId);
 }
 
 export function cycleTrack(direction) {

--- a/src/audio.js
+++ b/src/audio.js
@@ -182,3 +182,34 @@ export function fadeInGameplay(durationMs = 1500) {
 }
 
 export function isUnlocked() { return unlocked; }
+
+// ---- Seek / progress / play-pause API (used by the Lounge) ----
+
+const timeUpdateListeners = [];
+export function onTimeUpdate(cb) { timeUpdateListeners.push(cb); }
+audio.addEventListener('timeupdate', () => {
+  timeUpdateListeners.forEach(cb => { try { cb(audio.currentTime, audio.duration || 0); } catch {} });
+});
+
+export function getCurrentTime() { return audio.currentTime || 0; }
+export function getDuration()    { return audio.duration   || 0; }
+export function getProgress()    {
+  const d = audio.duration;
+  return (d && isFinite(d)) ? (audio.currentTime / d) : 0;
+}
+export function seekTo(fraction) {
+  const d = audio.duration;
+  if (!d || !isFinite(d)) return;
+  audio.currentTime = Math.max(0, Math.min(1, fraction)) * d;
+}
+export function isPlaying() { return !audio.paused; }
+export function getCurrentTrackId() { return currentTrackId; }
+
+export function pauseAudio() { audio.pause(); }
+export function resumeAudio() {
+  if (currentTrackId) audio.play().catch(() => {});
+}
+export function togglePlayPause() {
+  if (audio.paused) resumeAudio(); else pauseAudio();
+  return !audio.paused;
+}

--- a/src/content/trackFlavor.js
+++ b/src/content/trackFlavor.js
@@ -1,0 +1,62 @@
+// Mars Trail — per-theme flavor copy for the Lounge.
+// Keys are the audio.js track ids ('title' + GAMEPLAY_TRACKS ids).
+// Themes match the ids in src/theme.js: 'mc', 'lcars', 'starfighter', 'voltron'.
+// Missing keys fall back to the 'mc' (Mission Control) variant via getFlavor().
+
+export const TRACK_FLAVOR = {
+  title: {
+    mc:          "Opening signal — broadcast on first contact with Tractus Martis.",
+    lcars:       "Stardate 4127.1 — opening signature, transmitted on first contact with Tractus Martis.",
+    starfighter: "Pre-launch hum on the runway. Helmets on. Throttles up.",
+    voltron:     "The summoning hymn. Five lions, one sky."
+  },
+  vacuum: {
+    mc:          "Field recording — ambient harmonic in the Tharsis radio shadow.",
+    lcars:       "Stardate 4131.7 — ambient harmonic recorded in the Tharsis radio shadow.",
+    starfighter: "Track 4 on the long burn. Saved my sanity past Phobos.",
+    voltron:     "A lullaby the Blue Lion sings to the deep oceans of Naxzela."
+  },
+  choir: {
+    mc:          "Mission audio — chorus reconstructed from EVA helmet recordings.",
+    lcars:       "Stardate 4139.2 — chorus reconstructed from EVA helmet recordings.",
+    starfighter: "What you hear when the squadron flies tight enough to touch wings.",
+    voltron:     "The voices of the Castle of Lions, raised in unison at dawn."
+  },
+  violin: {
+    mc:          "Intercept — solo violin from a derelict relay station.",
+    lcars:       "Stardate 4144.0 — solo violin intercepted on a derelict relay.",
+    starfighter: "Cassette my wingmate left in the cockpit. Played it every sortie.",
+    voltron:     "Allura's lament, played the night Altea fell."
+  },
+  void: {
+    mc:          "Procedural composition — the mathematics of empty space.",
+    lcars:       "Stardate 4150.6 — algorithmic composition; mathematics of empty space.",
+    starfighter: "The math song. I hum it in the long dark between jumps.",
+    voltron:     "The Black Lion's meditation — patterns older than the Paladins."
+  },
+  star: {
+    mc:          "Site recording — captured on the salt flats of Meridiani Planum.",
+    lcars:       "Stardate 4157.4 — recording from the salt flats of Meridiani Planum.",
+    starfighter: "What the radio sounds like when there's no one out there to answer.",
+    voltron:     "The silence between roars. Sacred to the Red Lion."
+  },
+  crater: {
+    mc:          "Geophonic capture from inside the Gale Crater rim.",
+    lcars:       "Stardate 4162.9 — geophonic capture from inside Gale Crater rim.",
+    starfighter: "Bass that rumbles through the canopy. Felt it in my teeth.",
+    voltron:     "The Yellow Lion stomps and the earth answers."
+  },
+  voidbread: {
+    mc:          "Galley recording — hymn sung over recycled rations.",
+    lcars:       "Stardate 4170.3 — galley hymn, sung over recycled rations.",
+    starfighter: "The mess hall song. Sung loud, sung off-key, sung together.",
+    voltron:     "A blessing for the food, taught to the Paladins by the Olkari."
+  }
+};
+
+// Resolve a flavor line, with a safe fallback if a theme is missing copy.
+export function getFlavor(trackId, themeId) {
+  const entry = TRACK_FLAVOR[trackId];
+  if (!entry) return '';
+  return entry[themeId] || entry.mc || entry.lcars || '';
+}

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,8 @@ import { resolveMedicalStage, getMedicalStageView } from './systems/medicalEmerg
 import { WAYPOINTS } from './content/waypoints.js';
 import { makeLandmarkEncounter } from './content/landmarks.js';
 import './ui/codex.js';   // registers global click handler for codex terms
-import { GAMEPLAY_TRACKS, getSelectedTrackId, isMuted, playTitle, playGameplay, selectTrack, toggleMute, fadeOut, fadeInGameplay, cycleTrack, onTrackChange } from './audio.js';
+import { isMuted, playTitle, playGameplay, toggleMute, fadeOut, fadeInGameplay, cycleTrack } from './audio.js';
+import { openLounge } from './ui/lounge.js';
 
 let state = createInitialState();
 renderAll();
@@ -302,28 +303,13 @@ function renderAll() {
 }
 
 // ---- Music controls ----
-const musicSelect = document.getElementById('music-select');
-const musicMute   = document.getElementById('music-mute');
+const loungeOpenBtn = document.getElementById('lounge-open');
+const musicMute     = document.getElementById('music-mute');
 
-// Populate track selector.
-GAMEPLAY_TRACKS.forEach(t => {
-  const opt = document.createElement('option');
-  opt.value = t.id;
-  opt.textContent = t.name;
-  musicSelect.appendChild(opt);
-});
-musicSelect.value = getSelectedTrackId();
 musicMute.textContent = isMuted() ? '🔇' : '🔊';
 musicMute.classList.toggle('muted', isMuted());
 
-musicSelect.addEventListener('change', () => {
-  selectTrack(musicSelect.value);
-});
-
-// Keep dropdown in sync with shuffle-driven track changes.
-onTrackChange((id) => {
-  if (id !== 'title') musicSelect.value = id;
-});
+loungeOpenBtn.addEventListener('click', () => openLounge());
 
 musicMute.addEventListener('click', () => {
   const muted = toggleMute();
@@ -339,8 +325,7 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
     e.preventDefault();
     const dir = e.key === 'ArrowUp' ? -1 : 1;
-    const newId = cycleTrack(dir);
-    musicSelect.value = newId;
+    cycleTrack(dir);
   } else if (e.key === 'm' || e.key === 'M') {
     e.preventDefault();
     const muted = toggleMute();

--- a/src/theme.js
+++ b/src/theme.js
@@ -47,6 +47,11 @@ function populate(select) {
   }
 }
 
+export function getActiveTheme() {
+  if (typeof localStorage === 'undefined') return 'mc';
+  return resolveTheme(localStorage.getItem(STORAGE_KEY));
+}
+
 export function initTheme() {
   if (typeof document === 'undefined') return;
   const current = load();

--- a/src/theme.js
+++ b/src/theme.js
@@ -52,6 +52,13 @@ export function getActiveTheme() {
   return resolveTheme(localStorage.getItem(STORAGE_KEY));
 }
 
+export function setActiveTheme(raw) {
+  const next = resolveTheme(raw);
+  save(next);
+  apply(next);
+  return next;
+}
+
 export function initTheme() {
   if (typeof document === 'undefined') return;
   const current = load();

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -1,0 +1,224 @@
+// Mars Trail — The Lounge: a themed soundtrack jukebox screen.
+// Renders into #lounge-layer. Selecting a row calls audio.selectTrack
+// so playback continues seamlessly when the player closes the Lounge.
+
+import {
+  TITLE_TRACK,
+  GAMEPLAY_TRACKS,
+  selectTrack,
+  play,
+  togglePlayPause,
+  isPlaying,
+  isMuted,
+  toggleMute,
+  cycleTrack,
+  onTrackChange,
+  onTimeUpdate,
+  seekTo,
+  getCurrentTrackId,
+  getDuration,
+  getCurrentTime
+} from '../audio.js';
+import { getFlavor } from '../content/trackFlavor.js';
+import { getActiveTheme } from '../theme.js';
+
+const ALL_TRACKS = [TITLE_TRACK, ...GAMEPLAY_TRACKS];
+
+let opened = false;
+let onCloseCb = null;
+
+// Listeners are registered exactly once at module load. They no-op
+// whenever the Lounge is closed, so re-opening doesn't accumulate them.
+onTrackChange(() => {
+  if (!opened) return;
+  refreshNowPlaying();
+  refreshPlayPause();
+});
+onTimeUpdate((cur, dur) => {
+  if (!opened) return;
+  refreshProgress(cur, dur);
+});
+
+function fmtTime(sec) {
+  if (!isFinite(sec) || sec < 0) sec = 0;
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => (
+    { '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[c]
+  ));
+}
+
+function render() {
+  const layer = document.getElementById('lounge-layer');
+  if (!layer) return;
+  const theme = getActiveTheme();
+
+  const rows = ALL_TRACKS.map(t => `
+    <li class="lounge-row" data-track="${t.id}">
+      <div class="lounge-row-main">
+        <span class="lounge-row-name">${escapeHtml(t.name)}</span>
+        <span class="lounge-row-flavor">${escapeHtml(getFlavor(t.id, theme))}</span>
+      </div>
+      <span class="lounge-row-indicator" aria-hidden="true">▶</span>
+    </li>
+  `).join('');
+
+  layer.innerHTML = `
+    <div class="lounge-screen">
+      <header class="lounge-header">
+        <h1 class="lounge-title">THE LOUNGE</h1>
+        <button class="lounge-close" id="lounge-close" type="button" aria-label="Close the Lounge">CLOSE ✕</button>
+      </header>
+
+      <section class="lounge-now-playing" id="lounge-now-playing" aria-live="polite">
+        <div class="lounge-np-label">NOW PLAYING</div>
+        <div class="lounge-np-name"  id="lounge-np-name">—</div>
+        <div class="lounge-np-flavor" id="lounge-np-flavor"></div>
+        <div class="lounge-progress-row">
+          <span class="lounge-time" id="lounge-time-current">0:00</span>
+          <div class="lounge-progress" id="lounge-progress" role="slider"
+               aria-label="Seek" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+            <div class="lounge-progress-fill" id="lounge-progress-fill"></div>
+          </div>
+          <span class="lounge-time" id="lounge-time-total">0:00</span>
+        </div>
+        <div class="lounge-controls">
+          <button class="lounge-ctrl" id="lounge-prev"  type="button" aria-label="Previous track">⏮</button>
+          <button class="lounge-ctrl lounge-ctrl-play" id="lounge-playpause" type="button" aria-label="Play/Pause">⏸</button>
+          <button class="lounge-ctrl" id="lounge-next"  type="button" aria-label="Next track">⏭</button>
+          <button class="lounge-ctrl" id="lounge-mute"  type="button" aria-label="Mute/Unmute">🔊</button>
+        </div>
+      </section>
+
+      <section class="lounge-list-section">
+        <h2 class="lounge-list-header">SOUNDTRACK</h2>
+        <ul class="lounge-list" id="lounge-list">${rows}</ul>
+      </section>
+    </div>
+  `;
+
+  wire();
+  refreshNowPlaying();
+  refreshPlayPause();
+  refreshMute();
+  refreshProgress();
+}
+
+function wire() {
+  const layer = document.getElementById('lounge-layer');
+
+  layer.querySelector('#lounge-close').addEventListener('click', close);
+
+  layer.querySelector('#lounge-list').addEventListener('click', (e) => {
+    const row = e.target.closest('.lounge-row');
+    if (!row) return;
+    const id = row.dataset.track;
+    if (id === 'title') {
+      play('title');
+    } else {
+      selectTrack(id);
+    }
+  });
+
+  layer.querySelector('#lounge-prev').addEventListener('click', () => cycleTrack(-1));
+  layer.querySelector('#lounge-next').addEventListener('click', () => cycleTrack(1));
+  layer.querySelector('#lounge-playpause').addEventListener('click', () => {
+    togglePlayPause();
+    refreshPlayPause();
+  });
+  layer.querySelector('#lounge-mute').addEventListener('click', () => {
+    toggleMute();
+    refreshMute();
+  });
+
+  // Seek by clicking anywhere on the progress bar.
+  const bar = layer.querySelector('#lounge-progress');
+  const seekFromEvent = (e) => {
+    const rect = bar.getBoundingClientRect();
+    const x = (e.clientX ?? (e.touches?.[0]?.clientX ?? 0)) - rect.left;
+    seekTo(Math.max(0, Math.min(1, x / rect.width)));
+  };
+  bar.addEventListener('click', seekFromEvent);
+
+  // Drag-to-scrub.
+  let dragging = false;
+  bar.addEventListener('mousedown', (e) => { dragging = true; seekFromEvent(e); });
+  window.addEventListener('mousemove', (e) => { if (dragging) seekFromEvent(e); });
+  window.addEventListener('mouseup',   () => { dragging = false; });
+}
+
+function escClose(e) {
+  if (e.key === 'Escape' && opened) close();
+}
+
+function refreshNowPlaying() {
+  const id = getCurrentTrackId();
+  const track = ALL_TRACKS.find(t => t.id === id);
+  const layer = document.getElementById('lounge-layer');
+  if (!layer || !layer.querySelector('#lounge-np-name')) return;
+
+  layer.querySelector('#lounge-np-name').textContent = track ? track.name : '—';
+  layer.querySelector('#lounge-np-flavor').textContent = track ? getFlavor(track.id, getActiveTheme()) : '';
+
+  layer.querySelectorAll('.lounge-row').forEach(row => {
+    row.classList.toggle('playing', row.dataset.track === id);
+  });
+}
+
+function refreshProgress(current, duration) {
+  const layer = document.getElementById('lounge-layer');
+  if (!layer || !layer.querySelector('#lounge-progress-fill')) return;
+
+  const cur = (current !== undefined) ? current : getCurrentTime();
+  const dur = (duration !== undefined) ? duration : getDuration();
+  const pct = (dur > 0) ? Math.min(100, (cur / dur) * 100) : 0;
+
+  layer.querySelector('#lounge-progress-fill').style.width = `${pct}%`;
+  layer.querySelector('#lounge-progress').setAttribute('aria-valuenow', pct.toFixed(0));
+  layer.querySelector('#lounge-time-current').textContent = fmtTime(cur);
+  layer.querySelector('#lounge-time-total').textContent   = fmtTime(dur);
+}
+
+function refreshPlayPause() {
+  const layer = document.getElementById('lounge-layer');
+  const el = layer && layer.querySelector('#lounge-playpause');
+  if (!el) return;
+  el.textContent = isPlaying() ? '⏸' : '▶';
+}
+
+function refreshMute() {
+  const layer = document.getElementById('lounge-layer');
+  const el = layer && layer.querySelector('#lounge-mute');
+  if (!el) return;
+  el.textContent = isMuted() ? '🔇' : '🔊';
+}
+
+export function openLounge(onClose) {
+  if (opened) return;
+  opened = true;
+  onCloseCb = onClose || null;
+
+  const layer = document.getElementById('lounge-layer');
+  layer.classList.add('active');
+  render();
+
+  document.addEventListener('keydown', escClose);
+}
+
+export function close() {
+  if (!opened) return;
+  opened = false;
+  const layer = document.getElementById('lounge-layer');
+  if (layer) {
+    layer.classList.remove('active');
+    layer.innerHTML = '';
+  }
+  document.removeEventListener('keydown', escClose);
+  if (onCloseCb) { const cb = onCloseCb; onCloseCb = null; cb(); }
+}
+
+export function isLoungeOpen() { return opened; }

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -20,7 +20,7 @@ import {
   getCurrentTime
 } from '../audio.js';
 import { getFlavor } from '../content/trackFlavor.js';
-import { getActiveTheme } from '../theme.js';
+import { getActiveTheme, setActiveTheme, THEMES } from '../theme.js';
 
 const ALL_TRACKS = [TITLE_TRACK, ...GAMEPLAY_TRACKS];
 
@@ -71,7 +71,15 @@ function render() {
     <div class="lounge-screen">
       <header class="lounge-header">
         <h1 class="lounge-title">THE LOUNGE</h1>
-        <button class="lounge-close" id="lounge-close" type="button" aria-label="Close the Lounge">CLOSE ✕</button>
+        <div class="lounge-header-actions">
+          <label class="lounge-theme-label">
+            THEME
+            <select class="lounge-theme-select" id="lounge-theme-select" aria-label="Interface theme">
+              ${THEMES.map(t => `<option value="${t.id}" ${t.id === theme ? 'selected' : ''}>${escapeHtml(t.label)}</option>`).join('')}
+            </select>
+          </label>
+          <button class="lounge-close" id="lounge-close" type="button" aria-label="Close the Lounge">CLOSE ✕</button>
+        </div>
       </header>
 
       <section class="lounge-now-playing" id="lounge-now-playing" aria-live="polite">
@@ -112,6 +120,11 @@ function wire() {
   const layer = document.getElementById('lounge-layer');
 
   layer.querySelector('#lounge-close').addEventListener('click', close);
+
+  layer.querySelector('#lounge-theme-select').addEventListener('change', (e) => {
+    setActiveTheme(e.target.value);
+    render();   // re-render so flavor copy + skin update immediately
+  });
 
   layer.querySelector('#lounge-list').addEventListener('click', (e) => {
     const row = e.target.closest('.lounge-row');

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -169,10 +169,7 @@ export function showTitleLayer(onStart) {
       <p class="title-tagline">The colony is waiting. Earth cannot help you from here.</p>
       ${bestCaption}
       ${careerCaption}
-      <div class="title-actions">
-        <button class="title-start" id="title-start" type="button">START MISSION</button>
-        <button class="title-lounge" id="title-lounge" type="button">🎵 THE LOUNGE</button>
-      </div>
+      <button class="title-start" id="title-start" type="button">START MISSION</button>
       <div class="title-credits">
         <span class="title-credit-line">Created by</span>
         <span class="title-studio">Get Good Games and Tech</span>
@@ -184,9 +181,6 @@ export function showTitleLayer(onStart) {
   `;
 
   layer.querySelector('#title-start').addEventListener('click', onStart);
-  layer.querySelector('#title-lounge').addEventListener('click', () => {
-    import('./lounge.js').then(m => m.openLounge());
-  });
 }
 
 // Hide the START button once clicked; keep backdrop.

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -169,7 +169,10 @@ export function showTitleLayer(onStart) {
       <p class="title-tagline">The colony is waiting. Earth cannot help you from here.</p>
       ${bestCaption}
       ${careerCaption}
-      <button class="title-start" id="title-start" type="button">START MISSION</button>
+      <div class="title-actions">
+        <button class="title-start" id="title-start" type="button">START MISSION</button>
+        <button class="title-lounge" id="title-lounge" type="button">🎵 THE LOUNGE</button>
+      </div>
       <div class="title-credits">
         <span class="title-credit-line">Created by</span>
         <span class="title-studio">Get Good Games and Tech</span>
@@ -181,6 +184,9 @@ export function showTitleLayer(onStart) {
   `;
 
   layer.querySelector('#title-start').addEventListener('click', onStart);
+  layer.querySelector('#title-lounge').addEventListener('click', () => {
+    import('./lounge.js').then(m => m.openLounge());
+  });
 }
 
 // Hide the START button once clicked; keep backdrop.

--- a/styles/components.css
+++ b/styles/components.css
@@ -999,7 +999,7 @@ body[data-theme="lcars"] .eor-col-facts {
 .lounge-layer {
   position: fixed;
   inset: 0;
-  z-index: 90;
+  z-index: 600;        /* above title-layer (500), below modal-root (1000) */
   display: none;
   background: var(--bg);
   overflow: auto;
@@ -1027,6 +1027,32 @@ body[data-theme="lcars"] .eor-col-facts {
   letter-spacing: 0.15em;
   color: var(--fg);
   text-shadow: var(--glow);
+}
+.lounge-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.lounge-theme-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--fg-dim);
+}
+.lounge-theme-select {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 4px 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  cursor: pointer;
+}
+.lounge-theme-select option {
+  background: #000;
+  color: var(--fg);
 }
 .lounge-close {
   background: transparent;
@@ -1163,22 +1189,106 @@ body[data-theme="lcars"] .eor-col-facts {
 }
 .lounge-row.playing .lounge-row-indicator { visibility: visible; color: var(--fg); }
 
-/* Title screen — give the LOUNGE button a sibling layout */
-.title-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  align-items: center;
-  margin-top: 6px;
-}
-.title-lounge {
-  background: transparent;
-  color: var(--fg);
-  border: 1px solid var(--fg-faint);
-  padding: 8px 18px;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  letter-spacing: 0.15em;
+/* ----- Vinyl-record button ----- */
+/* Two stacked layers via background-image:
+   - top layer: thin concentric grooves (repeating-radial-gradient)
+   - bottom layer: solid black wax with a theme-colored center label
+   A separate ::after spot adds the center hole. */
+.lounge-vinyl {
+  appearance: none;
+  -webkit-appearance: none;
   cursor: pointer;
+  padding: 0;
+  box-sizing: border-box;
+  border: 1px solid var(--fg-faint);
+  border-radius: 50%;
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  background-color: #1a1a1a;
+  background-image:
+    /* Solid wax + theme-colored center label — clean album icon look. */
+    radial-gradient(circle at center,
+      var(--fg) 0,
+      var(--fg) 30%,
+      #0a0a0a 30.5%,
+      #0a0a0a 100%);
+  display: inline-block;
+  position: relative;
+  transition: box-shadow 0.2s ease;
+  flex-shrink: 0;
+  line-height: 0;
 }
-.title-lounge:hover { border-color: var(--fg); box-shadow: var(--glow); }
+.lounge-vinyl:hover {
+  box-shadow: 0 0 0 2px var(--fg), var(--glow);
+  animation: lounge-vinyl-spin 4s linear infinite;
+}
+
+@keyframes lounge-vinyl-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lounge-vinyl:hover { animation: none; }
+}
+.lounge-vinyl-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10%;
+  height: 10%;
+  border-radius: 50%;
+  background: #000;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.2);
+  z-index: 1;
+}
+
+/* Asymmetric outline arc — visible feature that reads as motion when
+   the disc spins. Lives inside the disc so overflow:hidden doesn't clip it. */
+.lounge-vinyl::after {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  border-top-color: var(--fg);
+  pointer-events: none;
+}
+
+.lounge-vinyl-sm { width: 30px; height: 30px; }
+.lounge-vinyl-md { width: 56px; height: 56px; }
+.lounge-vinyl-lg { width: 110px; height: 110px; }
+
+/* Floating Lounge button — anchored to lower-right of the viewport.
+   z-index 550 sits above the title-layer (500) so it appears on the
+   title screen too, but below the lounge-layer (600) so it's covered
+   while the Lounge is open, and below modal-root (1000). */
+.lounge-vinyl-corner {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 550;
+  box-shadow:
+    0 0 0 2px var(--fg-faint),
+    0 0 8px var(--fg-faint),
+    0 4px 14px rgba(0, 0, 0, 0.6);
+}
+
+.title-lounge {
+  background-color: transparent;     /* keep gradient from .lounge-vinyl */
+  color: var(--fg);
+  font-family: var(--font-mono);
+  position: relative;
+}
+.title-lounge-label {
+  position: absolute;
+  bottom: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--fg-dim);
+  white-space: nowrap;
+}
+.title-lounge:hover .title-lounge-label { color: var(--fg); }

--- a/styles/components.css
+++ b/styles/components.css
@@ -993,3 +993,192 @@ body[data-theme="lcars"] .eor-col-facts {
     box-shadow: 0 0 10px currentColor;
   }
 }
+
+/* ----- The Lounge ----- */
+
+.lounge-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: none;
+  background: var(--bg);
+  overflow: auto;
+}
+.lounge-layer.active { display: block; }
+
+.lounge-screen {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 24px 20px 48px;
+  display: grid;
+  gap: 20px;
+}
+
+.lounge-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--fg-faint);
+  padding-bottom: 8px;
+}
+.lounge-title {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: 0.15em;
+  color: var(--fg);
+  text-shadow: var(--glow);
+}
+.lounge-close {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 6px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+}
+.lounge-close:hover { border-color: var(--fg); box-shadow: var(--glow); }
+
+.lounge-now-playing {
+  border: 1px solid var(--fg-faint);
+  padding: 14px 16px;
+  background: var(--bg-panel);
+}
+.lounge-np-label {
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--fg-dim);
+}
+.lounge-np-name {
+  font-size: 18px;
+  margin: 4px 0 4px;
+  color: var(--fg);
+  text-shadow: var(--glow);
+}
+.lounge-np-flavor {
+  font-size: 12px;
+  color: var(--fg-dim);
+  font-style: italic;
+  min-height: 1.4em;
+}
+
+.lounge-progress-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+}
+.lounge-time {
+  font-size: 11px;
+  color: var(--fg-dim);
+  min-width: 3.2em;
+  text-align: center;
+}
+.lounge-progress {
+  position: relative;
+  height: 6px;
+  background: var(--fg-faint);
+  cursor: pointer;
+  user-select: none;
+}
+.lounge-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  background: var(--fg);
+  box-shadow: var(--glow);
+  transition: width 120ms linear;
+}
+
+.lounge-controls {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  justify-content: center;
+}
+.lounge-ctrl {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 6px 12px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  cursor: pointer;
+  min-width: 44px;
+}
+.lounge-ctrl:hover { border-color: var(--fg); box-shadow: var(--glow); }
+.lounge-ctrl-play  { min-width: 56px; }
+
+.lounge-list-section { display: grid; gap: 8px; }
+.lounge-list-header {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--fg-dim);
+  border-bottom: 1px dashed var(--fg-faint);
+  padding-bottom: 4px;
+}
+
+.lounge-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+}
+.lounge-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.lounge-row:hover {
+  border-color: var(--fg-faint);
+  background: var(--bg-panel);
+}
+.lounge-row.playing {
+  border-color: var(--fg);
+  background: var(--bg-panel);
+  box-shadow: var(--glow);
+}
+.lounge-row-main { display: grid; gap: 2px; min-width: 0; }
+.lounge-row-name {
+  font-size: 14px;
+  color: var(--fg);
+}
+.lounge-row-flavor {
+  font-size: 11px;
+  color: var(--fg-dim);
+  font-style: italic;
+}
+.lounge-row-indicator {
+  color: var(--fg-faint);
+  font-size: 12px;
+  visibility: hidden;
+}
+.lounge-row.playing .lounge-row-indicator { visibility: visible; color: var(--fg); }
+
+/* Title screen — give the LOUNGE button a sibling layout */
+.title-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  margin-top: 6px;
+}
+.title-lounge {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 8px 18px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.15em;
+  cursor: pointer;
+}
+.title-lounge:hover { border-color: var(--fg); box-shadow: var(--glow); }

--- a/styles/theme-lcars.css
+++ b/styles/theme-lcars.css
@@ -288,3 +288,21 @@ body[data-theme="lcars"] .theme-select option {
   color: var(--fg);
   background: #000;
 }
+
+/* ----- Lounge — LCARS skin ----- */
+body[data-theme="lcars"] .lounge-now-playing,
+body[data-theme="lcars"] .lounge-row { border-radius: 0 12px 0 12px; }
+body[data-theme="lcars"] .lounge-row.playing {
+  background: var(--fg);
+  color: var(--bg);
+}
+body[data-theme="lcars"] .lounge-row.playing .lounge-row-name,
+body[data-theme="lcars"] .lounge-row.playing .lounge-row-flavor {
+  color: var(--bg);
+}
+body[data-theme="lcars"] .lounge-row.playing .lounge-row-indicator {
+  color: var(--bg);
+}
+body[data-theme="lcars"] .lounge-progress { border-radius: 999px; height: 8px; }
+body[data-theme="lcars"] .lounge-progress-fill { border-radius: 999px; }
+body[data-theme="lcars"] .lounge-title { letter-spacing: 0.18em; }

--- a/styles/theme-starfighter.css
+++ b/styles/theme-starfighter.css
@@ -477,3 +477,28 @@ body[data-theme="starfighter"] .route-image {
   border: 1px solid var(--sf-red-dim);
   border-radius: 0;
 }
+
+/* ----- Lounge — Starfighter skin ----- */
+body[data-theme="starfighter"] .lounge-screen { padding-top: 32px; }
+body[data-theme="starfighter"] .lounge-title {
+  letter-spacing: 0.25em;
+  color: var(--sf-red);
+}
+body[data-theme="starfighter"] .lounge-now-playing,
+body[data-theme="starfighter"] .lounge-row {
+  border-style: dashed;
+  border-color: var(--sf-red-dim);
+}
+body[data-theme="starfighter"] .lounge-row:hover {
+  border-color: var(--fg-faint);
+}
+body[data-theme="starfighter"] .lounge-row.playing {
+  border-style: solid;
+  border-color: var(--sf-red);
+  background: rgba(255, 40, 64, 0.06);
+}
+body[data-theme="starfighter"] .lounge-progress { height: 4px; background: var(--sf-red-dim); }
+body[data-theme="starfighter"] .lounge-progress-fill { background: var(--fg); }
+body[data-theme="starfighter"] .lounge-np-name { color: var(--fg); }
+body[data-theme="starfighter"] .lounge-ctrl { border-color: var(--sf-red-dim); }
+body[data-theme="starfighter"] .lounge-ctrl:hover { border-color: var(--sf-red); }

--- a/styles/theme-voltron.css
+++ b/styles/theme-voltron.css
@@ -231,3 +231,28 @@ body[data-theme="voltron"] .theme-select option {
   background: var(--bg);
   color: var(--fg);
 }
+
+/* ----- Lounge — Voltron skin ----- */
+body[data-theme="voltron"] .lounge-title {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+}
+body[data-theme="voltron"] .lounge-now-playing,
+body[data-theme="voltron"] .lounge-row {
+  border-width: 2px;
+  border-color: var(--fg-faint);
+}
+body[data-theme="voltron"] .lounge-row.playing {
+  border-color: var(--fg-dim);
+  box-shadow: var(--glow);
+}
+body[data-theme="voltron"] .lounge-progress {
+  background: rgba(75, 216, 255, 0.18);
+  height: 6px;
+}
+body[data-theme="voltron"] .lounge-progress-fill {
+  background: var(--fg-dim);
+  box-shadow: 0 0 6px rgba(75, 216, 255, 0.9);
+}
+body[data-theme="voltron"] .lounge-ctrl { border-color: var(--fg-faint); }
+body[data-theme="voltron"] .lounge-ctrl:hover { border-color: var(--fg-dim); }


### PR DESCRIPTION
Closes #70.

## Summary
Adds **The Lounge**, a soundtrack jukebox screen with theme-flavored copy per track, now-playing card with seekable progress bar, and play/pause/prev/next/mute controls. Reachable from a single floating vinyl-record button in the lower-right corner (visible on title screen and during gameplay).

## What's in the Lounge
- 1 title theme + 7 gameplay tracks
- Each row shows the track name + per-theme flavor copy (mc / lcars / starfighter / voltron)
- Now-playing card with elapsed/total time and click/drag-to-seek progress bar
- Play/pause, prev, next, mute controls
- THEME selector inside the Lounge header (the topbar is covered while the Lounge is open)
- ESC or CLOSE ✕ to exit; music keeps playing seamlessly

## Implementation notes
- Extended \`src/audio.js\` with \`seekTo\` / \`getProgress\` / \`togglePlayPause\` / \`onTimeUpdate\` and friends
- Removed the topbar music \`<select>\` (the Lounge is now the canonical music UI)
- Replaced title-screen LOUNGE button with the floating vinyl (single entry point everywhere)
- Per-theme Lounge skins in each \`theme-*.css\` using existing theme tokens

## Test plan
- [x] Title screen → vinyl visible in lower-right, opens Lounge
- [x] Click a row → that track plays; highlight follows
- [x] Play/pause / prev / next / mute work and reflect state
- [x] Progress bar: click to seek, drag to scrub
- [x] In-Lounge THEME selector switches skin + flavor copy
- [x] ESC and CLOSE ✕ both close; music keeps playing
- [x] Track + mute persist across reload (localStorage)
- [x] No regressions to gameplay shuffle / title loop / fade in/out