### PR TITLE
v0.12.0: soundtrack visualizer + bubble-pop game

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "type": "module",
   "private": true,
-  "version": "0.11.0"
+  "version": "0.12.0"
 }

--- a/src/audio.js
+++ b/src/audio.js
@@ -211,3 +211,37 @@ export function togglePlayPause() {
   if (audio.paused) resumeAudio(); else pauseAudio();
   return !audio.paused;
 }
+
+// ---- Web Audio analyser (used by the Lounge visualizer) ----
+// Lazily wires the existing <audio> element through an AnalyserNode.
+// Created on first call (which only happens after the user opens the
+// Lounge — i.e., after a user gesture, satisfying autoplay policies).
+let analyser = null;
+let audioCtx = null;
+let mediaSource = null;
+
+export function getAnalyser() {
+  if (analyser) return analyser;
+  try {
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    if (!AudioCtx) return null;
+    audioCtx    = new AudioCtx();
+    mediaSource = audioCtx.createMediaElementSource(audio);
+    analyser    = audioCtx.createAnalyser();
+    analyser.fftSize = 256;
+    analyser.smoothingTimeConstant = 0.6;
+    mediaSource.connect(analyser);
+    analyser.connect(audioCtx.destination);
+    return analyser;
+  } catch (err) {
+    // createMediaElementSource throws if called twice on the same element.
+    // Anything else: degrade silently — visualizer falls back to backdrop-only.
+    return analyser;
+  }
+}
+
+export function resumeAudioContext() {
+  if (audioCtx && audioCtx.state === 'suspended') {
+    audioCtx.resume().catch(() => {});
+  }
+}

--- a/src/audio.js
+++ b/src/audio.js
@@ -4,6 +4,7 @@
 
 const STORAGE_KEY_TRACK = 'marsTrail.musicTrack';
 const STORAGE_KEY_MUTE  = 'marsTrail.musicMute';
+const STORAGE_KEY_SFX   = 'marsTrail.sfxMute';
 
 export const TITLE_TRACK = {
   id: 'title', name: 'Title Theme', file: 'assets/music/title-screen.mp3'
@@ -243,5 +244,68 @@ export function getAnalyser() {
 export function resumeAudioContext() {
   if (audioCtx && audioCtx.state === 'suspended') {
     audioCtx.resume().catch(() => {});
+  }
+}
+
+// ---- SFX (game-action sounds, separate from music mute) ----
+
+export function isSfxMuted() {
+  return localStorage.getItem(STORAGE_KEY_SFX) === '1';
+}
+
+export function setSfxMuted(muted) {
+  localStorage.setItem(STORAGE_KEY_SFX, muted ? '1' : '0');
+}
+
+export function toggleSfx() {
+  const next = !isSfxMuted();
+  setSfxMuted(next);
+  return next;
+}
+
+function getSfxContext() {
+  if (audioCtx) return audioCtx;
+  try {
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    if (!AudioCtx) return null;
+    audioCtx = new AudioCtx();
+    return audioCtx;
+  } catch { return null; }
+}
+
+export function playSfx(kind) {
+  if (isSfxMuted()) return;
+  const ac = getSfxContext();
+  if (!ac) return;
+  if (ac.state === 'suspended') ac.resume().catch(() => {});
+
+  const now = ac.currentTime;
+
+  if (kind === 'good') {
+    // Pleasant short pop — triangle wave, quick upward chirp.
+    const osc  = ac.createOscillator();
+    const gain = ac.createGain();
+    osc.type = 'triangle';
+    osc.frequency.setValueAtTime(660, now);
+    osc.frequency.exponentialRampToValueAtTime(1320, now + 0.08);
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.22, now + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.18);
+    osc.connect(gain).connect(ac.destination);
+    osc.start(now);
+    osc.stop(now + 0.22);
+  } else if (kind === 'bad') {
+    // Low thunk — square wave, downward slide.
+    const osc  = ac.createOscillator();
+    const gain = ac.createGain();
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(220, now);
+    osc.frequency.exponentialRampToValueAtTime(70, now + 0.18);
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.28, now + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.30);
+    osc.connect(gain).connect(ac.destination);
+    osc.start(now);
+    osc.stop(now + 0.34);
   }
 }

--- a/src/content/trackPalettes.js
+++ b/src/content/trackPalettes.js
@@ -1,0 +1,20 @@
+// Mars Trail — per-track 2-color palettes for the soundtrack visualizer.
+// Keys are the audio.js track ids ('title' + GAMEPLAY_TRACKS ids).
+// Two colors per track: bg (background drift base) and accent (pulse + orb highlight).
+
+export const TRACK_PALETTES = {
+  title:     { bg: '#1a0a3d', accent: '#a060ff' },
+  vacuum:    { bg: '#001a3a', accent: '#80a0ff' },
+  choir:     { bg: '#4d3a1a', accent: '#ffc850' },
+  violin:    { bg: '#4d1a3a', accent: '#ff50b4' },
+  void:      { bg: '#0a1a0a', accent: '#50ff80' },
+  star:      { bg: '#2a2a2a', accent: '#e0e0e0' },
+  crater:    { bg: '#3a1a0a', accent: '#ff8050' },
+  voidbread: { bg: '#1a3d2a', accent: '#80ffc0' }
+};
+
+const FALLBACK = TRACK_PALETTES.title;
+
+export function getPalette(trackId) {
+  return TRACK_PALETTES[trackId] || FALLBACK;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -317,14 +317,15 @@ musicMute.addEventListener('click', () => {
   musicMute.classList.toggle('muted', muted);
 });
 
-// Up/down arrows cycle gameplay tracks; M toggles mute.
+// Left/right arrows cycle gameplay tracks; M toggles mute.
+// (Up/down arrows are reserved for the Lounge bubble-count game.)
 document.addEventListener('keydown', (e) => {
   // Don't hijack keys when a select/input is focused.
   if (document.activeElement && (document.activeElement.tagName === 'SELECT' || document.activeElement.tagName === 'INPUT')) return;
 
-  if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
     e.preventDefault();
-    const dir = e.key === 'ArrowUp' ? -1 : 1;
+    const dir = e.key === 'ArrowLeft' ? -1 : 1;
     cycleTrack(dir);
   } else if (e.key === 'm' || e.key === 'M') {
     e.preventDefault();

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -21,6 +21,7 @@ import {
 } from '../audio.js';
 import { getFlavor } from '../content/trackFlavor.js';
 import { getActiveTheme, setActiveTheme, THEMES } from '../theme.js';
+import { startVisualizer, stopVisualizer } from './visualizer.js';
 
 const ALL_TRACKS = [TITLE_TRACK, ...GAMEPLAY_TRACKS];
 
@@ -83,23 +84,26 @@ function render() {
       </header>
 
       <section class="lounge-now-playing" id="lounge-now-playing" aria-live="polite">
-        <div class="lounge-np-label">NOW PLAYING</div>
-        <div class="lounge-np-name"  id="lounge-np-name">—</div>
-        <div class="lounge-np-flavor" id="lounge-np-flavor"></div>
-        <div class="lounge-progress-row">
-          <span class="lounge-time" id="lounge-time-current">0:00</span>
-          <div class="lounge-progress" id="lounge-progress" role="slider"
-               aria-label="Seek" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-            <div class="lounge-progress-fill" id="lounge-progress-fill"></div>
+        <div class="lounge-np-text">
+          <div class="lounge-np-label">NOW PLAYING</div>
+          <div class="lounge-np-name"  id="lounge-np-name">—</div>
+          <div class="lounge-np-flavor" id="lounge-np-flavor"></div>
+          <div class="lounge-progress-row">
+            <span class="lounge-time" id="lounge-time-current">0:00</span>
+            <div class="lounge-progress" id="lounge-progress" role="slider"
+                 aria-label="Seek" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <div class="lounge-progress-fill" id="lounge-progress-fill"></div>
+            </div>
+            <span class="lounge-time" id="lounge-time-total">0:00</span>
           </div>
-          <span class="lounge-time" id="lounge-time-total">0:00</span>
+          <div class="lounge-controls">
+            <button class="lounge-ctrl" id="lounge-prev"  type="button" aria-label="Previous track">⏮</button>
+            <button class="lounge-ctrl lounge-ctrl-play" id="lounge-playpause" type="button" aria-label="Play/Pause">⏸</button>
+            <button class="lounge-ctrl" id="lounge-next"  type="button" aria-label="Next track">⏭</button>
+            <button class="lounge-ctrl" id="lounge-mute"  type="button" aria-label="Mute/Unmute">🔊</button>
+          </div>
         </div>
-        <div class="lounge-controls">
-          <button class="lounge-ctrl" id="lounge-prev"  type="button" aria-label="Previous track">⏮</button>
-          <button class="lounge-ctrl lounge-ctrl-play" id="lounge-playpause" type="button" aria-label="Play/Pause">⏸</button>
-          <button class="lounge-ctrl" id="lounge-next"  type="button" aria-label="Next track">⏭</button>
-          <button class="lounge-ctrl" id="lounge-mute"  type="button" aria-label="Mute/Unmute">🔊</button>
-        </div>
+        <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
       </section>
 
       <section class="lounge-list-section">
@@ -123,7 +127,10 @@ function wire() {
 
   layer.querySelector('#lounge-theme-select').addEventListener('change', (e) => {
     setActiveTheme(e.target.value);
-    render();   // re-render so flavor copy + skin update immediately
+    stopVisualizer();
+    render();
+    const c = document.getElementById('lounge-visualizer');
+    if (c) startVisualizer(c, getCurrentTrackId);
   });
 
   layer.querySelector('#lounge-list').addEventListener('click', (e) => {
@@ -219,12 +226,16 @@ export function openLounge(onClose) {
   layer.classList.add('active');
   render();
 
+  const canvas = layer.querySelector('#lounge-visualizer');
+  if (canvas) startVisualizer(canvas, getCurrentTrackId);
+
   document.addEventListener('keydown', escClose);
 }
 
 export function close() {
   if (!opened) return;
   opened = false;
+  stopVisualizer();
   const layer = document.getElementById('lounge-layer');
   if (layer) {
     layer.classList.remove('active');

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -21,7 +21,7 @@ import {
 } from '../audio.js';
 import { getFlavor } from '../content/trackFlavor.js';
 import { getActiveTheme, setActiveTheme, THEMES } from '../theme.js';
-import { startVisualizer, stopVisualizer } from './visualizer.js';
+import { startVisualizer, stopVisualizer, popBubbleAt } from './visualizer.js';
 
 const ALL_TRACKS = [TITLE_TRACK, ...GAMEPLAY_TRACKS];
 
@@ -103,8 +103,11 @@ function render() {
             <button class="lounge-ctrl" id="lounge-mute"  type="button" aria-label="Mute/Unmute">🔊</button>
           </div>
         </div>
-        <div class="lounge-visualizer-frame" id="lounge-visualizer-frame" role="button" tabindex="0" aria-label="Toggle fullscreen visualizer" title="Click for fullscreen">
-          <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
+        <div class="lounge-visualizer-wrap">
+          <div class="lounge-visualizer-frame" id="lounge-visualizer-frame">
+            <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
+          </div>
+          <div class="lounge-visualizer-hint">CLICK BUBBLES TO POP · F TO TOGGLE FULLSCREEN</div>
         </div>
       </section>
 
@@ -158,20 +161,9 @@ function wire() {
   });
 
   const visFrame = layer.querySelector('#lounge-visualizer-frame');
-  const toggleFullscreen = () => {
-    const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
-    if (fsEl) {
-      (document.exitFullscreen || document.webkitExitFullscreen).call(document);
-    } else {
-      (visFrame.requestFullscreen || visFrame.webkitRequestFullscreen).call(visFrame);
-    }
-  };
-  visFrame.addEventListener('click', toggleFullscreen);
-  visFrame.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      toggleFullscreen();
-    }
+  visFrame.addEventListener('click', (e) => {
+    const rect = visFrame.getBoundingClientRect();
+    popBubbleAt(e.clientX - rect.left, e.clientY - rect.top);
   });
 
   // Seek by clicking anywhere on the progress bar.
@@ -191,7 +183,28 @@ function wire() {
 }
 
 function escClose(e) {
-  if (e.key === 'Escape' && opened) close();
+  if (!opened) return;
+  if (e.key === 'Escape') {
+    // If in fullscreen, let the browser handle ESC (it'll exit fullscreen);
+    // only close the Lounge when not in fullscreen.
+    const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+    if (!fsEl) close();
+    return;
+  }
+  if (e.key === 'f' || e.key === 'F') {
+    // Don't hijack the key while a select/input is focused.
+    const ae = document.activeElement;
+    if (ae && (ae.tagName === 'SELECT' || ae.tagName === 'INPUT')) return;
+    e.preventDefault();
+    const frame = document.getElementById('lounge-visualizer-frame');
+    if (!frame) return;
+    const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+    if (fsEl) {
+      (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+    } else {
+      (frame.requestFullscreen || frame.webkitRequestFullscreen).call(frame);
+    }
+  }
 }
 
 function refreshNowPlaying() {

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -17,7 +17,9 @@ import {
   seekTo,
   getCurrentTrackId,
   getDuration,
-  getCurrentTime
+  getCurrentTime,
+  isSfxMuted,
+  toggleSfx
 } from '../audio.js';
 import { getFlavor } from '../content/trackFlavor.js';
 import { getActiveTheme, setActiveTheme, THEMES } from '../theme.js';
@@ -107,7 +109,10 @@ function render() {
           <div class="lounge-visualizer-frame" id="lounge-visualizer-frame">
             <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
           </div>
-          <div class="lounge-visualizer-hint">CLICK BUBBLES TO POP · F TO TOGGLE FULLSCREEN</div>
+          <div class="lounge-visualizer-footer">
+            <span class="lounge-visualizer-hint">POP BUBBLES BEFORE THEY HIT THE DIAMOND · F FULLSCREEN</span>
+            <button class="lounge-sfx-btn" id="lounge-sfx" type="button" aria-label="Toggle pop sounds" title="Toggle pop sounds">${isSfxMuted() ? '🔇' : '🔊'}</button>
+          </div>
         </div>
       </section>
 
@@ -164,6 +169,12 @@ function wire() {
   visFrame.addEventListener('click', (e) => {
     const rect = visFrame.getBoundingClientRect();
     popBubbleAt(e.clientX - rect.left, e.clientY - rect.top);
+  });
+
+  const sfxBtn = layer.querySelector('#lounge-sfx');
+  sfxBtn.addEventListener('click', () => {
+    const muted = toggleSfx();
+    sfxBtn.textContent = muted ? '🔇' : '🔊';
   });
 
   // Seek by clicking anywhere on the progress bar.

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -103,7 +103,10 @@ function render() {
             <button class="lounge-ctrl" id="lounge-mute"  type="button" aria-label="Mute/Unmute">🔊</button>
           </div>
         </div>
-        <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
+        <div class="lounge-visualizer-frame" id="lounge-visualizer-frame">
+          <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
+          <button class="lounge-fullscreen-btn" id="lounge-fullscreen" type="button" aria-label="Toggle fullscreen visualizer" title="Fullscreen">⛶</button>
+        </div>
       </section>
 
       <section class="lounge-list-section">
@@ -153,6 +156,17 @@ function wire() {
   layer.querySelector('#lounge-mute').addEventListener('click', () => {
     toggleMute();
     refreshMute();
+  });
+
+  layer.querySelector('#lounge-fullscreen').addEventListener('click', () => {
+    const frame = layer.querySelector('#lounge-visualizer-frame');
+    if (!frame) return;
+    const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+    if (fsEl) {
+      (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+    } else {
+      (frame.requestFullscreen || frame.webkitRequestFullscreen).call(frame);
+    }
   });
 
   // Seek by clicking anywhere on the progress bar.

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -23,7 +23,7 @@ import {
 } from '../audio.js';
 import { getFlavor } from '../content/trackFlavor.js';
 import { getActiveTheme, setActiveTheme, THEMES } from '../theme.js';
-import { startVisualizer, stopVisualizer, popBubbleAt } from './visualizer.js';
+import { startVisualizer, stopVisualizer, popBubbleAt, addBubble, removeBubble } from './visualizer.js';
 
 const ALL_TRACKS = [TITLE_TRACK, ...GAMEPLAY_TRACKS];
 
@@ -203,7 +203,6 @@ function escClose(e) {
     return;
   }
   if (e.key === 'f' || e.key === 'F') {
-    // Don't hijack the key while a select/input is focused.
     const ae = document.activeElement;
     if (ae && (ae.tagName === 'SELECT' || ae.tagName === 'INPUT')) return;
     e.preventDefault();
@@ -215,6 +214,13 @@ function escClose(e) {
     } else {
       (frame.requestFullscreen || frame.webkitRequestFullscreen).call(frame);
     }
+    return;
+  }
+  if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+    const ae = document.activeElement;
+    if (ae && (ae.tagName === 'SELECT' || ae.tagName === 'INPUT')) return;
+    e.preventDefault();
+    if (e.key === 'ArrowUp') addBubble(); else removeBubble();
   }
 }
 

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -103,9 +103,8 @@ function render() {
             <button class="lounge-ctrl" id="lounge-mute"  type="button" aria-label="Mute/Unmute">🔊</button>
           </div>
         </div>
-        <div class="lounge-visualizer-frame" id="lounge-visualizer-frame">
+        <div class="lounge-visualizer-frame" id="lounge-visualizer-frame" role="button" tabindex="0" aria-label="Toggle fullscreen visualizer" title="Click for fullscreen">
           <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
-          <button class="lounge-fullscreen-btn" id="lounge-fullscreen" type="button" aria-label="Toggle fullscreen visualizer" title="Fullscreen">⛶</button>
         </div>
       </section>
 
@@ -158,14 +157,20 @@ function wire() {
     refreshMute();
   });
 
-  layer.querySelector('#lounge-fullscreen').addEventListener('click', () => {
-    const frame = layer.querySelector('#lounge-visualizer-frame');
-    if (!frame) return;
+  const visFrame = layer.querySelector('#lounge-visualizer-frame');
+  const toggleFullscreen = () => {
     const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
     if (fsEl) {
       (document.exitFullscreen || document.webkitExitFullscreen).call(document);
     } else {
-      (frame.requestFullscreen || frame.webkitRequestFullscreen).call(frame);
+      (visFrame.requestFullscreen || visFrame.webkitRequestFullscreen).call(visFrame);
+    }
+  };
+  visFrame.addEventListener('click', toggleFullscreen);
+  visFrame.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleFullscreen();
     }
   });
 

--- a/src/ui/lounge.js
+++ b/src/ui/lounge.js
@@ -23,12 +23,13 @@ import {
 } from '../audio.js';
 import { getFlavor } from '../content/trackFlavor.js';
 import { getActiveTheme, setActiveTheme, THEMES } from '../theme.js';
-import { startVisualizer, stopVisualizer, popBubbleAt, addBubble, removeBubble } from './visualizer.js';
+import { startVisualizer, stopVisualizer, popBubbleAt, addBubble, removeBubble, getScore, getBubbleCount } from './visualizer.js';
 
 const ALL_TRACKS = [TITLE_TRACK, ...GAMEPLAY_TRACKS];
 
 let opened = false;
 let onCloseCb = null;
+let hudInterval = 0;
 
 // Listeners are registered exactly once at module load. They no-op
 // whenever the Lounge is closed, so re-opening doesn't accumulate them.
@@ -108,6 +109,14 @@ function render() {
         <div class="lounge-visualizer-wrap">
           <div class="lounge-visualizer-frame" id="lounge-visualizer-frame">
             <canvas class="lounge-visualizer" id="lounge-visualizer" aria-hidden="true"></canvas>
+            <div class="lounge-hud" id="lounge-hud" aria-hidden="true">
+              <div class="hud-track" id="hud-track">—</div>
+              <div class="hud-time"  id="hud-time">0:00 / 0:00</div>
+              <div class="hud-stats">
+                <span id="hud-score">SCORE  +0</span>
+                <span id="hud-bubbles">BUBBLES  0</span>
+              </div>
+            </div>
           </div>
           <div class="lounge-visualizer-footer">
             <span class="lounge-visualizer-hint">POP BUBBLES BEFORE THEY HIT THE DIAMOND · F FULLSCREEN</span>
@@ -224,6 +233,24 @@ function escClose(e) {
   }
 }
 
+function refreshHud() {
+  const layer = document.getElementById('lounge-layer');
+  if (!layer) return;
+  const trackEl = layer.querySelector('#hud-track');
+  const timeEl  = layer.querySelector('#hud-time');
+  const scoreEl = layer.querySelector('#hud-score');
+  const bubEl   = layer.querySelector('#hud-bubbles');
+  if (!trackEl || !timeEl || !scoreEl || !bubEl) return;
+
+  const id = getCurrentTrackId();
+  const track = ALL_TRACKS.find(t => t.id === id);
+  trackEl.textContent = track ? track.name : '—';
+  timeEl.textContent  = `${fmtTime(getCurrentTime())} / ${fmtTime(getDuration())}`;
+  const s = getScore();
+  scoreEl.textContent  = `SCORE  ${s >= 0 ? '+' : ''}${s}`;
+  bubEl.textContent    = `BUBBLES  ${getBubbleCount()}`;
+}
+
 function refreshNowPlaying() {
   const id = getCurrentTrackId();
   const track = ALL_TRACKS.find(t => t.id === id);
@@ -278,12 +305,16 @@ export function openLounge(onClose) {
   const canvas = layer.querySelector('#lounge-visualizer');
   if (canvas) startVisualizer(canvas, getCurrentTrackId);
 
+  refreshHud();
+  hudInterval = setInterval(refreshHud, 200);
+
   document.addEventListener('keydown', escClose);
 }
 
 export function close() {
   if (!opened) return;
   opened = false;
+  if (hudInterval) { clearInterval(hudInterval); hudInterval = 0; }
   stopVisualizer();
   const layer = document.getElementById('lounge-layer');
   if (layer) {

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -159,8 +159,8 @@ function drawBubbleBody(b, cx, cy, r, bodyProgress, t) {
   const orbitR     = rr * 0.38;
   const hx = cx + Math.cos(orbitAngle) * orbitR;
   const hy = cy + Math.sin(orbitAngle) * orbitR;
-  ctx.strokeStyle = `rgba(255,255,255,${0.92 * alphaMul})`;
-  ctx.lineWidth = 1.4;
+  ctx.strokeStyle = `rgba(255,255,255,${0.35 * alphaMul})`;
+  ctx.lineWidth = 1;
   ctx.beginPath();
   ctx.ellipse(hx, hy, rr * b.highlightMajor, rr * b.highlightMinor, tiltAngle, 0, Math.PI * 2);
   ctx.stroke();

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -13,6 +13,12 @@ const TRIGGER_FACTOR = 1.40;   // RMS must exceed avg * this to spawn a ring
 const TRIGGER_MIN_GAP = 350;   // ms between ring spawns
 const RMS_HISTORY    = 30;     // ~0.5s @ 60fps for moving average
 
+const BUBBLE_COUNT     = 4;
+const BUBBLE_POINTS    = 64;
+const BUBBLE_HARMONICS = 3;
+const POP_DURATION     = 280;    // ms — how long the burst animation lasts
+const POP_HIT_PADDING  = 6;      // px slop on the hit radius (forgiving clicks)
+
 let canvas = null;
 let ctx    = null;
 let getTrackIdFn = null;
@@ -20,6 +26,7 @@ let rafId = 0;
 let analyser = null;
 let timeData = null;
 let orbs = [];
+let bubbles = [];
 let rings = [];
 let rmsHistory = [];
 let lastTriggerAt = 0;
@@ -35,6 +42,144 @@ function resizeCanvasToBackingStore() {
     canvas.height = targetH;
   }
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function makeBubble(palette, i) {
+  // Closed wobbly curve with a slight spec highlight — reads as a soft
+  // bubble. Drifts slowly until popped.
+  return {
+    cx: 0.2 + Math.random() * 0.6,
+    cy: 0.2 + Math.random() * 0.6,
+    baseR: 0.10 + Math.random() * 0.10,
+    driftFreqX: 0.00006 + Math.random() * 0.0001,
+    driftFreqY: 0.00006 + Math.random() * 0.0001,
+    driftAmpX: 0.08 + Math.random() * 0.06,
+    driftAmpY: 0.06 + Math.random() * 0.06,
+    phaseX: Math.random() * Math.PI * 2,
+    phaseY: Math.random() * Math.PI * 2,
+    harmonics: Array.from({ length: BUBBLE_HARMONICS }, () => ({
+      k:     2 + Math.floor(Math.random() * 4),
+      amp:   0.03 + Math.random() * 0.05,
+      freq:  0.0003 + Math.random() * 0.0006,
+      phase: Math.random() * Math.PI * 2
+    })),
+    color: i % 2 === 0 ? palette.accent : palette.bg,
+    state: 'alive',           // or 'popping'
+    popStartedAt: 0,
+    popParticles: null,       // populated when popped
+    _lastCx: 0, _lastCy: 0, _lastR: 0,
+    _paletteSig: paletteSig(palette)
+  };
+}
+
+function buildBubbles(palette) {
+  return Array.from({ length: BUBBLE_COUNT }, (_, i) => makeBubble(palette, i));
+}
+
+function drawBubbles(w, h, t, now) {
+  const minDim = Math.min(w, h);
+  for (let bi = 0; bi < bubbles.length; bi++) {
+    const b = bubbles[bi];
+    const cx = w * (b.cx + Math.sin(t * b.driftFreqX + b.phaseX) * b.driftAmpX);
+    const cy = h * (b.cy + Math.cos(t * b.driftFreqY + b.phaseY) * b.driftAmpY);
+    const baseR = minDim * b.baseR;
+
+    // Cache for hit-testing in popBubbleAt().
+    b._lastCx = cx; b._lastCy = cy; b._lastR = baseR;
+
+    if (b.state === 'popping') {
+      const age = now - b.popStartedAt;
+      if (age >= POP_DURATION) {
+        const palette = getPalette(getTrackIdFn ? getTrackIdFn() : null);
+        bubbles[bi] = makeBubble(palette, bi);
+        continue;
+      }
+      drawBubbleBody(b, cx, cy, baseR, t, /*popProgress*/ age / POP_DURATION);
+      drawPopParticles(b, age / POP_DURATION);
+      continue;
+    }
+
+    drawBubbleBody(b, cx, cy, baseR, t, 0);
+  }
+}
+
+function drawBubbleBody(b, cx, cy, baseR, t, popProgress) {
+  // popProgress 0 → 1 inflates the bubble and fades it out.
+  const scale = 1 + popProgress * 0.5;
+  const alphaMul = 1 - popProgress;
+  const r = baseR * scale;
+
+  ctx.beginPath();
+  for (let i = 0; i <= BUBBLE_POINTS; i++) {
+    const theta = (i / BUBBLE_POINTS) * Math.PI * 2;
+    let rr = r;
+    for (const harm of b.harmonics) {
+      rr += r * harm.amp * Math.sin(theta * harm.k + t * harm.freq + harm.phase);
+    }
+    const x = cx + rr * Math.cos(theta);
+    const y = cy + rr * Math.sin(theta);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.fillStyle = hexWithAlpha(b.color, 0.08 * alphaMul);
+  ctx.fill();
+  ctx.strokeStyle = hexWithAlpha(b.color, 0.45 * alphaMul);
+  ctx.lineWidth = 1.5;
+  ctx.stroke();
+
+  // Specular highlight — small ellipse near top-left.
+  if (popProgress < 0.7) {
+    const hx = cx - r * 0.35;
+    const hy = cy - r * 0.45;
+    ctx.fillStyle = `rgba(255,255,255,${0.20 * alphaMul})`;
+    ctx.beginPath();
+    ctx.ellipse(hx, hy, r * 0.18, r * 0.10, -0.6, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawPopParticles(b, popProgress) {
+  if (!b.popParticles) return;
+  const fade = 1 - popProgress;
+  ctx.fillStyle = hexWithAlpha(b.color, 0.7 * fade);
+  for (const p of b.popParticles) {
+    const dist = p.dist * popProgress;
+    const x = b._lastCx + Math.cos(p.angle) * dist;
+    const y = b._lastCy + Math.sin(p.angle) * dist;
+    ctx.beginPath();
+    ctx.arc(x, y, p.size * fade, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+export function popBubbleAt(xCss, yCss, now = performance.now()) {
+  // Returns true if a live bubble was hit and popped.
+  let hit = -1;
+  let bestDistSq = Infinity;
+  for (let i = 0; i < bubbles.length; i++) {
+    const b = bubbles[i];
+    if (b.state !== 'alive') continue;
+    const dx = xCss - b._lastCx;
+    const dy = yCss - b._lastCy;
+    const dSq = dx * dx + dy * dy;
+    const r = b._lastR + POP_HIT_PADDING;
+    if (dSq <= r * r && dSq < bestDistSq) {
+      hit = i;
+      bestDistSq = dSq;
+    }
+  }
+  if (hit === -1) return false;
+  const b = bubbles[hit];
+  b.state = 'popping';
+  b.popStartedAt = now;
+  // Spawn a small ring of particles for the burst.
+  const N = 8;
+  b.popParticles = Array.from({ length: N }, (_, i) => ({
+    angle: (i / N) * Math.PI * 2 + Math.random() * 0.4,
+    dist:  b._lastR * (1.4 + Math.random() * 0.6),
+    size:  2 + Math.random() * 2
+  }));
+  return true;
 }
 
 function buildOrbs(palette) {
@@ -150,8 +295,12 @@ function frame(now) {
   if (orbs.length === 0 || orbs[0]._paletteSig !== paletteSig(palette)) {
     orbs = buildOrbs(palette);
   }
+  if (bubbles.length === 0 || bubbles[0]._paletteSig !== paletteSig(palette)) {
+    bubbles = buildBubbles(palette);
+  }
 
   drawBackdrop(palette, w, h, t);
+  drawBubbles(w, h, t, now);
   maybeSpawnRing(palette, now);
   drawRings(w, h, now);
 
@@ -181,6 +330,7 @@ export function startVisualizer(canvasEl, getTrackId) {
   }
 
   orbs = [];
+  bubbles = [];
   rings = [];
   rmsHistory = [];
   lastTriggerAt = 0;

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -6,7 +6,7 @@
 import { getAnalyser, resumeAudioContext, isPlaying, playSfx } from '../audio.js';
 import { getPalette } from '../content/trackPalettes.js';
 
-const ORB_COUNT      = 5;
+const ORB_COUNT      = 12;
 const RING_LIFETIME  = 900;    // ms
 const RING_MAX       = 8;      // concurrent rings cap
 const TRIGGER_FACTOR = 1.40;   // RMS must exceed avg * this to spawn a ring
@@ -41,6 +41,10 @@ let startTime = 0;
 let lastFrameTime = 0;
 let lastW = 0;
 let lastH = 0;
+let score = 0;
+
+const BUBBLE_MIN = 1;
+const BUBBLE_MAX = 14;
 
 function resizeCanvasToBackingStore() {
   const dpr = window.devicePixelRatio || 1;
@@ -210,19 +214,21 @@ function drawBubbles(w, h, t, now) {
       }
       const popProgress = age / POP_DURATION;
       const bodyProgress = Math.min(1, popProgress / 0.25);
-      drawBubbleBody(b, b.x, b.y, b.r, bodyProgress, t);
+      drawBubbleBody(b, b.x, b.y, b.r, bodyProgress, t, 1);
       drawPopParticles(b, popProgress, w, h);
       continue;
     }
 
-    drawBubbleBody(b, b.x, b.y, b.r, 0, t);
+    const entryAlpha = Math.min(1, (now - b.entryStartedAt) / 1500);
+    drawBubbleBody(b, b.x, b.y, b.r, 0, t, entryAlpha);
   }
 }
 
-function drawBubbleBody(b, cx, cy, r, bodyProgress, t) {
+function drawBubbleBody(b, cx, cy, r, bodyProgress, t, entryAlpha = 1) {
   // bodyProgress 0 → 1 inflates the bubble and fades it out.
+  // entryAlpha 0 → 1 fades the bubble in as it glides from off-screen.
   const scale = 1 + bodyProgress * 0.4;
-  const alphaMul = 1 - bodyProgress;
+  const alphaMul = (1 - bodyProgress) * entryAlpha;
   if (alphaMul <= 0) return;
   const rr = r * scale;
 
@@ -276,6 +282,7 @@ function popBubble(b, kind, now) {
     speed: 0.55 + Math.random() * 0.55,
     size:  2 + Math.random() * 3
   }));
+  score += (kind === 'good') ? 1 : -1;
   playSfx(kind);
 }
 
@@ -325,6 +332,36 @@ function drawDiamond(w, h, t) {
   ctx.stroke();
   ctx.restore();
 }
+
+function drawScore(w, h) {
+  ctx.save();
+  ctx.font = '11px monospace';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'top';
+  ctx.fillStyle = 'rgba(255,255,255,0.45)';
+  ctx.fillText(`SCORE  ${score >= 0 ? '+' : ''}${score}`, 8, 8);
+  ctx.fillStyle = 'rgba(255,255,255,0.28)';
+  ctx.fillText(`BUBBLES  ${bubbles.length}`, 8, 22);
+  ctx.restore();
+}
+
+export function addBubble() {
+  if (bubbles.length >= BUBBLE_MAX) return bubbles.length;
+  if (!getTrackIdFn || !canvas) return bubbles.length;
+  const palette = getPalette(getTrackIdFn());
+  const rect = canvas.getBoundingClientRect();
+  bubbles.push(makeBubble(palette, bubbles.length, performance.now(), rect.width, rect.height));
+  return bubbles.length;
+}
+
+export function removeBubble() {
+  if (bubbles.length <= BUBBLE_MIN) return bubbles.length;
+  bubbles.pop();
+  return bubbles.length;
+}
+
+export function getScore() { return score; }
+export function getBubbleCount() { return bubbles.length; }
 
 function checkDiamondHits(w, h, now) {
   const cx = w / 2;
@@ -476,6 +513,7 @@ function frame(now) {
   drawBubbles(w, h, t, now);
   maybeSpawnRing(palette, now);
   drawRings(w, h, now);
+  drawScore(w, h);
 
   rafId = requestAnimationFrame(frame);
 }
@@ -510,6 +548,7 @@ export function startVisualizer(canvasEl, getTrackId) {
   lastFrameTime = 0;
   lastW = 0;
   lastH = 0;
+  score = 0;
   startTime = performance.now();
   rafId = requestAnimationFrame(frame);
 }

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -17,7 +17,7 @@ const BUBBLE_COUNT     = 5;
 const POP_DURATION     = 1800;   // ms — particles travel slowly past the edges
 const POP_PARTICLES    = 14;
 const POP_HIT_PADDING  = 6;
-const ENTRY_DURATION   = 1200;
+const ENTRY_DURATION   = 3500;   // ms — slow glide from off-screen edge
 const ENTRY_OFFSCREEN  = 0.18;   // cx offset just past the visible edge
 
 let canvas = null;
@@ -75,7 +75,7 @@ function buildBubbles(palette) {
   const now = performance.now();
   return Array.from({ length: BUBBLE_COUNT }, (_, i) => {
     const b = makeBubble(palette, i, now);
-    b.entryStartedAt = now - i * 180;        // start each ~180ms apart
+    b.entryStartedAt = now - i * 400;        // stagger first paint
     return b;
   });
 }

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -6,7 +6,7 @@
 import { getAnalyser, resumeAudioContext, isPlaying, playSfx } from '../audio.js';
 import { getPalette } from '../content/trackPalettes.js';
 
-const ORB_COUNT      = 12;
+const ORB_COUNT      = 22;
 const RING_LIFETIME  = 900;    // ms
 const RING_MAX       = 8;      // concurrent rings cap
 const TRIGGER_FACTOR = 1.40;   // RMS must exceed avg * this to spawn a ring
@@ -382,7 +382,7 @@ function buildOrbs(palette) {
   return Array.from({ length: ORB_COUNT }, (_, i) => ({
     cx: Math.random(),
     cy: Math.random(),
-    r:  0.18 + Math.random() * 0.18,
+    r:  0.10 + Math.random() * 0.30,           // wider size range — small to large
     dxFreq: 0.00007 + Math.random() * 0.00012,
     dyFreq: 0.00007 + Math.random() * 0.00012,
     dxAmp:  0.18 + Math.random() * 0.10,
@@ -390,6 +390,7 @@ function buildOrbs(palette) {
     phaseX: Math.random() * Math.PI * 2,
     phaseY: Math.random() * Math.PI * 2,
     color:  i % 2 === 0 ? palette.bg : palette.accent,
+    intensity: 0.35 + Math.random() * 0.85,    // some orbs nearly invisible, some bright
     _paletteSig: paletteSig(palette)
   }));
 }
@@ -419,8 +420,8 @@ function drawBackdrop(palette, w, h, t) {
     const y = h * (orb.cy + Math.cos(t * orb.dyFreq + orb.phaseY) * orb.dyAmp);
     const r = minDim * orb.r;
     const grad = ctx.createRadialGradient(x, y, 0, x, y, r);
-    grad.addColorStop(0,   hexWithAlpha(orb.color, 0.45));
-    grad.addColorStop(0.6, hexWithAlpha(orb.color, 0.10));
+    grad.addColorStop(0,   hexWithAlpha(orb.color, 0.45 * orb.intensity));
+    grad.addColorStop(0.6, hexWithAlpha(orb.color, 0.10 * orb.intensity));
     grad.addColorStop(1,   hexWithAlpha(orb.color, 0));
     ctx.fillStyle = grad;
     ctx.fillRect(0, 0, w, h);

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -13,11 +13,12 @@ const TRIGGER_FACTOR = 1.40;   // RMS must exceed avg * this to spawn a ring
 const TRIGGER_MIN_GAP = 350;   // ms between ring spawns
 const RMS_HISTORY    = 30;     // ~0.5s @ 60fps for moving average
 
-const BUBBLE_COUNT     = 4;
-const BUBBLE_POINTS    = 64;
-const BUBBLE_HARMONICS = 3;
-const POP_DURATION     = 280;    // ms — how long the burst animation lasts
-const POP_HIT_PADDING  = 6;      // px slop on the hit radius (forgiving clicks)
+const BUBBLE_COUNT     = 5;
+const POP_DURATION     = 1800;   // ms — particles travel slowly past the edges
+const POP_PARTICLES    = 14;
+const POP_HIT_PADDING  = 6;
+const ENTRY_DURATION   = 1200;
+const ENTRY_OFFSCREEN  = 0.18;   // cx offset just past the visible edge
 
 let canvas = null;
 let ctx    = null;
@@ -44,110 +45,124 @@ function resizeCanvasToBackingStore() {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 }
 
-function makeBubble(palette, i) {
-  // Closed wobbly curve with a slight spec highlight — reads as a soft
-  // bubble. Drifts slowly until popped.
+function makeBubble(palette, i, now = performance.now()) {
+  // Plain circle (not wobbly). Enters from the left or right edge, then
+  // settles into a slow sine drift around its target position.
+  const fromRight = Math.random() < 0.5;
   return {
     cx: 0.2 + Math.random() * 0.6,
     cy: 0.2 + Math.random() * 0.6,
-    baseR: 0.10 + Math.random() * 0.10,
+    baseR: 0.07 + Math.random() * 0.06,
     driftFreqX: 0.00006 + Math.random() * 0.0001,
     driftFreqY: 0.00006 + Math.random() * 0.0001,
-    driftAmpX: 0.08 + Math.random() * 0.06,
-    driftAmpY: 0.06 + Math.random() * 0.06,
+    driftAmpX: 0.06 + Math.random() * 0.06,
+    driftAmpY: 0.05 + Math.random() * 0.05,
     phaseX: Math.random() * Math.PI * 2,
     phaseY: Math.random() * Math.PI * 2,
-    harmonics: Array.from({ length: BUBBLE_HARMONICS }, () => ({
-      k:     2 + Math.floor(Math.random() * 4),
-      amp:   0.03 + Math.random() * 0.05,
-      freq:  0.0003 + Math.random() * 0.0006,
-      phase: Math.random() * Math.PI * 2
-    })),
+    entrySide: fromRight ? 1 : -1,         // +1 right, -1 left
+    entryStartedAt: now,
     color: i % 2 === 0 ? palette.accent : palette.bg,
-    state: 'alive',           // or 'popping'
+    state: 'alive',                         // or 'popping'
     popStartedAt: 0,
-    popParticles: null,       // populated when popped
+    popParticles: null,
     _lastCx: 0, _lastCy: 0, _lastR: 0,
     _paletteSig: paletteSig(palette)
   };
 }
 
 function buildBubbles(palette) {
-  return Array.from({ length: BUBBLE_COUNT }, (_, i) => makeBubble(palette, i));
+  // Stagger entry times so they don't all glide in at once on first paint.
+  const now = performance.now();
+  return Array.from({ length: BUBBLE_COUNT }, (_, i) => {
+    const b = makeBubble(palette, i, now);
+    b.entryStartedAt = now - i * 180;        // start each ~180ms apart
+    return b;
+  });
+}
+
+function easeOutCubic(t) {
+  const u = 1 - t;
+  return 1 - u * u * u;
 }
 
 function drawBubbles(w, h, t, now) {
   const minDim = Math.min(w, h);
   for (let bi = 0; bi < bubbles.length; bi++) {
     const b = bubbles[bi];
-    const cx = w * (b.cx + Math.sin(t * b.driftFreqX + b.phaseX) * b.driftAmpX);
-    const cy = h * (b.cy + Math.cos(t * b.driftFreqY + b.phaseY) * b.driftAmpY);
+
+    // Settled position with slow sine drift around the target.
+    const targetCxFrac = b.cx + Math.sin(t * b.driftFreqX + b.phaseX) * b.driftAmpX;
+    const cyFrac       = b.cy + Math.cos(t * b.driftFreqY + b.phaseY) * b.driftAmpY;
+
+    // Side-entry: lerp from off-screen edge to settled cx over ENTRY_DURATION.
+    const entryAge = now - b.entryStartedAt;
+    let cxFrac = targetCxFrac;
+    if (entryAge < ENTRY_DURATION) {
+      const tEntry = easeOutCubic(Math.max(0, entryAge / ENTRY_DURATION));
+      const startCx = b.entrySide > 0 ? 1 + ENTRY_OFFSCREEN : -ENTRY_OFFSCREEN;
+      cxFrac = startCx + (targetCxFrac - startCx) * tEntry;
+    }
+
+    const cx = w * cxFrac;
+    const cy = h * cyFrac;
     const baseR = minDim * b.baseR;
 
-    // Cache for hit-testing in popBubbleAt().
     b._lastCx = cx; b._lastCy = cy; b._lastR = baseR;
 
     if (b.state === 'popping') {
       const age = now - b.popStartedAt;
       if (age >= POP_DURATION) {
         const palette = getPalette(getTrackIdFn ? getTrackIdFn() : null);
-        bubbles[bi] = makeBubble(palette, bi);
+        bubbles[bi] = makeBubble(palette, bi, now);
         continue;
       }
-      drawBubbleBody(b, cx, cy, baseR, t, /*popProgress*/ age / POP_DURATION);
-      drawPopParticles(b, age / POP_DURATION);
+      const popProgress = age / POP_DURATION;
+      // Body fades fast (first ~25% of pop), then only fragments remain.
+      const bodyProgress = Math.min(1, popProgress / 0.25);
+      drawBubbleBody(b, cx, cy, baseR, bodyProgress);
+      drawPopParticles(b, popProgress, w, h);
       continue;
     }
 
-    drawBubbleBody(b, cx, cy, baseR, t, 0);
+    drawBubbleBody(b, cx, cy, baseR, 0);
   }
 }
 
-function drawBubbleBody(b, cx, cy, baseR, t, popProgress) {
-  // popProgress 0 → 1 inflates the bubble and fades it out.
-  const scale = 1 + popProgress * 0.5;
-  const alphaMul = 1 - popProgress;
-  const r = baseR * scale;
+function drawBubbleBody(b, cx, cy, r, bodyProgress) {
+  // bodyProgress 0 → 1 inflates the bubble and fades it out.
+  const scale = 1 + bodyProgress * 0.4;
+  const alphaMul = 1 - bodyProgress;
+  if (alphaMul <= 0) return;
+  const rr = r * scale;
 
   ctx.beginPath();
-  for (let i = 0; i <= BUBBLE_POINTS; i++) {
-    const theta = (i / BUBBLE_POINTS) * Math.PI * 2;
-    let rr = r;
-    for (const harm of b.harmonics) {
-      rr += r * harm.amp * Math.sin(theta * harm.k + t * harm.freq + harm.phase);
-    }
-    const x = cx + rr * Math.cos(theta);
-    const y = cy + rr * Math.sin(theta);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  }
-  ctx.closePath();
-  ctx.fillStyle = hexWithAlpha(b.color, 0.08 * alphaMul);
+  ctx.arc(cx, cy, rr, 0, Math.PI * 2);
+  ctx.fillStyle = hexWithAlpha(b.color, 0.10 * alphaMul);
   ctx.fill();
-  ctx.strokeStyle = hexWithAlpha(b.color, 0.45 * alphaMul);
+  ctx.strokeStyle = hexWithAlpha(b.color, 0.55 * alphaMul);
   ctx.lineWidth = 1.5;
   ctx.stroke();
 
   // Specular highlight — small ellipse near top-left.
-  if (popProgress < 0.7) {
-    const hx = cx - r * 0.35;
-    const hy = cy - r * 0.45;
-    ctx.fillStyle = `rgba(255,255,255,${0.20 * alphaMul})`;
-    ctx.beginPath();
-    ctx.ellipse(hx, hy, r * 0.18, r * 0.10, -0.6, 0, Math.PI * 2);
-    ctx.fill();
-  }
+  const hx = cx - rr * 0.35;
+  const hy = cy - rr * 0.45;
+  ctx.fillStyle = `rgba(255,255,255,${0.22 * alphaMul})`;
+  ctx.beginPath();
+  ctx.ellipse(hx, hy, rr * 0.18, rr * 0.10, -0.6, 0, Math.PI * 2);
+  ctx.fill();
 }
 
-function drawPopParticles(b, popProgress) {
+function drawPopParticles(b, popProgress, w, h) {
   if (!b.popParticles) return;
-  const fade = 1 - popProgress;
-  ctx.fillStyle = hexWithAlpha(b.color, 0.7 * fade);
+  const maxDist = Math.max(w, h) * 1.1;       // enough to fly past either edge
+  const fade = Math.max(0, 1 - popProgress * 0.85);
+  ctx.fillStyle = hexWithAlpha(b.color, 0.85 * fade);
   for (const p of b.popParticles) {
-    const dist = p.dist * popProgress;
+    const dist = maxDist * p.speed * popProgress;
     const x = b._lastCx + Math.cos(p.angle) * dist;
     const y = b._lastCy + Math.sin(p.angle) * dist;
     ctx.beginPath();
-    ctx.arc(x, y, p.size * fade, 0, Math.PI * 2);
+    ctx.arc(x, y, p.size * Math.max(0.4, 1 - popProgress * 0.5), 0, Math.PI * 2);
     ctx.fill();
   }
 }
@@ -172,12 +187,13 @@ export function popBubbleAt(xCss, yCss, now = performance.now()) {
   const b = bubbles[hit];
   b.state = 'popping';
   b.popStartedAt = now;
-  // Spawn a small ring of particles for the burst.
-  const N = 8;
-  b.popParticles = Array.from({ length: N }, (_, i) => ({
-    angle: (i / N) * Math.PI * 2 + Math.random() * 0.4,
-    dist:  b._lastR * (1.4 + Math.random() * 0.6),
-    size:  2 + Math.random() * 2
+  // Shatter into a ring of fragments. Each fragment has its own outward
+  // speed multiplier and size, so they break apart unevenly and travel
+  // past the visible edges of the panel.
+  b.popParticles = Array.from({ length: POP_PARTICLES }, (_, i) => ({
+    angle: (i / POP_PARTICLES) * Math.PI * 2 + (Math.random() - 0.5) * 0.5,
+    speed: 0.55 + Math.random() * 0.55,
+    size:  2 + Math.random() * 3
   }));
   return true;
 }

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -9,8 +9,8 @@ import { getPalette } from '../content/trackPalettes.js';
 const ORB_COUNT      = 5;
 const RING_LIFETIME  = 900;    // ms
 const RING_MAX       = 8;      // concurrent rings cap
-const TRIGGER_FACTOR = 1.18;   // RMS must exceed avg * this to spawn a ring
-const TRIGGER_MIN_GAP = 120;   // ms between ring spawns
+const TRIGGER_FACTOR = 1.40;   // RMS must exceed avg * this to spawn a ring
+const TRIGGER_MIN_GAP = 350;   // ms between ring spawns
 const RMS_HISTORY    = 30;     // ~0.5s @ 60fps for moving average
 
 let canvas = null;

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -61,6 +61,12 @@ function makeBubble(palette, i, now = performance.now()) {
     phaseY: Math.random() * Math.PI * 2,
     entrySide: fromRight ? 1 : -1,         // +1 right, -1 left
     entryStartedAt: now,
+    // Animated "clear" highlight inside the bubble — orbits the center
+    // and slowly rotates on its own axis.
+    highlightOrbitPhase: Math.random() * Math.PI * 2,
+    highlightOrbitFreq:  0.0006 + Math.random() * 0.0008,
+    highlightTiltPhase:  Math.random() * Math.PI * 2,
+    highlightTiltFreq:   0.0003 + Math.random() * 0.0005,
     color: i % 2 === 0 ? palette.accent : palette.bg,
     state: 'alive',                         // or 'popping'
     popStartedAt: 0,
@@ -119,16 +125,16 @@ function drawBubbles(w, h, t, now) {
       const popProgress = age / POP_DURATION;
       // Body fades fast (first ~25% of pop), then only fragments remain.
       const bodyProgress = Math.min(1, popProgress / 0.25);
-      drawBubbleBody(b, cx, cy, baseR, bodyProgress);
+      drawBubbleBody(b, cx, cy, baseR, bodyProgress, t);
       drawPopParticles(b, popProgress, w, h);
       continue;
     }
 
-    drawBubbleBody(b, cx, cy, baseR, 0);
+    drawBubbleBody(b, cx, cy, baseR, 0, t);
   }
 }
 
-function drawBubbleBody(b, cx, cy, r, bodyProgress) {
+function drawBubbleBody(b, cx, cy, r, bodyProgress, t) {
   // bodyProgress 0 → 1 inflates the bubble and fades it out.
   const scale = 1 + bodyProgress * 0.4;
   const alphaMul = 1 - bodyProgress;
@@ -143,13 +149,17 @@ function drawBubbleBody(b, cx, cy, r, bodyProgress) {
   ctx.lineWidth = 1.5;
   ctx.stroke();
 
-  // Specular highlight — small ellipse near top-left.
-  const hx = cx - rr * 0.35;
-  const hy = cy - rr * 0.45;
-  ctx.fillStyle = `rgba(255,255,255,${0.22 * alphaMul})`;
+  // Clear (outlined) highlight — orbits the bubble center + slowly tilts.
+  const orbitAngle = b.highlightOrbitPhase + t * b.highlightOrbitFreq;
+  const tiltAngle  = b.highlightTiltPhase  + t * b.highlightTiltFreq;
+  const orbitR     = rr * 0.38;
+  const hx = cx + Math.cos(orbitAngle) * orbitR;
+  const hy = cy + Math.sin(orbitAngle) * orbitR;
+  ctx.strokeStyle = `rgba(255,255,255,${0.55 * alphaMul})`;
+  ctx.lineWidth = 1.2;
   ctx.beginPath();
-  ctx.ellipse(hx, hy, rr * 0.18, rr * 0.10, -0.6, 0, Math.PI * 2);
-  ctx.fill();
+  ctx.ellipse(hx, hy, rr * 0.22, rr * 0.10, tiltAngle, 0, Math.PI * 2);
+  ctx.stroke();
 }
 
 function drawPopParticles(b, popProgress, w, h) {

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -1,0 +1,182 @@
+// Mars Trail — Lounge soundtrack visualizer.
+// One <canvas>, one RAF loop. Draws:
+//   1. Per-track ambient backdrop (drifting orbs in the palette)
+//   2. Audio-reactive pulse rings (spawned on amplitude transients)
+
+import { getAnalyser, resumeAudioContext, isPlaying } from '../audio.js';
+import { getPalette } from '../content/trackPalettes.js';
+
+const ORB_COUNT      = 5;
+const RING_LIFETIME  = 900;    // ms
+const RING_MAX       = 8;      // concurrent rings cap
+const TRIGGER_FACTOR = 1.18;   // RMS must exceed avg * this to spawn a ring
+const TRIGGER_MIN_GAP = 120;   // ms between ring spawns
+const RMS_HISTORY    = 30;     // ~0.5s @ 60fps for moving average
+
+let canvas = null;
+let ctx    = null;
+let getTrackIdFn = null;
+let rafId = 0;
+let analyser = null;
+let timeData = null;
+let orbs = [];
+let rings = [];
+let rmsHistory = [];
+let lastTriggerAt = 0;
+let startTime = 0;
+
+function resizeCanvasToBackingStore() {
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  const targetW = Math.max(1, Math.floor(rect.width  * dpr));
+  const targetH = Math.max(1, Math.floor(rect.height * dpr));
+  if (canvas.width !== targetW || canvas.height !== targetH) {
+    canvas.width  = targetW;
+    canvas.height = targetH;
+  }
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function buildOrbs(palette) {
+  return Array.from({ length: ORB_COUNT }, (_, i) => ({
+    cx: Math.random(),
+    cy: Math.random(),
+    r:  0.18 + Math.random() * 0.18,
+    dxFreq: 0.00007 + Math.random() * 0.00012,
+    dyFreq: 0.00007 + Math.random() * 0.00012,
+    dxAmp:  0.18 + Math.random() * 0.10,
+    dyAmp:  0.14 + Math.random() * 0.10,
+    phaseX: Math.random() * Math.PI * 2,
+    phaseY: Math.random() * Math.PI * 2,
+    color:  i % 2 === 0 ? palette.bg : palette.accent,
+    _paletteSig: paletteSig(palette)
+  }));
+}
+
+function drawBackdrop(palette, w, h, t) {
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, w, h);
+
+  const minDim = Math.min(w, h);
+  for (const orb of orbs) {
+    const x = w * (orb.cx + Math.sin(t * orb.dxFreq + orb.phaseX) * orb.dxAmp);
+    const y = h * (orb.cy + Math.cos(t * orb.dyFreq + orb.phaseY) * orb.dyAmp);
+    const r = minDim * orb.r;
+    const grad = ctx.createRadialGradient(x, y, 0, x, y, r);
+    grad.addColorStop(0,   hexWithAlpha(orb.color, 0.45));
+    grad.addColorStop(0.6, hexWithAlpha(orb.color, 0.10));
+    grad.addColorStop(1,   hexWithAlpha(orb.color, 0));
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, w, h);
+  }
+}
+
+function maybeSpawnRing(palette, now) {
+  if (!analyser || !timeData) return;
+  if (!isPlaying()) return;
+
+  analyser.getByteTimeDomainData(timeData);
+
+  let sumSq = 0;
+  for (let i = 0; i < timeData.length; i++) {
+    const v = (timeData[i] - 128) / 128;
+    sumSq += v * v;
+  }
+  const rms = Math.sqrt(sumSq / timeData.length);
+
+  rmsHistory.push(rms);
+  if (rmsHistory.length > RMS_HISTORY) rmsHistory.shift();
+  const avg = rmsHistory.reduce((a, b) => a + b, 0) / rmsHistory.length;
+
+  if (rms > avg * TRIGGER_FACTOR && (now - lastTriggerAt) > TRIGGER_MIN_GAP) {
+    if (rings.length < RING_MAX) {
+      rings.push({
+        spawnAt: now,
+        peakAlpha: Math.min(0.9, 0.35 + (rms - avg) * 4),
+        color: palette.accent
+      });
+      lastTriggerAt = now;
+    }
+  }
+}
+
+function drawRings(w, h, now) {
+  if (rings.length === 0) return;
+  const cx = w / 2;
+  const cy = h / 2;
+  const maxR = Math.min(w, h) * 0.55;
+
+  ctx.lineWidth = 2;
+  for (let i = rings.length - 1; i >= 0; i--) {
+    const ring = rings[i];
+    const age = now - ring.spawnAt;
+    if (age >= RING_LIFETIME) { rings.splice(i, 1); continue; }
+    const progress = age / RING_LIFETIME;
+    const r = Math.min(maxR, maxR * progress);
+    const alpha = ring.peakAlpha * (1 - progress);
+    ctx.strokeStyle = hexWithAlpha(ring.color, alpha);
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function frame(now) {
+  if (!canvas || !ctx) return;
+  resizeCanvasToBackingStore();
+
+  const rect = canvas.getBoundingClientRect();
+  const w = rect.width;
+  const h = rect.height;
+  const t = now - startTime;
+
+  const palette = getPalette(getTrackIdFn ? getTrackIdFn() : null);
+
+  if (orbs.length === 0 || orbs[0]._paletteSig !== paletteSig(palette)) {
+    orbs = buildOrbs(palette);
+  }
+
+  drawBackdrop(palette, w, h, t);
+  maybeSpawnRing(palette, now);
+  drawRings(w, h, now);
+
+  rafId = requestAnimationFrame(frame);
+}
+
+function paletteSig(p) { return `${p.bg}|${p.accent}`; }
+
+function hexWithAlpha(hex, alpha) {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+export function startVisualizer(canvasEl, getTrackId) {
+  canvas = canvasEl;
+  ctx = canvas.getContext('2d');
+  getTrackIdFn = getTrackId;
+
+  analyser = getAnalyser();
+  if (analyser) {
+    timeData = new Uint8Array(analyser.fftSize);
+    resumeAudioContext();
+  }
+
+  orbs = [];
+  rings = [];
+  rmsHistory = [];
+  lastTriggerAt = 0;
+  startTime = performance.now();
+  rafId = requestAnimationFrame(frame);
+}
+
+export function stopVisualizer() {
+  if (rafId) cancelAnimationFrame(rafId);
+  rafId = 0;
+  canvas = null;
+  ctx = null;
+  getTrackIdFn = null;
+}

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -57,6 +57,21 @@ function drawBackdrop(palette, w, h, t) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, w, h);
 
+  // Slow rotational depth layer — a conic gradient that creeps around the
+  // center over ~40 seconds. Adds the impression of the whole panel
+  // drifting, not just the orbs floating.
+  const angle = (t * 0.00016) % (Math.PI * 2);
+  if (typeof ctx.createConicGradient === 'function') {
+    const conic = ctx.createConicGradient(angle, w / 2, h / 2);
+    conic.addColorStop(0,    hexWithAlpha(palette.accent, 0.07));
+    conic.addColorStop(0.25, 'rgba(0,0,0,0)');
+    conic.addColorStop(0.5,  hexWithAlpha(palette.accent, 0.05));
+    conic.addColorStop(0.75, 'rgba(0,0,0,0)');
+    conic.addColorStop(1,    hexWithAlpha(palette.accent, 0.07));
+    ctx.fillStyle = conic;
+    ctx.fillRect(0, 0, w, h);
+  }
+
   const minDim = Math.min(w, h);
   for (const orb of orbs) {
     const x = w * (orb.cx + Math.sin(t * orb.dxFreq + orb.phaseX) * orb.dxAmp);

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -62,11 +62,14 @@ function makeBubble(palette, i, now = performance.now()) {
     entrySide: fromRight ? 1 : -1,         // +1 right, -1 left
     entryStartedAt: now,
     // Animated "clear" highlight inside the bubble — orbits the center
-    // and slowly rotates on its own axis.
+    // and rotates on its own axis. Direction (sign) and speed vary per
+    // bubble so no two move alike.
     highlightOrbitPhase: Math.random() * Math.PI * 2,
-    highlightOrbitFreq:  0.0006 + Math.random() * 0.0008,
+    highlightOrbitFreq:  (Math.random() < 0.5 ? -1 : 1) * (0.0004 + Math.random() * 0.0014),
     highlightTiltPhase:  Math.random() * Math.PI * 2,
-    highlightTiltFreq:   0.0003 + Math.random() * 0.0005,
+    highlightTiltFreq:   (Math.random() < 0.5 ? -1 : 1) * (0.0002 + Math.random() * 0.0010),
+    highlightMajor:      0.18 + Math.random() * 0.10,   // ellipse semi-major as fraction of r
+    highlightMinor:      0.07 + Math.random() * 0.06,   // ellipse semi-minor as fraction of r
     color: i % 2 === 0 ? palette.accent : palette.bg,
     state: 'alive',                         // or 'popping'
     popStartedAt: 0,
@@ -149,16 +152,17 @@ function drawBubbleBody(b, cx, cy, r, bodyProgress, t) {
   ctx.lineWidth = 1.5;
   ctx.stroke();
 
-  // Clear (outlined) highlight — orbits the bubble center + slowly tilts.
+  // Clear (outlined) highlight — orbits the bubble center, rotates with
+  // its own per-bubble direction + speed.
   const orbitAngle = b.highlightOrbitPhase + t * b.highlightOrbitFreq;
   const tiltAngle  = b.highlightTiltPhase  + t * b.highlightTiltFreq;
   const orbitR     = rr * 0.38;
   const hx = cx + Math.cos(orbitAngle) * orbitR;
   const hy = cy + Math.sin(orbitAngle) * orbitR;
-  ctx.strokeStyle = `rgba(255,255,255,${0.55 * alphaMul})`;
-  ctx.lineWidth = 1.2;
+  ctx.strokeStyle = `rgba(255,255,255,${0.92 * alphaMul})`;
+  ctx.lineWidth = 1.4;
   ctx.beginPath();
-  ctx.ellipse(hx, hy, rr * 0.22, rr * 0.10, tiltAngle, 0, Math.PI * 2);
+  ctx.ellipse(hx, hy, rr * b.highlightMajor, rr * b.highlightMinor, tiltAngle, 0, Math.PI * 2);
   ctx.stroke();
 }
 

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -307,6 +307,21 @@ export function popBubbleAt(xCss, yCss, now = performance.now()) {
   return true;
 }
 
+function drawDiamondHalo(w, h) {
+  // Static glow orb anchored to the panel center — sits behind the diamond
+  // so the diamond reads as the focal point even on busy palettes.
+  const cx = w / 2;
+  const cy = h / 2;
+  const minDim = Math.min(w, h);
+  const r = minDim * 0.32;
+  const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+  grad.addColorStop(0,   hexWithAlpha(DIAMOND_COLOR, 0.30));
+  grad.addColorStop(0.5, hexWithAlpha(DIAMOND_COLOR, 0.10));
+  grad.addColorStop(1,   hexWithAlpha(DIAMOND_COLOR, 0));
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, w, h);
+}
+
 function drawDiamond(w, h, t) {
   const cx = w / 2;
   const cy = h / 2;
@@ -510,6 +525,7 @@ function frame(now) {
   checkDiamondHits(w, h, now);
 
   drawBackdrop(palette, w, h, t);
+  drawDiamondHalo(w, h);
   drawDiamond(w, h, t);
   drawBubbles(w, h, t, now);
   maybeSpawnRing(palette, now);

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -348,18 +348,6 @@ function drawDiamond(w, h, t) {
   ctx.restore();
 }
 
-function drawScore(w, h) {
-  ctx.save();
-  ctx.font = '11px monospace';
-  ctx.textAlign = 'left';
-  ctx.textBaseline = 'top';
-  ctx.fillStyle = 'rgba(255,255,255,0.45)';
-  ctx.fillText(`SCORE  ${score >= 0 ? '+' : ''}${score}`, 8, 8);
-  ctx.fillStyle = 'rgba(255,255,255,0.28)';
-  ctx.fillText(`BUBBLES  ${bubbles.length}`, 8, 22);
-  ctx.restore();
-}
-
 export function addBubble() {
   if (bubbles.length >= BUBBLE_MAX) return bubbles.length;
   if (!getTrackIdFn || !canvas) return bubbles.length;
@@ -530,7 +518,6 @@ function frame(now) {
   drawBubbles(w, h, t, now);
   maybeSpawnRing(palette, now);
   drawRings(w, h, now);
-  drawScore(w, h);
 
   rafId = requestAnimationFrame(frame);
 }

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -3,7 +3,7 @@
 //   1. Per-track ambient backdrop (drifting orbs in the palette)
 //   2. Audio-reactive pulse rings (spawned on amplitude transients)
 
-import { getAnalyser, resumeAudioContext, isPlaying } from '../audio.js';
+import { getAnalyser, resumeAudioContext, isPlaying, playSfx } from '../audio.js';
 import { getPalette } from '../content/trackPalettes.js';
 
 const ORB_COUNT      = 5;
@@ -21,6 +21,10 @@ const ENTRY_DURATION   = 5500;   // ms — speed-decay from entry to drift
 const ENTRY_SPEED      = 0.16;   // px/ms — initial inward speed off-screen
 const DRIFT_SPEED_MIN  = 0.012;  // px/ms — gentle wandering speed
 const DRIFT_SPEED_MAX  = 0.034;
+
+const DIAMOND_VIS_R_FRAC = 0.07; // visual radius (fraction of minDim)
+const DIAMOND_HIT_R_FRAC = 0.055;// hit radius (slightly smaller — slightly forgiving)
+const DIAMOND_COLOR      = '#ffe066';
 
 let canvas = null;
 let ctx    = null;
@@ -261,6 +265,20 @@ function drawPopParticles(b, popProgress, w, h) {
   }
 }
 
+function popBubble(b, kind, now) {
+  if (b.state !== 'alive') return;
+  b.state = 'popping';
+  b.popStartedAt = now;
+  b.popOriginX = b.x;
+  b.popOriginY = b.y;
+  b.popParticles = Array.from({ length: POP_PARTICLES }, (_, i) => ({
+    angle: (i / POP_PARTICLES) * Math.PI * 2 + (Math.random() - 0.5) * 0.5,
+    speed: 0.55 + Math.random() * 0.55,
+    size:  2 + Math.random() * 3
+  }));
+  playSfx(kind);
+}
+
 export function popBubbleAt(xCss, yCss, now = performance.now()) {
   // Returns true if a live bubble was hit and popped.
   let hit = -1;
@@ -278,20 +296,49 @@ export function popBubbleAt(xCss, yCss, now = performance.now()) {
     }
   }
   if (hit === -1) return false;
-  const b = bubbles[hit];
-  b.state = 'popping';
-  b.popStartedAt = now;
-  b.popOriginX = b.x;
-  b.popOriginY = b.y;
-  // Shatter into a ring of fragments. Each fragment has its own outward
-  // speed multiplier and size, so they break apart unevenly and travel
-  // past the visible edges of the panel.
-  b.popParticles = Array.from({ length: POP_PARTICLES }, (_, i) => ({
-    angle: (i / POP_PARTICLES) * Math.PI * 2 + (Math.random() - 0.5) * 0.5,
-    speed: 0.55 + Math.random() * 0.55,
-    size:  2 + Math.random() * 3
-  }));
+  popBubble(bubbles[hit], 'good', now);
   return true;
+}
+
+function drawDiamond(w, h, t) {
+  const cx = w / 2;
+  const cy = h / 2;
+  const minDim = Math.min(w, h);
+  const r = minDim * DIAMOND_VIS_R_FRAC;
+  const rot = t * 0.0008;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(rot);
+  ctx.shadowColor = DIAMOND_COLOR;
+  ctx.shadowBlur = 14;
+  ctx.beginPath();
+  ctx.moveTo(0, -r);
+  ctx.lineTo(r, 0);
+  ctx.lineTo(0, r);
+  ctx.lineTo(-r, 0);
+  ctx.closePath();
+  ctx.fillStyle = hexWithAlpha(DIAMOND_COLOR, 0.22);
+  ctx.fill();
+  ctx.strokeStyle = DIAMOND_COLOR;
+  ctx.lineWidth = 1.6;
+  ctx.stroke();
+  ctx.restore();
+}
+
+function checkDiamondHits(w, h, now) {
+  const cx = w / 2;
+  const cy = h / 2;
+  const dHitR = Math.min(w, h) * DIAMOND_HIT_R_FRAC;
+  for (const b of bubbles) {
+    if (b.state !== 'alive' || !b.inside) continue;
+    const dx = b.x - cx;
+    const dy = b.y - cy;
+    const sumR = b.r + dHitR;
+    if (dx * dx + dy * dy < sumR * sumR) {
+      popBubble(b, 'bad', now);
+    }
+  }
 }
 
 function buildOrbs(palette) {
@@ -422,8 +469,10 @@ function frame(now) {
   const dt = Math.min(48, lastFrameTime ? (now - lastFrameTime) : 16);
   lastFrameTime = now;
   updateBubbles(w, h, dt, now);
+  checkDiamondHits(w, h, now);
 
   drawBackdrop(palette, w, h, t);
+  drawDiamond(w, h, t);
   drawBubbles(w, h, t, now);
   maybeSpawnRing(palette, now);
   drawRings(w, h, now);

--- a/src/ui/visualizer.js
+++ b/src/ui/visualizer.js
@@ -14,11 +14,13 @@ const TRIGGER_MIN_GAP = 350;   // ms between ring spawns
 const RMS_HISTORY    = 30;     // ~0.5s @ 60fps for moving average
 
 const BUBBLE_COUNT     = 5;
-const POP_DURATION     = 1800;   // ms — particles travel slowly past the edges
+const POP_DURATION     = 1800;
 const POP_PARTICLES    = 14;
 const POP_HIT_PADDING  = 6;
-const ENTRY_DURATION   = 3500;   // ms — slow glide from off-screen edge
-const ENTRY_OFFSCREEN  = 0.18;   // cx offset just past the visible edge
+const ENTRY_DURATION   = 5500;   // ms — speed-decay from entry to drift
+const ENTRY_SPEED      = 0.16;   // px/ms — initial inward speed off-screen
+const DRIFT_SPEED_MIN  = 0.012;  // px/ms — gentle wandering speed
+const DRIFT_SPEED_MAX  = 0.034;
 
 let canvas = null;
 let ctx    = null;
@@ -32,6 +34,9 @@ let rings = [];
 let rmsHistory = [];
 let lastTriggerAt = 0;
 let startTime = 0;
+let lastFrameTime = 0;
+let lastW = 0;
+let lastH = 0;
 
 function resizeCanvasToBackingStore() {
   const dpr = window.devicePixelRatio || 1;
@@ -45,46 +50,68 @@ function resizeCanvasToBackingStore() {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 }
 
-function makeBubble(palette, i, now = performance.now()) {
-  // Plain circle (not wobbly). Enters from the left or right edge, then
-  // settles into a slow sine drift around its target position.
-  const fromRight = Math.random() < 0.5;
+function luminance(hex) {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  const r = parseInt(h.slice(0, 2), 16) / 255;
+  const g = parseInt(h.slice(2, 4), 16) / 255;
+  const b = parseInt(h.slice(4, 6), 16) / 255;
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+function makeBubble(palette, i, now = performance.now(), w = 800, h = 450) {
+  // Pixel-space position + velocity. Bubble spawns just off one of the four
+  // edges and glides inward at ENTRY_SPEED, then decays to its own drift
+  // speed. Bounces off walls and other bubbles after it's fully entered.
+  const minDim = Math.min(w, h);
+  const r = minDim * (0.07 + Math.random() * 0.06);
+
+  const side = Math.floor(Math.random() * 4);   // 0=left, 1=right, 2=top, 3=bottom
+  let x, y, vx, vy;
+  const wobble = (Math.random() - 0.5) * ENTRY_SPEED * 0.4;
+  switch (side) {
+    case 0:                                     // left → moving right
+      x = -r; y = r + Math.random() * (h - 2 * r);
+      vx = ENTRY_SPEED; vy = wobble; break;
+    case 1:                                     // right → moving left
+      x = w + r; y = r + Math.random() * (h - 2 * r);
+      vx = -ENTRY_SPEED; vy = wobble; break;
+    case 2:                                     // top → moving down
+      x = r + Math.random() * (w - 2 * r); y = -r;
+      vx = wobble; vy = ENTRY_SPEED; break;
+    default:                                    // bottom → moving up
+      x = r + Math.random() * (w - 2 * r); y = h + r;
+      vx = wobble; vy = -ENTRY_SPEED; break;
+  }
+
+  const color = i % 2 === 0 ? palette.accent : palette.bg;
   return {
-    cx: 0.2 + Math.random() * 0.6,
-    cy: 0.2 + Math.random() * 0.6,
-    baseR: 0.07 + Math.random() * 0.06,
-    driftFreqX: 0.00006 + Math.random() * 0.0001,
-    driftFreqY: 0.00006 + Math.random() * 0.0001,
-    driftAmpX: 0.06 + Math.random() * 0.06,
-    driftAmpY: 0.05 + Math.random() * 0.05,
-    phaseX: Math.random() * Math.PI * 2,
-    phaseY: Math.random() * Math.PI * 2,
-    entrySide: fromRight ? 1 : -1,         // +1 right, -1 left
+    x, y, vx, vy, r,
+    driftSpeed: DRIFT_SPEED_MIN + Math.random() * (DRIFT_SPEED_MAX - DRIFT_SPEED_MIN),
     entryStartedAt: now,
-    // Animated "clear" highlight inside the bubble — orbits the center
-    // and rotates on its own axis. Direction (sign) and speed vary per
-    // bubble so no two move alike.
+    inside: false,                              // flips true once fully inside the panel
+    color,
+    lum: luminance(color),
+    state: 'alive',
+    popStartedAt: 0,
+    popOriginX: 0,
+    popOriginY: 0,
+    popParticles: null,
     highlightOrbitPhase: Math.random() * Math.PI * 2,
     highlightOrbitFreq:  (Math.random() < 0.5 ? -1 : 1) * (0.0004 + Math.random() * 0.0014),
     highlightTiltPhase:  Math.random() * Math.PI * 2,
     highlightTiltFreq:   (Math.random() < 0.5 ? -1 : 1) * (0.0002 + Math.random() * 0.0010),
-    highlightMajor:      0.18 + Math.random() * 0.10,   // ellipse semi-major as fraction of r
-    highlightMinor:      0.07 + Math.random() * 0.06,   // ellipse semi-minor as fraction of r
-    color: i % 2 === 0 ? palette.accent : palette.bg,
-    state: 'alive',                         // or 'popping'
-    popStartedAt: 0,
-    popParticles: null,
-    _lastCx: 0, _lastCy: 0, _lastR: 0,
+    highlightMajor:      0.18 + Math.random() * 0.10,
+    highlightMinor:      0.07 + Math.random() * 0.06,
     _paletteSig: paletteSig(palette)
   };
 }
 
-function buildBubbles(palette) {
-  // Stagger entry times so they don't all glide in at once on first paint.
+function buildBubbles(palette, w = 800, h = 450) {
   const now = performance.now();
   return Array.from({ length: BUBBLE_COUNT }, (_, i) => {
-    const b = makeBubble(palette, i, now);
-    b.entryStartedAt = now - i * 400;        // stagger first paint
+    const b = makeBubble(palette, i, now, w, h);
+    b.entryStartedAt = now - i * 600;           // stagger first paint
     return b;
   });
 }
@@ -94,46 +121,97 @@ function easeOutCubic(t) {
   return 1 - u * u * u;
 }
 
-function drawBubbles(w, h, t, now) {
-  const minDim = Math.min(w, h);
-  for (let bi = 0; bi < bubbles.length; bi++) {
-    const b = bubbles[bi];
+function updateBubbles(w, h, dt, now) {
+  // Integrate position, decay entry velocity to drift speed, bounce off
+  // walls (only after entering), then resolve bubble-bubble collisions.
+  for (let i = 0; i < bubbles.length; i++) {
+    const b = bubbles[i];
+    if (b.state !== 'alive') continue;
 
-    // Settled position with slow sine drift around the target.
-    const targetCxFrac = b.cx + Math.sin(t * b.driftFreqX + b.phaseX) * b.driftAmpX;
-    const cyFrac       = b.cy + Math.cos(t * b.driftFreqY + b.phaseY) * b.driftAmpY;
+    b.x += b.vx * dt;
+    b.y += b.vy * dt;
 
-    // Side-entry: lerp from off-screen edge to settled cx over ENTRY_DURATION.
     const entryAge = now - b.entryStartedAt;
-    let cxFrac = targetCxFrac;
-    if (entryAge < ENTRY_DURATION) {
-      const tEntry = easeOutCubic(Math.max(0, entryAge / ENTRY_DURATION));
-      const startCx = b.entrySide > 0 ? 1 + ENTRY_OFFSCREEN : -ENTRY_OFFSCREEN;
-      cxFrac = startCx + (targetCxFrac - startCx) * tEntry;
+    const targetSpeed = (entryAge < ENTRY_DURATION)
+      ? ENTRY_SPEED + (b.driftSpeed - ENTRY_SPEED) * easeOutCubic(Math.max(0, entryAge / ENTRY_DURATION))
+      : b.driftSpeed;
+    const speed = Math.hypot(b.vx, b.vy);
+    if (speed > 0.0001) {
+      b.vx = (b.vx / speed) * targetSpeed;
+      b.vy = (b.vy / speed) * targetSpeed;
     }
 
-    const cx = w * cxFrac;
-    const cy = h * cyFrac;
-    const baseR = minDim * b.baseR;
+    if (!b.inside) {
+      if (b.x >= b.r && b.x <= w - b.r && b.y >= b.r && b.y <= h - b.r) b.inside = true;
+    }
+    if (b.inside) {
+      if (b.x < b.r)        { b.x = b.r;     b.vx =  Math.abs(b.vx); }
+      if (b.x > w - b.r)    { b.x = w - b.r; b.vx = -Math.abs(b.vx); }
+      if (b.y < b.r)        { b.y = b.r;     b.vy =  Math.abs(b.vy); }
+      if (b.y > h - b.r)    { b.y = h - b.r; b.vy = -Math.abs(b.vy); }
+    }
+  }
 
-    b._lastCx = cx; b._lastCy = cy; b._lastR = baseR;
+  // Pairwise elastic collisions (equal mass).
+  for (let i = 0; i < bubbles.length; i++) {
+    const a = bubbles[i];
+    if (a.state !== 'alive' || !a.inside) continue;
+    for (let j = i + 1; j < bubbles.length; j++) {
+      const b = bubbles[j];
+      if (b.state !== 'alive' || !b.inside) continue;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const distSq = dx * dx + dy * dy;
+      const sumR = a.r + b.r;
+      if (distSq < sumR * sumR && distSq > 0.0001) {
+        const dist = Math.sqrt(distSq);
+        const nx = dx / dist;
+        const ny = dy / dist;
+        // Project velocities onto the normal and swap them (equal mass).
+        const va = a.vx * nx + a.vy * ny;
+        const vb = b.vx * nx + b.vy * ny;
+        const dvA = vb - va;
+        const dvB = va - vb;
+        a.vx += dvA * nx; a.vy += dvA * ny;
+        b.vx += dvB * nx; b.vy += dvB * ny;
+        // De-overlap.
+        const overlap = (sumR - dist) * 0.5;
+        a.x -= nx * overlap; a.y -= ny * overlap;
+        b.x += nx * overlap; b.y += ny * overlap;
+      }
+    }
+  }
+}
+
+function rescaleBubbles(sx, sy) {
+  const sMin = Math.min(sx, sy);
+  for (const b of bubbles) {
+    b.x  *= sx; b.y  *= sy;
+    b.vx *= sx; b.vy *= sy;
+    b.r  *= sMin;
+    b.driftSpeed *= sMin;
+  }
+}
+
+function drawBubbles(w, h, t, now) {
+  for (let bi = 0; bi < bubbles.length; bi++) {
+    const b = bubbles[bi];
 
     if (b.state === 'popping') {
       const age = now - b.popStartedAt;
       if (age >= POP_DURATION) {
         const palette = getPalette(getTrackIdFn ? getTrackIdFn() : null);
-        bubbles[bi] = makeBubble(palette, bi, now);
+        bubbles[bi] = makeBubble(palette, bi, now, w, h);
         continue;
       }
       const popProgress = age / POP_DURATION;
-      // Body fades fast (first ~25% of pop), then only fragments remain.
       const bodyProgress = Math.min(1, popProgress / 0.25);
-      drawBubbleBody(b, cx, cy, baseR, bodyProgress, t);
+      drawBubbleBody(b, b.x, b.y, b.r, bodyProgress, t);
       drawPopParticles(b, popProgress, w, h);
       continue;
     }
 
-    drawBubbleBody(b, cx, cy, baseR, 0, t);
+    drawBubbleBody(b, b.x, b.y, b.r, 0, t);
   }
 }
 
@@ -159,7 +237,9 @@ function drawBubbleBody(b, cx, cy, r, bodyProgress, t) {
   const orbitR     = rr * 0.38;
   const hx = cx + Math.cos(orbitAngle) * orbitR;
   const hy = cy + Math.sin(orbitAngle) * orbitR;
-  ctx.strokeStyle = `rgba(255,255,255,${0.35 * alphaMul})`;
+  // Highlight is dimmer on darker bubbles (less luminance → less alpha).
+  const highlightAlpha = 0.35 * Math.min(1, 0.15 + b.lum * 1.5);
+  ctx.strokeStyle = `rgba(255,255,255,${highlightAlpha * alphaMul})`;
   ctx.lineWidth = 1;
   ctx.beginPath();
   ctx.ellipse(hx, hy, rr * b.highlightMajor, rr * b.highlightMinor, tiltAngle, 0, Math.PI * 2);
@@ -173,8 +253,8 @@ function drawPopParticles(b, popProgress, w, h) {
   ctx.fillStyle = hexWithAlpha(b.color, 0.85 * fade);
   for (const p of b.popParticles) {
     const dist = maxDist * p.speed * popProgress;
-    const x = b._lastCx + Math.cos(p.angle) * dist;
-    const y = b._lastCy + Math.sin(p.angle) * dist;
+    const x = b.popOriginX + Math.cos(p.angle) * dist;
+    const y = b.popOriginY + Math.sin(p.angle) * dist;
     ctx.beginPath();
     ctx.arc(x, y, p.size * Math.max(0.4, 1 - popProgress * 0.5), 0, Math.PI * 2);
     ctx.fill();
@@ -188,10 +268,10 @@ export function popBubbleAt(xCss, yCss, now = performance.now()) {
   for (let i = 0; i < bubbles.length; i++) {
     const b = bubbles[i];
     if (b.state !== 'alive') continue;
-    const dx = xCss - b._lastCx;
-    const dy = yCss - b._lastCy;
+    const dx = xCss - b.x;
+    const dy = yCss - b.y;
     const dSq = dx * dx + dy * dy;
-    const r = b._lastR + POP_HIT_PADDING;
+    const r = b.r + POP_HIT_PADDING;
     if (dSq <= r * r && dSq < bestDistSq) {
       hit = i;
       bestDistSq = dSq;
@@ -201,6 +281,8 @@ export function popBubbleAt(xCss, yCss, now = performance.now()) {
   const b = bubbles[hit];
   b.state = 'popping';
   b.popStartedAt = now;
+  b.popOriginX = b.x;
+  b.popOriginY = b.y;
   // Shatter into a ring of fragments. Each fragment has its own outward
   // speed multiplier and size, so they break apart unevenly and travel
   // past the visible edges of the panel.
@@ -326,8 +408,20 @@ function frame(now) {
     orbs = buildOrbs(palette);
   }
   if (bubbles.length === 0 || bubbles[0]._paletteSig !== paletteSig(palette)) {
-    bubbles = buildBubbles(palette);
+    bubbles = buildBubbles(palette, w, h);
   }
+
+  // Rescale bubble positions/velocities/radii on size change (e.g.
+  // fullscreen toggle, window resize) so they stay in the visible area.
+  if (lastW > 0 && lastH > 0 && (lastW !== w || lastH !== h)) {
+    rescaleBubbles(w / lastW, h / lastH);
+  }
+  lastW = w; lastH = h;
+
+  // Physics step. Cap dt so a tab-blur stall doesn't fling everything.
+  const dt = Math.min(48, lastFrameTime ? (now - lastFrameTime) : 16);
+  lastFrameTime = now;
+  updateBubbles(w, h, dt, now);
 
   drawBackdrop(palette, w, h, t);
   drawBubbles(w, h, t, now);
@@ -364,6 +458,9 @@ export function startVisualizer(canvasEl, getTrackId) {
   rings = [];
   rmsHistory = [];
   lastTriggerAt = 0;
+  lastFrameTime = 0;
+  lastW = 0;
+  lastH = 0;
   startTime = performance.now();
   rafId = requestAnimationFrame(frame);
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -1080,21 +1080,66 @@ body[data-theme="lcars"] .eor-col-facts {
   flex-direction: column;
   justify-content: center;
 }
-.lounge-visualizer {
+.lounge-visualizer-frame {
+  position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
-  height: auto;
+  align-self: center;
   border: 1px solid var(--fg-faint);
   background: #000;
+}
+.lounge-visualizer {
   display: block;
-  align-self: center;
+  width: 100%;
+  height: 100%;
+  background: #000;
+}
+.lounge-fullscreen-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  width: 28px;
+  height: 28px;
+  background: rgba(0, 0, 0, 0.55);
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity 0.15s ease, border-color 0.15s ease;
+}
+.lounge-visualizer-frame:hover .lounge-fullscreen-btn,
+.lounge-fullscreen-btn:focus {
+  opacity: 1;
+  border-color: var(--fg);
+}
+
+/* Fullscreen mode — frame fills the screen, canvas fills the frame,
+   16:9 constraint relaxed. */
+.lounge-visualizer-frame:fullscreen,
+.lounge-visualizer-frame:-webkit-full-screen {
+  width: 100vw;
+  height: 100vh;
+  aspect-ratio: auto;
+  border: none;
+}
+.lounge-visualizer-frame:fullscreen .lounge-fullscreen-btn,
+.lounge-visualizer-frame:-webkit-full-screen .lounge-fullscreen-btn {
+  top: 18px;
+  right: 18px;
+  width: 36px;
+  height: 36px;
+  font-size: 18px;
 }
 
 @media (max-width: 640px) {
   .lounge-now-playing {
     grid-template-columns: 1fr;
   }
-  .lounge-visualizer {
+  .lounge-visualizer-frame {
     order: -1;
   }
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -1087,52 +1087,25 @@ body[data-theme="lcars"] .eor-col-facts {
   align-self: center;
   border: 1px solid var(--fg-faint);
   background: #000;
+  cursor: pointer;
 }
+.lounge-visualizer-frame:hover { border-color: var(--fg); }
+.lounge-visualizer-frame:focus { outline: 1px solid var(--fg); outline-offset: 2px; }
 .lounge-visualizer {
   display: block;
   width: 100%;
   height: 100%;
   background: #000;
-}
-.lounge-fullscreen-btn {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  z-index: 2;
-  width: 28px;
-  height: 28px;
-  background: rgba(0, 0, 0, 0.55);
-  color: var(--fg);
-  border: 1px solid var(--fg-faint);
-  font-family: var(--font-mono);
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-  opacity: 0.55;
-  transition: opacity 0.15s ease, border-color 0.15s ease;
-}
-.lounge-visualizer-frame:hover .lounge-fullscreen-btn,
-.lounge-fullscreen-btn:focus {
-  opacity: 1;
-  border-color: var(--fg);
+  pointer-events: none;     /* clicks pass through to the frame */
 }
 
-/* Fullscreen mode — frame fills the screen, canvas fills the frame,
-   16:9 constraint relaxed. */
+/* Fullscreen mode — frame fills the screen, 16:9 constraint relaxed. */
 .lounge-visualizer-frame:fullscreen,
 .lounge-visualizer-frame:-webkit-full-screen {
   width: 100vw;
   height: 100vh;
   aspect-ratio: auto;
   border: none;
-}
-.lounge-visualizer-frame:fullscreen .lounge-fullscreen-btn,
-.lounge-visualizer-frame:-webkit-full-screen .lounge-fullscreen-btn {
-  top: 18px;
-  right: 18px;
-  width: 36px;
-  height: 36px;
-  font-size: 18px;
 }
 
 @media (max-width: 640px) {

--- a/styles/components.css
+++ b/styles/components.css
@@ -1070,6 +1070,33 @@ body[data-theme="lcars"] .eor-col-facts {
   border: 1px solid var(--fg-faint);
   padding: 14px 16px;
   background: var(--bg-panel);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-items: stretch;
+}
+.lounge-np-text {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.lounge-visualizer {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  border: 1px solid var(--fg-faint);
+  background: #000;
+  display: block;
+  align-self: center;
+}
+
+@media (max-width: 640px) {
+  .lounge-now-playing {
+    grid-template-columns: 1fr;
+  }
+  .lounge-visualizer {
+    order: -1;
+  }
 }
 .lounge-np-label {
   font-size: 10px;

--- a/styles/components.css
+++ b/styles/components.css
@@ -1080,26 +1080,37 @@ body[data-theme="lcars"] .eor-col-facts {
   flex-direction: column;
   justify-content: center;
 }
+.lounge-visualizer-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-self: center;
+}
 .lounge-visualizer-frame {
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
-  align-self: center;
   border: 1px solid var(--fg-faint);
   background: #000;
-  cursor: pointer;
+  cursor: crosshair;        /* hints "click to interact" */
 }
-.lounge-visualizer-frame:hover { border-color: var(--fg); }
-.lounge-visualizer-frame:focus { outline: 1px solid var(--fg); outline-offset: 2px; }
 .lounge-visualizer {
   display: block;
   width: 100%;
   height: 100%;
   background: #000;
-  pointer-events: none;     /* clicks pass through to the frame */
+  pointer-events: none;     /* click passes through to the frame */
+}
+.lounge-visualizer-hint {
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  color: var(--fg-dim);
+  text-align: center;
+  font-family: var(--font-mono);
 }
 
-/* Fullscreen mode — frame fills the screen, 16:9 constraint relaxed. */
+/* Fullscreen mode — frame fills the screen, 16:9 constraint relaxed,
+   the hint label hides since the wrapper isn't part of fullscreen. */
 .lounge-visualizer-frame:fullscreen,
 .lounge-visualizer-frame:-webkit-full-screen {
   width: 100vw;
@@ -1112,7 +1123,7 @@ body[data-theme="lcars"] .eor-col-facts {
   .lounge-now-playing {
     grid-template-columns: 1fr;
   }
-  .lounge-visualizer-frame {
+  .lounge-visualizer-wrap {
     order: -1;
   }
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -1101,13 +1101,31 @@ body[data-theme="lcars"] .eor-col-facts {
   background: #000;
   pointer-events: none;     /* click passes through to the frame */
 }
+.lounge-visualizer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
 .lounge-visualizer-hint {
   font-size: 10px;
   letter-spacing: 0.2em;
   color: var(--fg-dim);
   text-align: center;
   font-family: var(--font-mono);
+  flex: 1;
 }
+.lounge-sfx-btn {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--fg-faint);
+  padding: 2px 8px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.lounge-sfx-btn:hover { border-color: var(--fg); box-shadow: var(--glow); }
 
 /* Fullscreen mode — frame fills the screen, 16:9 constraint relaxed,
    the hint label hides since the wrapper isn't part of fullscreen. */

--- a/styles/components.css
+++ b/styles/components.css
@@ -1101,6 +1101,43 @@ body[data-theme="lcars"] .eor-col-facts {
   background: #000;
   pointer-events: none;     /* click passes through to the frame */
 }
+
+.lounge-hud {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 1;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.50);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  line-height: 1.5;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 60%;
+}
+.hud-track {
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: bold;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hud-time {
+  color: rgba(255, 255, 255, 0.45);
+}
+.hud-stats {
+  display: flex;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.55);
+  margin-top: 1px;
+}
 .lounge-visualizer-footer {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #72.

## Summary
Adds a 16:9 audio-reactive visualizer next to the now-playing card in the Lounge — and turns it into a small game.

## What's in it
- **Per-track palette** — 8 tracks each get a 2-color palette driving 22 drifting orbs of varied size + intensity
- **Slow rotational depth layer** — conic gradient sweeps around the center over ~40s, panel feels alive
- **Bubble physics** — 5 (default) circular bubbles with orbiting/clear highlights enter from any of the four edges (faded in), bounce off each other and the walls, and decay from entry speed to gentle drift over 5.5s
- **Pulse rings** — RMS transients spawn rings from center (capped + cooldown so it doesn't over-trigger)
- **Diamond hazard** — yellow rotating diamond with a static halo orb behind it sits in the panel center
- **Bubble-pop game** — click a bubble for **+1** with a pleasant chirp; bubble hitting the diamond auto-pops for **−1** with a low thunk
- **HUD box** — upper-left overlay shows current track name, elapsed/total time, score, bubble count
- **Controls**
  - Click on a bubble → pop
  - **F** → fullscreen the visualizer (works in or out of fullscreen)
  - **ESC** → exit fullscreen, then close the Lounge
  - **↑ / ↓** (Lounge open) → add / remove bubbles (1–14)
  - **← / →** → cycle music tracks (was ↑/↓ before — remapped)
  - **🔊 button** in the visualizer footer → toggle pop SFX (separate from music mute, persists)

## Implementation notes
- Lazy \`AudioContext\` + \`MediaElementAudioSourceNode\` + \`AnalyserNode\` wired into existing music \`Audio\` element
- Pop SFX synthesized on demand via \`OscillatorNode\` (no audio assets)
- Visualizer module owns its RAF loop, position state, and physics; resizes/rescales on fullscreen + window resize
- All HUD overlays live inside \`.lounge-visualizer-frame\` so they go fullscreen with the canvas

## Test plan
- [x] Visualizer renders in the Lounge top-right with 16:9 ratio
- [x] Each of 8 tracks shows a visibly distinct palette
- [x] Click bubble → +1 + good sound; diamond hit → −1 + bad sound
- [x] Up/Down add/remove bubbles in the Lounge; Left/Right cycle tracks anywhere
- [x] F toggles fullscreen; ESC exits fullscreen first, Lounge stays open
- [x] SFX toggle persists across reload
- [x] No regressions to existing audio playback (shuffle, fade, title loop)